### PR TITLE
Add a new lint rule for bad template vars, likely copied from APKBUILDs.

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -110,6 +110,22 @@ func TestLinter_Rules(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			file: "bad-template-var.yaml",
+			want: EvalResult{
+				File: "bad-template-var",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "bad-template-var",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[bad-template-var]: package contains likely incorrect template var $pkgdir (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lint/testdata/files/bad-template-var.yaml
+++ b/pkg/lint/testdata/files/bad-template-var.yaml
@@ -1,0 +1,13 @@
+package:
+  name: bad-template-var
+  version: 1.0.0
+  epoch: 0
+  description: "a package with a wrong pipeline fetch uri"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+pipeline:
+  - runs: |
+      cat $pkgdir


### PR DESCRIPTION
Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>