### PR TITLE
lint: forbid rules for package and keyring

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -31,6 +31,38 @@ func TestLinter_Rules(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			file: "forbidden-repository.yaml",
+			want: EvalResult{
+				File: "forbidden-repository",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "forbidden-repository-used",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[forbidden-repository-used]: forbidden repository https://packages.wolfi.dev/os is used (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			file: "forbidden-keyring.yaml",
+			want: EvalResult{
+				File: "forbidden-keyring",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "forbidden-keyring-used",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[forbidden-keyring-used]: forbidden keyring https://packages.wolfi.dev/os/wolfi-signing.rsa.pub is used (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			file: "wrong-pipeline-fetch-uri.yaml",
 			want: EvalResult{
 				File: "wrong-pipeline-fetch-uri",

--- a/pkg/lint/testdata/files/forbidden-keyring.yaml
+++ b/pkg/lint/testdata/files/forbidden-keyring.yaml
@@ -1,0 +1,24 @@
+package:
+  name: forbidden-keyring
+  version: 1.0.0
+  epoch: 0
+  description: A package with a forbidden keyring used
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - foo
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/foo/bar/baz.tar.gz
+      expected-sha512: 6d8e828fa406518b4b3f55b0e5f62bbd5cf25cb5782d1884b9d5eaf61fb0614deaacad4236ab7420fa5b3868c79df226ae1aa5193bb136c556aa52853eeca553
+  - runs: |
+      go build .

--- a/pkg/lint/testdata/files/forbidden-repository.yaml
+++ b/pkg/lint/testdata/files/forbidden-repository.yaml
@@ -1,0 +1,24 @@
+package:
+  name: forbidden-repository
+  version: 1.0.0
+  epoch: 0
+  description: A package with a forbidden repository used
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - foo
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/foo/bar/baz.tar.gz
+      expected-sha512: 6d8e828fa406518b4b3f55b0e5f62bbd5cf25cb5782d1884b9d5eaf61fb0614deaacad4236ab7420fa5b3868c79df226ae1aa5193bb136c556aa52853eeca553
+  - runs: |
+      go build .


### PR DESCRIPTION
This PR introduces 2 news lint rules with their tests:
* `forbidden-repository-used`
* `forbidden-keyring-used`

These checks are required to get rid of "legacy" [lint.sh](https://github.com/wolfi-dev/os/blob/main/lint.sh) script:

```
  # Don't specify packages.wolfi.dev/os as a repository, and remove it from the keyring.
  # Packages from the bootstrap repo should be allowed, but otherwise packages
  # should be fetched locally and the local repository should be appended at
  # build time.
  if grep -q packages.wolfi.dev/os $f; then
    yq -i 'del(.environment.contents.repositories)' $f
    yq -i 'del(.environment.contents.keyring)' $f
  fi
```

Also please check: https://github.com/wolfi-dev/os/issues/86

> checked-in packages shouldn't depend on packages.wolfi.dev/os or include its keyring; packages are fetched from that repo and depended on locally during the build

Intentionally used _list_ to get better control to forbid multiple repos and keyrings (if need be)

Signed-off-by: Furkan <furkan.turkal@trendyol.com>