### PR TITLE
Add golangci-lint job, fix errors and bugs

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,13 @@
+name: "golangci-lint"
+on:
+  pull_request
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 wolfictl
 .bin/
+.vscode

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,183 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m
+issues:
+  exclude-rules:
+    # counterfeiter fakes are usually named 'fake_<something>.go'
+    - path: fake_.*\.go
+      linters:
+        - gocritic
+        - golint
+        - dupl
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    #- misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    #  - rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649
+    # - sqlclosecheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    # - cyclop
+    # - errorlint
+    # - exhaustive
+    # - exhaustivestruct
+    # - exportloopref
+    # - forbidigo
+    # - forcetypeassert
+    # - funlen
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - godot
+    # - goerr113
+    # - gomnd
+    # - ifshort
+    # - lll
+    # - nestif
+    # - nilerr
+    # - nlreturn
+    # - noctx
+    # - paralleltest
+    # - scopelint
+    # - tagliatelle
+    # - testpackage
+    # - thelper
+    # - tparallel
+    # - wastedassign
+    # - wrapcheck
+    # - wsl
+linters-settings:
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - appendAssign
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
+      # - ifElseChain
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    # TODO(lint): Enforce machine-readable `nolint` directives
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    # TODO(lint): Enforce explanations for `nolint` directives
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -101,17 +101,21 @@ type options struct {
 
 func parseArgs() (*options, error) {
 	opts := &options{}
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getting cwd: %w", err)
+	}
 	flags := pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
 	flags.StringVar(&opts.source, "root", cwd, "Path to project root")
 	flags.StringVar(&opts.target, "target", "/tmp", "Target path for generated yaml files")
 	flags.StringVar(&opts.kind, "kind", "markdown", "Kind of docs to generate (supported: man, markdown)")
-	err := flags.Parse(os.Args[1:])
-	return opts, err
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		return nil, fmt.Errorf("parsing arguments: %w", err)
+	}
+	return opts, nil
 }
 
