### PR TITLE
add an action that can be used from another GitHub Action

### DIFF
--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -1,0 +1,18 @@
+name: wolfictl-lint
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@main
+      with:
+        repository: wolfi-dev/wolfictl
+        path: wolfictl-setup-gha
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+    - id: build
+      shell: bash
+      run: |
+        cd wolfictl-setup-gha
+        make wolfictl
+        mv wolfictl /home/runner/go/bin/
+        rm -rf wolfictl-setup-gha


### PR DESCRIPTION
initially for faster iterations let's compile wolfictl, in the future we can switch to using a released version

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>