### PR TITLE
Fix vex test issues

### DIFF
--- a/pkg/vex/testdata/git.yaml
+++ b/pkg/vex/testdata/git.yaml
@@ -33,6 +33,7 @@ advisories:
       action: 'action statement'
     - timestamp: 2022-12-24T02:50:18-05:00
       status: fixed
+      fixed-version: 1.2.3-r4
 
 environment:
   contents:

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -3,11 +3,11 @@ package vex
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/vex/pkg/vex"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,97 +43,98 @@ func TestFromPackageConfiguration(t *testing.T) {
 
 	// zero out non-deterministic fields
 	doc.Timestamp = nil
-	timePointer := func(t time.Time) *time.Time { return &t }
-	tz := time.FixedZone("-0500", -5*3600)
+	doc.ID = ""
+
+	// TODO: re-introduce timestamp comparisons once latest version of VEX module is imported
+
 	expected := &vex.VEX{
 		Metadata: vex.Metadata{
-			ID:     "vex-60d2bb8952362a0a7bf52b2ac2619a7846cd2394a5cdb3dfe83a66f5f9838e7d",
 			Format: "text/vex",
 		},
 		Statements: []vex.Statement{
 			{
 				Vulnerability: "CVE-1234-5678",
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status: "not_affected",
 			},
 			{
 				Vulnerability: "CVE-2022-1111",
-				Timestamp:     timePointer(time.Date(2022, 12, 23, 1, 28, 16, 0, tz)),
+				// Timestamp:     timePointer(time.Date(2022, 12, 23, 1, 28, 16, 0, tz)),
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status: "under_investigation",
 			},
 			{
 				Vulnerability: "CVE-2022-1111",
-				Timestamp:     timePointer(time.Date(2022, 12, 23, 2, 11, 57, 0, tz)),
+				// Timestamp:     timePointer(time.Date(2022, 12, 23, 2, 11, 57, 0, tz)),
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status:        "not_affected",
 				Justification: "component_not_present",
 			},
 			{
 				Vulnerability: "CVE-2022-2222",
-				Timestamp:     timePointer(time.Date(2022, 12, 24, 1, 28, 16, 0, tz)),
+				// Timestamp:     timePointer(time.Date(2022, 12, 24, 1, 28, 16, 0, tz)),
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status: "under_investigation",
 			},
 			{
 				Vulnerability: "CVE-2022-2222",
-				Timestamp:     timePointer(time.Date(2022, 12, 24, 2, 12, 49, 0, tz)),
+				// Timestamp:     timePointer(time.Date(2022, 12, 24, 2, 12, 49, 0, tz)),
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status:          "affected",
 				ActionStatement: "action statement",
 			},
 			{
 				Vulnerability: "CVE-2022-2222",
-				Timestamp:     timePointer(time.Date(2022, 12, 24, 2, 50, 18, 0, tz)),
+				// Timestamp:     timePointer(time.Date(2022, 12, 24, 2, 50, 18, 0, tz)),
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status: "fixed",
 			},
 			{
 				Vulnerability: "CVE-2022-39253",
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status: "fixed",
 			},
 			{
 				Vulnerability: "CVE-2022-39260",
 				Products: []string{
-					"pkg:apk/wolfi/git@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-daemon@2.39.0-r0?distro=wolfi",
-					"pkg:apk/wolfi/git-email@2.39.0-r0?distro=wolfi",
+					"pkg:apk/wolfi/git@2.39.0-r0",
+					"pkg:apk/wolfi/git-daemon@2.39.0-r0",
+					"pkg:apk/wolfi/git-email@2.39.0-r0",
 				},
 				Status: "fixed",
 			},
 		},
 	}
 
-	if diff := cmp.Diff(expected, doc); diff != "" {
+	if diff := cmp.Diff(expected, doc, cmpopts.IgnoreFields(vex.Statement{}, "Timestamp")); diff != "" {
 		t.Errorf("Unexpected result from FromPackageConfiguration (-want, +got):\n%s", diff)
 	}
 }

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -32,9 +32,8 @@ func TestIndexMelangeConfigsDir(t *testing.T) {
 
 func TestFromPackageConfiguration(t *testing.T) {
 	buildCfg, err := build.ParseConfiguration(filepath.Join("testdata", "git.yaml"))
-	if err != nil {
-		return
-	}
+	require.NoError(t, err)
+
 	vexCfg := Config{
 		Distro: "wolfi",
 	}


### PR DESCRIPTION
There were two issues with the test `vex.TestFromPackageConfiguration` (that were my fault :picard-facepalm:):

1. The test was passing when it shouldn't have been, because errors from parsing Melange configs were ignored.
2. This hid another issue where the test would've failed because the VEX doc generation was generating timestamps non-deterministically.

The latter issue has been addressed in https://github.com/chainguard-dev/vex/pull/52. In #13, we'll import that update into this repo, which should mean we can safely compare timestamps in this test.