-func parseMDContent(mdString string) (string, string) {
-	var description, examples string
+func parseMDContent(mdString string) (description, examples string) {
 	parsedContent := strings.Split(mdString, "\n## ")
 	for _, s := range parsedContent {
 		if strings.Index(s, "Description") == 0 {

--- a/cmd/docs/man_docs.go
+++ b/cmd/docs/man_docs.go
@@ -65,7 +65,7 @@ func GenManTreeFromOpts(cmd *cobra.Command, opts GenManTreeOptions) error {
 	if opts.CommandSeparator != "" {
 		separator = opts.CommandSeparator
 	}
-	basename := strings.Replace(cmd.CommandPath(), " ", separator, -1)
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", separator)
 	filename := filepath.Join(opts.Path, basename+"."+section)
 	f, err := os.Create(filename)
 	if err != nil {
@@ -112,7 +112,7 @@ func GenMan(cmd *cobra.Command, header *GenManHeader, w io.Writer) error {
 
 func fillHeader(header *GenManHeader, name string) error {
 	if header.Title == "" {
-		header.Title = strings.ToUpper(strings.Replace(name, " ", "\\-", -1))
+		header.Title = strings.ToUpper(strings.ReplaceAll(name, " ", "\\-"))
 	}
 	if header.Section == "" {
 		header.Section = "1"
@@ -189,7 +189,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 	cmd.InitDefaultHelpFlag()
 
 	// something like `rootcmd-subcmd1-subcmd2`
-	dashCommandName := strings.Replace(cmd.CommandPath(), " ", "-", -1)
+	dashCommandName := strings.ReplaceAll(cmd.CommandPath(), " ", "-")
 
 	buf := new(bytes.Buffer)
 
@@ -204,7 +204,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 		seealsos := make([]string, 0)
 		if cmd.HasParent() {
 			parentPath := cmd.Parent().CommandPath()
-			dashParentPath := strings.Replace(parentPath, " ", "-", -1)
+			dashParentPath := strings.ReplaceAll(parentPath, " ", "-")
 			seealso := fmt.Sprintf("**%s(%s)**", dashParentPath, header.Section)
 			seealsos = append(seealsos, seealso)
 			cmd.VisitParents(func(c *cobra.Command) {

--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -89,7 +89,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			parent := cmd.Parent()
 			pname := parent.CommandPath()
 			link := pname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short))
 			cmd.VisitParents(func(c *cobra.Command) {
 				if c.DisableAutoGenTag {
@@ -107,7 +107,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			}
 			cname := name + " " + child.Name()
 			link := cname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", cname, linkHandler(link), child.Short))
 		}
 		buf.WriteString("\n")
@@ -143,7 +143,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 		}
 	}
 
-	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + ".md"
 	filename := filepath.Join(dir, basename)
 	f, err := os.Create(filename)
 	if err != nil {

--- a/pkg/cli/lint.go
+++ b/pkg/cli/lint.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/lint"
@@ -49,7 +49,7 @@ func (o lintOptions) LintCmd() error {
 	}
 	if result.HasErrors() {
 		linter.Print(result)
-		return fmt.Errorf("linting failed!")
+		return errors.New("linting failed")
 	}
 	return nil
 }

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,29 +48,27 @@ func Update() *cobra.Command {
 }
 
 func (o options) UpdateCmd(ctx context.Context, repoURI string) error {
-	context := update.New()
+	updateContext := update.New()
 
 	if !o.dryRun && os.Getenv("GITHUB_TOKEN") == "" {
 		return errors.New("no GITHUB_TOKEN token found")
 	}
 
-	_, err := url.ParseRequestURI(repoURI)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse URI %s", repoURI)
+	if _, err := url.ParseRequestURI(repoURI); err != nil {
+		return fmt.Errorf("failed to parse URI %s: %w", repoURI, err)
 	}
-	context.PackageNames = o.packageNames
-	context.RepoURI = repoURI
-	context.DataMapperURL = o.dataMapperURL
-	context.DryRun = o.dryRun
-	context.Batch = o.batch
-	context.PullRequestBaseBranch = o.pullRequestBaseBranch
-	context.PullRequestTitle = o.pullRequestTitle
-	context.ReleaseMonitoringQuery = o.releaseMonitoringQuery
-	context.GithubReleaseQuery = o.githubReleaseQuery
+	updateContext.PackageNames = o.packageNames
+	updateContext.RepoURI = repoURI
+	updateContext.DataMapperURL = o.dataMapperURL
+	updateContext.DryRun = o.dryRun
+	updateContext.Batch = o.batch
+	updateContext.PullRequestBaseBranch = o.pullRequestBaseBranch
+	updateContext.PullRequestTitle = o.pullRequestTitle
+	updateContext.ReleaseMonitoringQuery = o.releaseMonitoringQuery
+	updateContext.GithubReleaseQuery = o.githubReleaseQuery
 
-	err = context.Update()
-	if err != nil {
-		return errors.Wrapf(err, "creating updates")
+	if err := updateContext.Update(); err != nil {
+		return fmt.Errorf("creating updates: %w", err)
 	}
 
 	return nil

--- a/pkg/cli/vex.go
+++ b/pkg/cli/vex.go
@@ -28,7 +28,7 @@ func VEX() *cobra.Command {
 				AuthorRole: role,
 			}
 
-			doc, err := vex.FromPackageConfiguration(*buildCfg, vexCfg)
+			doc, err := vex.FromPackageConfiguration(buildCfg, vexCfg)
 			if err != nil {
 				return err
 			}

--- a/pkg/gh/github.go
+++ b/pkg/gh/github.go
@@ -157,10 +157,10 @@ func (o *GitOptions) CheckExistingPullRequests(pr *GetPullRequest) (string, erro
 func (o *GitOptions) wait(delay time.Duration) {
 	// If we couldn't determine a more accurate delay from GitHub API response headers, then fall back to our user-configurable default
 	if delay == 0 {
-		delay = time.Duration(o.SecondsToSleepWhenRateLimited)
+		delay = time.Duration(o.SecondsToSleepWhenRateLimited * int(time.Second))
 	}
 	o.Logger.Printf("retrying PR again later with %d second delay due to secondary rate limiting.", delay)
-	time.Sleep(delay * time.Second)
+	time.Sleep(delay)
 }
 
 func (o *GitOptions) closePullRequest(pr *GetPullRequest, openPr *github.PullRequest) error {

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -50,8 +50,7 @@ func (l *Linter) Lint() (Result, error) {
 	}
 
 	results := make(Result, 0)
-	for name, config := range filesToLint {
-		// var failedRules *multierror.Error
+	for name := range filesToLint {
 		failedRules := make(EvalRuleErrors, 0)
 		for _, rule := range rules {
 			// Check if we should skip this rule.
@@ -74,7 +73,7 @@ func (l *Linter) Lint() (Result, error) {
 			}
 
 			// Evaluate the rule.
-			if err := rule.LintFunc(config); err != nil {
+			if err := rule.LintFunc(filesToLint[name]); err != nil {
 				msg := fmt.Sprintf("[%s]: %s (%s)", rule.Name, err.Error(), rule.Severity)
 				if l.options.Verbose {
 					msg += fmt.Sprintf(" - (%s)", rule.Description)
@@ -132,14 +131,14 @@ func (l *Linter) checkIfMakefileExists() ConditionFunc {
 
 // readMakefile reads the Makefile from the file.
 func (l *Linter) readMakefile() error {
-	bytes, err := os.ReadFile(filepath.Join(l.options.Path, "Makefile"))
+	b, err := os.ReadFile(filepath.Join(l.options.Path, "Makefile"))
 	if err != nil {
 		return fmt.Errorf("failed to open Makefile: %w", err)
 	}
-	if len(bytes) == 0 {
+	if len(b) == 0 {
 		return fmt.Errorf("makefile is empty")
 	}
-	l.makefileBytes = bytes
+	l.makefileBytes = b
 	return nil
 }
 

--- a/pkg/lint/types.go
+++ b/pkg/lint/types.go
@@ -31,7 +31,7 @@ type Rule struct {
 	// Severity is the severity of the rule.
 	Severity Severity
 
-	// Function is the function that lints a single configuration.
+	// LintFunc is the function that lints a single configuration.
 	LintFunc Function
 
 	// ConditionFuncs is a list of and-conditioned functions that check if the rule should be executed.

--- a/pkg/lint/types.go
+++ b/pkg/lint/types.go
@@ -5,8 +5,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// LintFunc is a function that lints a single configuration.
-type LintFunc func(build.Configuration) error
+// Function is a function that lints a single configuration.
+type Function func(build.Configuration) error
 
 // ConditionFunc is a function that checks if a rule should be executed.
 type ConditionFunc func() bool
@@ -31,8 +31,8 @@ type Rule struct {
 	// Severity is the severity of the rule.
 	Severity Severity
 
-	// LintFunc is the function that lints a single configuration.
-	LintFunc LintFunc
+	// Function is the function that lints a single configuration.
+	LintFunc Function
 
 	// ConditionFuncs is a list of and-conditioned functions that check if the rule should be executed.
 	ConditionFuncs []ConditionFunc

--- a/pkg/update/githubReleases_test.go
+++ b/pkg/update/githubReleases_test.go
@@ -58,6 +58,7 @@ type ReleasesSearchResponse struct {
 }
 
 // todo convert to test http server
+//nolint:gocritic
 //func TestMonitorService_API(t *testing.T) {
 //	ts := oauth2.StaticTokenSource(
 //		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},

--- a/pkg/update/mapper.go
+++ b/pkg/update/mapper.go
@@ -15,8 +15,11 @@ type Row struct {
 	StripPrefixChar string
 }
 
-func (o Options) getMonitorServiceData() (map[string]Row, error) {
-	req, _ := http.NewRequest("GET", o.DataMapperURL, nil)
+func (o *Options) getMonitorServiceData() (map[string]Row, error) {
+	req, err := http.NewRequest("GET", o.DataMapperURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP request: %w", err)
+	}
 	resp, err := o.Client.Do(req)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed getting URI %s", o.DataMapperURL)
@@ -34,7 +37,7 @@ func (o Options) getMonitorServiceData() (map[string]Row, error) {
 	return o.parseData(string(b))
 }
 
-func (o Options) parseData(rawdata string) (map[string]Row, error) {
+func (o *Options) parseData(rawdata string) (map[string]Row, error) {
 	data := make(map[string]Row)
 
 	lines := strings.Split(rawdata, "\n")
@@ -58,7 +61,6 @@ func (o Options) parseData(rawdata string) (map[string]Row, error) {
 			ServiceName:     strings.TrimSpace(parts[3]),
 			StripPrefixChar: strings.TrimSpace(parts[4]),
 		}
-
 	}
 
 	return data, nil

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_parseGitURL(t *testing.T) {
@@ -130,10 +131,12 @@ func TestUpdate_updateMakefile(t *testing.T) {
 	// make the temp test dir a git repo
 	fs := osfs.New(tempDir)
 	storage := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	wt, _ := fs.Chroot("melange")
+	wt, err := fs.Chroot("melange")
+	require.NoError(t, err)
 	r, err := git.Init(storage, wt)
 	assert.NoError(t, err)
-	w, _ := r.Worktree()
+	w, err := r.Worktree()
+	require.NoError(t, err)
 
 	// copy test file into temp git repo
 	err = util.WriteFile(w.Filesystem, "Makefile", data, 0o644)

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -15,7 +15,7 @@ type Config struct {
 }
 
 // FromPackageConfiguration generates a new VEX document for the Wolfi package described by the build.Configuration.
-func FromPackageConfiguration(buildCfg build.Configuration, vexCfg Config) (vex.VEX, error) {
+func FromPackageConfiguration(buildCfg *build.Configuration, vexCfg Config) (vex.VEX, error) {
 	doc := vex.New()
 
 	doc.ID = generateDocumentID(buildCfg.Package.Name)
@@ -34,29 +34,28 @@ func FromPackageConfiguration(buildCfg build.Configuration, vexCfg Config) (vex.
 	return doc, nil
 }
 
-func statementsFromConfiguration(cfg build.Configuration, documentTimestamp time.Time, purls []string) []vex.Statement {
+func statementsFromConfiguration(cfg *build.Configuration, documentTimestamp time.Time, purls []string) []vex.Statement {
 	// We should also add a lint rule for when advisories obviate particular secfixes items.
 	secfixesStatements := statementsFromSecfixes(cfg.Secfixes, purls)
 	advisoriesStatements := statementsFromAdvisories(cfg.Advisories, purls)
 
 	// don't include "not_affected" statements from secfixes that are obviated by statements from advisories
 	notAffectedVulns := make(map[string]struct{})
-	for _, stmt := range advisoriesStatements {
-		if stmt.Status == vex.StatusNotAffected {
-			notAffectedVulns[stmt.Vulnerability] = struct{}{}
+	for i := range advisoriesStatements {
+		if advisoriesStatements[i].Status == vex.StatusNotAffected {
+			notAffectedVulns[advisoriesStatements[i].Vulnerability] = struct{}{}
 		}
 	}
 	var statements []vex.Statement
-	for _, sfStmt := range secfixesStatements {
-		if _, seen := notAffectedVulns[sfStmt.Vulnerability]; !seen {
-			statements = append(statements, sfStmt)
+	for i := range secfixesStatements {
+		if _, seen := notAffectedVulns[secfixesStatements[i].Vulnerability]; !seen {
+			statements = append(statements, secfixesStatements[i])
 		}
 	}
 
 	statements = append(statements, advisoriesStatements...)
 
 	// TODO: also find and weed out duplicate "fixed" statements
-
 	vex.SortStatements(statements, documentTimestamp)
 	return statements
 }
@@ -65,15 +64,17 @@ func statementsFromAdvisories(advisories build.Advisories, purls []string) []vex
 	var stmts []vex.Statement
 
 	for v, entries := range advisories {
-		for _, entry := range entries {
-			stmts = append(stmts, statementFromAdvisoryContent(entry, v, purls))
+		for i := range entries {
+			stmts = append(stmts, statementFromAdvisoryContent(&entries[i], v, purls))
 		}
 	}
 
 	return stmts
 }
 
-func statementFromAdvisoryContent(content build.AdvisoryContent, vulnerability string, purls []string) vex.Statement {
+func statementFromAdvisoryContent(
+	content *build.AdvisoryContent, vulnerability string, purls []string,
+) vex.Statement {
 	return vex.Statement{
 		Vulnerability:   vulnerability,
 		Status:          content.Status,
@@ -115,6 +116,5 @@ func determineStatus(packageVersion string) vex.Status {
 }
 
 func generateDocumentID(packageName string) string {
-	uuid := uuid.New()
-	return fmt.Sprintf("vex-%s-%s", packageName, uuid)
+	return fmt.Sprintf("vex-%s-%s", packageName, uuid.New())
 }

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -19,7 +19,7 @@ func TestFromPackageConfiguration(t *testing.T) {
 		Distro: "wolfi",
 	}
 
-	doc, err := FromPackageConfiguration(*buildCfg, vexCfg)
+	doc, err := FromPackageConfiguration(buildCfg, vexCfg)
 	require.NoError(t, err)
 
 	// zero out non-deterministic fields


### PR DESCRIPTION
This PR adds golangci-lint into the repository and fixes all errors in the code. It fixes some minor bugs and starts to remove deprecated code from some modules. It also adds a new job to run golangci-lint in a presubmit.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
