### PR TITLE
Add --sync flag to advisory create and update

### DIFF
--- a/pkg/advisory/sync/need.go
+++ b/pkg/advisory/sync/need.go
@@ -224,3 +224,17 @@ func GetAdvisoriesNeeds(configEntry configs.Entry, index *configs.Index) []Need 
 
 	return needs
 }
+
+// Unmet filters the given set of Needs down to just the set of needs that are
+// not met.
+func Unmet(needs []Need) []Need {
+	var result []Need
+
+	for _, need := range needs {
+		if !need.Met() {
+			result = append(result, need)
+		}
+	}
+
+	return result
+}

--- a/pkg/cli/advisory_list.go
+++ b/pkg/cli/advisory_list.go
@@ -17,7 +17,7 @@ func AdvisoryList() *cobra.Command {
 		Short:         "list advisories for specific packages or across all of Wolfi",
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			index, err := argsToConfigs(args)
+			index, err := newConfigIndexFromArgs(args...)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/advisory_sync_secfixes.go
+++ b/pkg/cli/advisory_sync_secfixes.go
@@ -15,7 +15,7 @@ func AdvisorySyncSecfixes() *cobra.Command {
 		Short:         "synchronize secfixes and advisories for specific packages or across all of Wolfi",
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			index, err := argsToConfigs(args)
+			index, err := newConfigIndexFromArgs(args...)
 			if err != nil {
 				return err
 			}

--- a/pkg/configs/index.go
+++ b/pkg/configs/index.go
@@ -139,6 +139,11 @@ func (i *Index) Configurations() []build.Configuration {
 	return i.cfgs
 }
 
+// Len returns the number of configurations stored in the Index.
+func (i *Index) Len() int {
+	return len(i.cfgs)
+}
+
 type IndexEntryFunc func(entry Entry) error
 
 // ForEach applies the given IndexEntryFunc to every item in the Index. If the


### PR DESCRIPTION
This adds a new `--sync` flag to `wolfictl advisory create` and `... update`. When used, this will automatically update the config's `secfixes:` section to stay in sync with the modifications made to the `advisories:` section, if needed.

Once the advisories section is stable, we'll stop using secfixes altogether. But we're not quite there yet, and we want to make sure we're still building accurate secdbs in the meantime.