### PR TITLE
Make VEX doc generation deterministic

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -1,6 +1,7 @@
 package vex
 
 import (
+	"errors"
 	"time"
 
 	"chainguard.dev/melange/pkg/build"
@@ -13,7 +14,13 @@ type Config struct {
 }
 
 // FromPackageConfiguration generates a new VEX document for the Wolfi package described by the build.Configuration.
+//
+//nolint:gocritic // hugeParam on vexCfg
 func FromPackageConfiguration(buildCfg *build.Configuration, vexCfg Config) (vex.VEX, error) {
+	if buildCfg == nil {
+		return vex.VEX{}, errors.New("cannot create VEX document from nil buildCfg")
+	}
+
 	doc := vex.New()
 
 	doc.ID = vexCfg.DocumentID

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -1,33 +1,27 @@
 package vex
 
 import (
-	"fmt"
 	"time"
 
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/vex/pkg/vex"
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 type Config struct {
-	Distro, Author, AuthorRole string
+	DocumentID, Distro, Author, AuthorRole string
+	DocumentTimestamp                      time.Time
 }
 
 // FromPackageConfiguration generates a new VEX document for the Wolfi package described by the build.Configuration.
 func FromPackageConfiguration(buildCfg build.Configuration, vexCfg Config) (vex.VEX, error) {
 	doc := vex.New()
 
-	doc.ID = generateDocumentID(buildCfg.Package.Name)
+	doc.ID = vexCfg.DocumentID
+	doc.Timestamp = &vexCfg.DocumentTimestamp
 	doc.Author = vexCfg.Author
 	doc.AuthorRole = vexCfg.AuthorRole
 
 	purls := buildCfg.PackageURLs(vexCfg.Distro)
-
-	if doc.Timestamp == nil {
-		// We don't expect this case, since `vex.New()` sets a document timestamp.
-		return vex.VEX{}, errors.New("document timestamp must be set")
-	}
 
 	doc.Statements = statementsFromConfiguration(buildCfg, *doc.Timestamp, purls)
 
@@ -112,9 +106,4 @@ func determineStatus(packageVersion string) vex.Status {
 	}
 
 	return vex.StatusFixed
-}
-
-func generateDocumentID(packageName string) string {
-	uuid := uuid.New()
-	return fmt.Sprintf("vex-%s-%s", packageName, uuid)
 }

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -3,6 +3,7 @@ package vex
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/vex/pkg/vex"
@@ -15,20 +16,24 @@ func TestFromPackageConfiguration(t *testing.T) {
 	if err != nil {
 		return
 	}
+
+	const documentID = "vex-git-abcdef0"
+	var documentTimestamp = time.Time{}
+
 	vexCfg := Config{
-		Distro: "wolfi",
+		Distro:            "wolfi",
+		DocumentID:        documentID,
+		DocumentTimestamp: documentTimestamp,
 	}
 
 	doc, err := FromPackageConfiguration(*buildCfg, vexCfg)
 	require.NoError(t, err)
 
-	// zero out non-deterministic fields
-	doc.ID = ""
-	doc.Timestamp = nil
-
 	expected := vex.VEX{
 		Metadata: vex.Metadata{
-			Format: "text/vex+json",
+			Format:    "text/vex+json",
+			ID:        documentID,
+			Timestamp: &documentTimestamp,
 		},
 		Statements: []vex.Statement{
 			{

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -18,7 +18,7 @@ func TestFromPackageConfiguration(t *testing.T) {
 	}
 
 	const documentID = "vex-git-abcdef0"
-	var documentTimestamp = time.Time{}
+	documentTimestamp := time.Time{}
 
 	vexCfg := Config{
 		Distro:            "wolfi",


### PR DESCRIPTION
This adjusts `wolfictl vex ...` to produce VEX documents in a **deterministic** way.

Document IDs are now produced as a function of the package name and the last git commit that affect the package configuration file.

Document timestamps are now set to the author timestamp for the last git commit that affect the package configuration file.