### PR TITLE
wolfictl release: add a new command to calculate a new version, tag a…

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -18,6 +18,7 @@ func New() *cobra.Command {
 		VEX(),
 		Advisory(),
 		Bump(),
+		Gh(),
 	)
 
 	return cmd

--- a/pkg/cli/gh.go
+++ b/pkg/cli/gh.go
@@ -1,0 +1,18 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func Gh() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "gh",
+		DisableAutoGenTag: true,
+		SilenceUsage:      true,
+		Short:             "Commands used to interact with GitHub",
+	}
+
+	cmd.AddCommand(
+		Release(),
+	)
+
+	return cmd
+}

--- a/pkg/cli/release.go
+++ b/pkg/cli/release.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/gh"
+)
+
+func Release() *cobra.Command {
+	releaseOpts := gh.NewReleaseOptions()
+
+	cmd := &cobra.Command{
+		Use:               "release",
+		DisableAutoGenTag: true,
+		SilenceUsage:      true,
+		Short:             "Performs a GitHub release using git tags to calculate the release version",
+		Long: `Performs a GitHub release using git tags to calculate the release version
+
+Examples:
+
+wolfictl gh release --bump-major
+wolfictl gh release --bump-minor
+wolfictl gh release --bump-patch
+wolfictl gh release --bump-prerelease-with-prefix rc
+`,
+		Args: cobra.RangeArgs(0, 0),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !releaseOpts.BumpMajor &&
+				!releaseOpts.BumpMinor &&
+				!releaseOpts.BumpPatch &&
+				releaseOpts.BumpPrereleaseWithPrefix == "" {
+				return errors.New("missing flag to bump release version")
+			}
+
+			return releaseOpts.Release()
+		},
+	}
+
+	cmd.Flags().BoolVar(&releaseOpts.BumpMajor, "bump-major", false, "bumps the major release version")
+	cmd.Flags().BoolVar(&releaseOpts.BumpMinor, "bump-minor", false, "bumps the minor release version")
+	cmd.Flags().BoolVar(&releaseOpts.BumpPatch, "bump-patch", false, "bumps the patch release version")
+	cmd.Flags().StringVar(&releaseOpts.BumpPrereleaseWithPrefix, "bump-prerelease-with-prefix", "", "bumps the prerelease version using the supplied prefix, if no existing prerelease exists the patch version is also bumped to align with semantic versioning")
+	cmd.Flags().StringVar(&releaseOpts.Dir, "dir", ".", "directory containing the cloned github repository to release")
+
+	return cmd
+}

--- a/pkg/gh/github.go
+++ b/pkg/gh/github.go
@@ -2,15 +2,16 @@ package gh
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"strings"
+	"os"
 	"time"
 
-	"github.com/hashicorp/go-version"
+	http2 "github.com/wolfi-dev/wolfictl/pkg/http"
+	"golang.org/x/time/rate"
+
+	"golang.org/x/oauth2"
 
 	"github.com/google/go-github/v48/github"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -24,17 +25,6 @@ type BasePullRequest struct {
 	PullRequestBaseBranch string
 	Retries               int
 }
-type NewPullRequest struct {
-	BasePullRequest
-	Title string
-	Body  string
-}
-
-type GetPullRequest struct {
-	BasePullRequest
-	PackageName string
-	Version     string
-}
 
 type GitOptions struct {
 	GithubClient                  *github.Client
@@ -43,48 +33,26 @@ type GitOptions struct {
 	Logger                        *log.Logger
 }
 
-// OpenPullRequest opens a pull request on GitHub
-func (o *GitOptions) OpenPullRequest(pr *NewPullRequest) (string, error) {
-	// if our new version is more recent that the existing PR close it and create a new one, otherwise skip
+func New() GitOptions {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
+	)
 
-	// If the current request has already exhausted the configured number of PR retries, short-circuit
-	if pr.Retries > o.MaxPullRequestRetries {
-		return "", fmt.Errorf("failed max number of retries, tried %d max %d", pr.Retries, o.MaxPullRequestRetries)
+	ratelimit := &http2.RLHTTPClient{
+		Client: oauth2.NewClient(context.Background(), ts),
+
+		// 1 request every (n) second(s) to avoid DOS'ing server. https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-secondary-rate-limits
+		Ratelimiter: rate.NewLimiter(rate.Every(3*time.Second), 1),
 	}
 
-	// Configure pull request options that the GitHub client accepts when making calls to open new pull requests
-	newPR := &github.NewPullRequest{
-		Title: github.String(pr.Title),
-		Head:  github.String(pr.Branch),
-		Base:  github.String(pr.PullRequestBaseBranch),
-		Body:  github.String(pr.Body),
+	return GitOptions{
+		GithubClient: github.NewClient(ratelimit.Client),
+		Logger:       log.New(log.Writer(), "wolfictl gh release: ", log.LstdFlags|log.Lmsgprefix),
 	}
-
-	// make a pull request
-	githubPR, resp, err := o.GithubClient.PullRequests.Create(context.Background(), pr.Owner, pr.RepoName, newPR)
-
-	githubErr := github.CheckResponse(resp.Response)
-
-	if githubErr != nil {
-		isRateLimited, delay := o.checkRateLimiting(githubErr)
-		if isRateLimited {
-			pr.Retries++
-			o.wait(delay)
-
-			// retry opening a pull request
-			return o.OpenPullRequest(pr)
-		}
-	}
-
-	if err != nil {
-		return "", errors.Wrapf(err, "failed opening pull request")
-	}
-
-	return githubPR.GetHTMLURL(), nil
 }
 
 // checks if error codes returned from GitHub tell us we are being rate limited
-func (o *GitOptions) checkRateLimiting(githubErr error) (bool, time.Duration) {
+func (o GitOptions) checkRateLimiting(githubErr error) (bool, time.Duration) {
 	isRateLimited := false
 
 	var delay time.Duration
@@ -109,116 +77,11 @@ func (o *GitOptions) checkRateLimiting(githubErr error) (bool, time.Duration) {
 	return isRateLimited, delay
 }
 
-// CheckExistingPullRequests if an existing PR is open with the same version skip, if it's an older version close the PR and we'll create a new one
-func (o *GitOptions) CheckExistingPullRequests(pr *GetPullRequest) (string, error) {
-	// check if there's an existing PR open for the same package
-	openPullRequests, resp, err := o.GithubClient.PullRequests.List(context.Background(), pr.Owner, pr.RepoName, &github.PullRequestListOptions{State: "open"})
-
-	githubErr := github.CheckResponse(resp.Response)
-
-	if githubErr != nil {
-		isRateLimited, delay := o.checkRateLimiting(githubErr)
-
-		if isRateLimited {
-			pr.Retries++
-			o.wait(delay)
-
-			// retry opening a pull request
-			return o.CheckExistingPullRequests(pr)
-		}
-	}
-
-	if err != nil {
-		return "", errors.Wrapf(err, "failed listing pull requests")
-	}
-
-	for _, openPr := range openPullRequests {
-		// if we already have a PR for the same version return
-		if strings.HasPrefix(*openPr.Title, fmt.Sprintf("%s/%s", pr.PackageName, pr.Version)) {
-			return openPr.GetHTMLURL(), nil
-		}
-
-		prTitle := *openPr.Title
-		// if we have a pull request for the package but it's for an old version close it
-		isOld := o.isPullRequestOldVersion(pr.PackageName, pr.Version, prTitle)
-
-		if isOld {
-			o.Logger.Printf("closing old pull request %s as we have a newer version %s", openPr.GetHTMLURL(), pr.Version)
-			err = o.closePullRequest(pr, openPr)
-			if err != nil {
-				o.Logger.Printf("failed closing old pull request %s.  Error: %s", openPr.GetHTMLURL(), err.Error())
-			}
-		}
-	}
-
-	return "", nil
-}
-
-func (o *GitOptions) wait(delay time.Duration) {
+func (o GitOptions) wait(delay time.Duration) {
 	// If we couldn't determine a more accurate delay from GitHub API response headers, then fall back to our user-configurable default
 	if delay == 0 {
 		delay = time.Duration(o.SecondsToSleepWhenRateLimited * int(time.Second))
 	}
 	o.Logger.Printf("retrying PR again later with %d second delay due to secondary rate limiting.", delay)
 	time.Sleep(delay)
-}
-
-func (o *GitOptions) closePullRequest(pr *GetPullRequest, openPr *github.PullRequest) error {
-	closed := "closed"
-	openPr.State = &closed
-
-	_, resp, err := o.GithubClient.PullRequests.Edit(context.Background(), pr.Owner, pr.RepoName, *openPr.Number, openPr)
-	githubErr := github.CheckResponse(resp.Response)
-
-	if githubErr != nil {
-		isRateLimited, delay := o.checkRateLimiting(githubErr)
-
-		if isRateLimited {
-			// If this request has been seen before, increment its retries count, taking into account previous iterations
-			pr.Retries++
-			o.wait(delay)
-
-			// retry opening a pull request
-			return o.closePullRequest(pr, openPr)
-		}
-	}
-	return err
-}
-
-// a matching pull request will have a title in the form of "package_name/v1.2.3 package update"
-func (o *GitOptions) isPullRequestOldVersion(packageName, packageVersion, prTitle string) bool {
-	if strings.HasPrefix(prTitle, fmt.Sprintf("%s/", packageName)) {
-		parts := strings.SplitAfter(prTitle, fmt.Sprintf("%s/", packageName))
-		if len(parts) != 2 {
-			return false
-		}
-
-		// try and get a version after the package name.
-		versionParts := strings.SplitAfter(parts[1], " ")
-		if len(versionParts) == 0 {
-			return false
-		}
-
-		currentVersion := strings.TrimSpace(versionParts[0])
-
-		// get the version from the existing pull request title
-		currentVersionSemver, err := version.NewVersion(currentVersion)
-		if err != nil {
-			o.Logger.Printf("cannot get new version from current version %s. Error %s", currentVersion, err.Error())
-			return false
-		}
-
-		// get a comparable version format for our new package version
-		latestVersionSemver, err := version.NewVersion(packageVersion)
-		if err != nil {
-			o.Logger.Printf("cannot get new version from package version %s. Error %s", packageVersion, err.Error())
-			return false
-		}
-
-		// compare if the existing open pull request has an older version, if so close it and continue to create a new onw
-		if currentVersionSemver.LessThan(latestVersionSemver) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/gh/pull_request.go
+++ b/pkg/gh/pull_request.go
@@ -1,0 +1,170 @@
+package gh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/google/go-github/v48/github"
+
+	"github.com/pkg/errors"
+)
+
+type NewPullRequest struct {
+	BasePullRequest
+	Title string
+	Body  string
+}
+
+type GetPullRequest struct {
+	BasePullRequest
+	PackageName string
+	Version     string
+}
+
+// OpenPullRequest opens a pull request on GitHub
+func (o GitOptions) OpenPullRequest(pr *NewPullRequest) (string, error) {
+	// if our new version is more recent that the existing PR close it and create a new one, otherwise skip
+
+	// If the current request has already exhausted the configured number of PR retries, short-circuit
+	if pr.Retries > o.MaxPullRequestRetries {
+		return "", fmt.Errorf("failed max number of retries, tried %d max %d", pr.Retries, o.MaxPullRequestRetries)
+	}
+
+	// Configure pull request options that the GitHub client accepts when making calls to open new pull requests
+	newPR := &github.NewPullRequest{
+		Title: github.String(pr.Title),
+		Head:  github.String(pr.Branch),
+		Base:  github.String(pr.PullRequestBaseBranch),
+		Body:  github.String(pr.Body),
+	}
+
+	// make a pull request
+	githubPR, resp, err := o.GithubClient.PullRequests.Create(context.Background(), pr.Owner, pr.RepoName, newPR)
+
+	githubErr := github.CheckResponse(resp.Response)
+
+	if githubErr != nil {
+		isRateLimited, delay := o.checkRateLimiting(githubErr)
+		if isRateLimited {
+			pr.Retries++
+			o.wait(delay)
+
+			// retry opening a pull request
+			return o.OpenPullRequest(pr)
+		}
+	}
+
+	if err != nil {
+		return "", errors.Wrapf(err, "failed opening pull request")
+	}
+
+	return githubPR.GetHTMLURL(), nil
+}
+
+// CheckExistingPullRequests if an existing PR is open with the same version skip, if it's an older version close the PR and we'll create a new one
+func (o GitOptions) CheckExistingPullRequests(pr *GetPullRequest) (string, error) {
+	// check if there's an existing PR open for the same package
+	openPullRequests, resp, err := o.GithubClient.PullRequests.List(context.Background(), pr.Owner, pr.RepoName, &github.PullRequestListOptions{State: "open"})
+
+	githubErr := github.CheckResponse(resp.Response)
+
+	if githubErr != nil {
+		isRateLimited, delay := o.checkRateLimiting(githubErr)
+
+		if isRateLimited {
+			pr.Retries++
+			o.wait(delay)
+
+			// retry opening a pull request
+			return o.CheckExistingPullRequests(pr)
+		}
+	}
+
+	if err != nil {
+		return "", errors.Wrapf(err, "failed listing pull requests")
+	}
+
+	for _, openPr := range openPullRequests {
+		// if we already have a PR for the same version return
+		if strings.HasPrefix(*openPr.Title, fmt.Sprintf("%s/%s", pr.PackageName, pr.Version)) {
+			return openPr.GetHTMLURL(), nil
+		}
+
+		prTitle := *openPr.Title
+		// if we have a pull request for the package but it's for an old version close it
+		isOld := o.isPullRequestOldVersion(pr.PackageName, pr.Version, prTitle)
+
+		if isOld {
+			o.Logger.Printf("closing old pull request %s as we have a newer version %s", openPr.GetHTMLURL(), pr.Version)
+			err = o.closePullRequest(pr, openPr)
+			if err != nil {
+				o.Logger.Printf("failed closing old pull request %s.  Error: %s", openPr.GetHTMLURL(), err.Error())
+			}
+		}
+	}
+
+	return "", nil
+}
+
+func (o GitOptions) closePullRequest(pr *GetPullRequest, openPr *github.PullRequest) error {
+	closed := "closed"
+	openPr.State = &closed
+
+	_, resp, err := o.GithubClient.PullRequests.Edit(context.Background(), pr.Owner, pr.RepoName, *openPr.Number, openPr)
+	githubErr := github.CheckResponse(resp.Response)
+
+	if githubErr != nil {
+		isRateLimited, delay := o.checkRateLimiting(githubErr)
+
+		if isRateLimited {
+			// If this request has been seen before, increment its retries count, taking into account previous iterations
+			pr.Retries++
+			o.wait(delay)
+
+			// retry opening a pull request
+			return o.closePullRequest(pr, openPr)
+		}
+	}
+	return err
+}
+
+// a matching pull request will have a title in the form of "package_name/v1.2.3 package update"
+func (o GitOptions) isPullRequestOldVersion(packageName, packageVersion, prTitle string) bool {
+	if strings.HasPrefix(prTitle, fmt.Sprintf("%s/", packageName)) {
+		parts := strings.SplitAfter(prTitle, fmt.Sprintf("%s/", packageName))
+		if len(parts) != 2 {
+			return false
+		}
+
+		// try and get a version after the package name.
+		versionParts := strings.SplitAfter(parts[1], " ")
+		if len(versionParts) == 0 {
+			return false
+		}
+
+		currentVersion := strings.TrimSpace(versionParts[0])
+
+		// get the version from the existing pull request title
+		currentVersionSemver, err := version.NewVersion(currentVersion)
+		if err != nil {
+			o.Logger.Printf("cannot get new version from current version %s. Error %s", currentVersion, err.Error())
+			return false
+		}
+
+		// get a comparable version format for our new package version
+		latestVersionSemver, err := version.NewVersion(packageVersion)
+		if err != nil {
+			o.Logger.Printf("cannot get new version from package version %s. Error %s", packageVersion, err.Error())
+			return false
+		}
+
+		// compare if the existing open pull request has an older version, if so close it and continue to create a new onw
+		if currentVersionSemver.LessThan(latestVersionSemver) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/gh/release.go
+++ b/pkg/gh/release.go
@@ -1,0 +1,279 @@
+package gh
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	http2 "github.com/wolfi-dev/wolfictl/pkg/http"
+	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
+
+	"github.com/google/go-github/v48/github"
+
+	"github.com/pkg/errors"
+	wolfigit "github.com/wolfi-dev/wolfictl/pkg/git"
+	wolfiversions "github.com/wolfi-dev/wolfictl/pkg/versions"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+
+	"github.com/go-git/go-git/v5"
+)
+
+const defaultStartVersion = "v0.0.0"
+
+type ReleaseOptions struct {
+	GithubClient             *github.Client
+	Logger                   *log.Logger
+	BumpMajor                bool
+	BumpMinor                bool
+	BumpPatch                bool
+	BumpPrereleaseWithPrefix string
+	Dir                      string
+}
+
+func NewReleaseOptions() ReleaseOptions {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
+	)
+
+	ratelimit := &http2.RLHTTPClient{
+		Client: oauth2.NewClient(context.Background(), ts),
+
+		// 1 request every (n) second(s) to avoid DOS'ing server. https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-secondary-rate-limits
+		Ratelimiter: rate.NewLimiter(rate.Every(3*time.Second), 1),
+	}
+
+	return ReleaseOptions{
+		GithubClient: github.NewClient(ratelimit.Client),
+		Logger:       log.New(log.Writer(), "wolfictl gh release: ", log.LstdFlags|log.Lmsgprefix),
+	}
+}
+
+// Release will create a new GitHub release
+func (o ReleaseOptions) Release() error {
+	// get the latest git tag
+	current, err := o.getCurrentVersionFromTag()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get current version from tag in dir %s", o.Dir)
+	}
+
+	o.Logger.Printf("current latest version tag is %s", current.Original())
+
+	// increment
+	next, err := o.bumpReleaseVersion(current)
+	if err != nil {
+		return errors.Wrapf(err, "failed to bump current version %s", current.Original())
+	}
+
+	// create new tag + GitHub release
+	err = o.createTag(next.Original(), "", "")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create tag %s", next.Original())
+	}
+
+	// push new tag
+	err = o.pushTag(next.Original())
+	if err != nil {
+		return err
+	}
+
+	return o.createGitHubRelease(next.Original())
+}
+
+func (o ReleaseOptions) getCurrentVersionFromTag() (*version.Version, error) {
+	r, err := git.PlainOpen(o.Dir)
+	if err != nil {
+		return nil, err
+	}
+
+	tagRefs, err := r.Tags()
+	if err != nil {
+		return nil, err
+	}
+
+	// collect all tags
+	var versions []*version.Version
+
+	err = tagRefs.ForEach(func(t *plumbing.Reference) error {
+		releaseVersionSemver, err := version.NewVersion(t.Name().Short())
+		if err != nil {
+			return errors.Wrapf(err, "failed to create new version from tag %s", t.Name().Short())
+		}
+		versions = append(versions, releaseVersionSemver)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// get the latest tag, maybe need to sort?
+	sort.Sort(wolfiversions.ByLatest(versions))
+	var latest *version.Version
+	if len(versions) == 0 {
+		latest, err = version.NewVersion(defaultStartVersion)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create new version from tag %s", defaultStartVersion)
+		}
+	} else {
+		// get the last tag
+		latest = versions[len(versions)-1]
+	}
+	return latest, nil
+}
+
+// bumpReleaseVersion will increment parts of a new release version based on flags supplied when running the CLI command
+func (o ReleaseOptions) bumpReleaseVersion(current *version.Version) (*version.Version, error) {
+	prefix := ""
+	if strings.HasPrefix(current.Original(), "v") {
+		prefix = "v"
+	}
+
+	major := current.Segments()[0]
+	minor := current.Segments()[1]
+	patch := current.Segments()[2]
+
+	if o.BumpMajor {
+		major++
+	}
+
+	if o.BumpMinor {
+		minor++
+	}
+
+	if o.BumpPatch {
+		patch++
+	}
+
+	newPrerelease := ""
+	if o.BumpPrereleaseWithPrefix != "" {
+		prerelease := current.Prerelease()
+
+		// if no existing prerelease automatically bump the patch as semver will say existing patch version is newer than our new prerelease
+		if prerelease == "" {
+			newPrerelease = fmt.Sprintf("%s%d", o.BumpPrereleaseWithPrefix, 1)
+
+			// override bumping patch if no existing prerelease
+			if !o.BumpPatch {
+				patch++
+			}
+		} else {
+			preReleaseVersion := strings.TrimPrefix(prerelease, o.BumpPrereleaseWithPrefix)
+
+			i, err := strconv.Atoi(preReleaseVersion)
+			if err != nil {
+				return nil, err
+			}
+			newPrerelease = fmt.Sprintf("%s%d", o.BumpPrereleaseWithPrefix, i+1)
+		}
+	}
+
+	// this needs to be in the form 1.2.3rc2 and not 1.2.3-rc2 as apk doesn't recognise the latter as newer than a previous prerelease like 1.2.3-rc1
+	newVersion := fmt.Sprintf("%s%d.%d.%d%s", prefix, major, minor, patch, newPrerelease)
+
+	return version.NewVersion(newVersion)
+}
+
+func (o ReleaseOptions) createTag(tag, overrideGitName, overrideGitEmail string) error {
+	r, err := git.PlainOpen(o.Dir)
+	if err != nil {
+		return err
+	}
+
+	o.Logger.Printf("creating tag %s", tag)
+	h, err := r.Head()
+	if err != nil {
+		return err
+	}
+
+	tagOptions := &git.CreateTagOptions{
+		Message: tag,
+	}
+	// override default git config tagger info
+	if overrideGitName != "" && overrideGitEmail != "" {
+		o.Logger.Printf("overriding default git tagger config with name %s: email: %s", overrideGitName, overrideGitEmail)
+		tagOptions.Tagger = &object.Signature{
+			Name:  overrideGitName,
+			Email: overrideGitEmail,
+			When:  time.Now(),
+		}
+	}
+
+	_, err = r.CreateTag(tag, h.Hash(), tagOptions)
+
+	return err
+}
+
+// createGitHubRelease creates a new release on GitHub
+func (o ReleaseOptions) createGitHubRelease(v string) error {
+	repo, err := git.PlainOpen(o.Dir)
+	if err != nil {
+		return err
+	}
+
+	gitURL, err := wolfigit.GetRemoteURL(repo)
+	if err != nil {
+		return fmt.Errorf("failed to find git origin URL: %w", err)
+	}
+
+	input := &github.RepositoryRelease{
+		Name:    github.String(v),
+		TagName: github.String(v),
+	}
+
+	ctx := context.Background()
+	release, _, err := o.GithubClient.Repositories.CreateRelease(ctx, gitURL.Organisation, gitURL.Name, input)
+	if err != nil {
+		return err
+	}
+
+	o.Logger.Printf("successfully created new release %s", *release.HTMLURL)
+	return nil
+}
+
+func (o ReleaseOptions) pushTag(tagName string) error {
+	r, err := git.PlainOpen(o.Dir)
+	if err != nil {
+		return err
+	}
+
+	// force remote URL to be https, using git@ requires ssh keys and we default to using basic auth
+	remote, err := r.Remote("origin")
+	if err != nil {
+		return err
+	}
+	gitURL, err := wolfigit.ParseGitURL(remote.Config().URLs[0])
+	if err != nil {
+		return err
+	}
+	remoteURL := fmt.Sprintf("https://github.com/%s/%s.git", gitURL.Organisation, gitURL.Name)
+
+	po := &git.PushOptions{
+		RemoteName: "origin",
+		RemoteURL:  remoteURL,
+		RefSpecs:   []config.RefSpec{config.RefSpec(fmt.Sprintf("refs/tags/%s:refs/tags/%s", tagName, tagName))},
+		Auth:       wolfigit.GetGitAuth(),
+	}
+
+	err = r.Push(po)
+
+	if err != nil {
+		if err == git.NoErrAlreadyUpToDate {
+			o.Logger.Println("origin remote was up to date, no push done")
+			return nil
+		}
+		return errors.Wrapf(err, "failed to push tag")
+	}
+
+	return nil
+}

--- a/pkg/gh/release_test.go
+++ b/pkg/gh/release_test.go
@@ -1,0 +1,179 @@
+package gh
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/util"
+
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrereleaseBump(t *testing.T) {
+	tests := []struct {
+		current  string
+		expected string
+		ReleaseOptions
+	}{
+		{
+			current: "v1", expected: "v1.0.1ab1",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v1.2", expected: "v1.2.1ab1",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v1.2.3", expected: "v1.2.4ab1",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v1.2.4ab1", expected: "v1.2.4ab2",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v1.2.4ab10", expected: "v1.2.4ab11",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v1.2.4ab12", expected: "v1.2.4ab13",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v0.0.0", expected: "v0.0.1ab1",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v1.0.0", expected: "v2.0.0",
+			ReleaseOptions: ReleaseOptions{
+				BumpMajor: true,
+			},
+		},
+		{
+			current: "v1.1.0", expected: "v1.2.0",
+			ReleaseOptions: ReleaseOptions{
+				BumpMinor: true,
+			},
+		},
+		{
+			current: "v1.0.1", expected: "v1.0.2",
+			ReleaseOptions: ReleaseOptions{
+				BumpPatch: true,
+			},
+		},
+		{
+			current: "v1.0.1", expected: "v1.0.2ab1",
+			ReleaseOptions: ReleaseOptions{
+				BumpPatch:                true,
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+		{
+			current: "v1.0.10ab10", expected: "v1.0.10ab11",
+			ReleaseOptions: ReleaseOptions{
+				BumpPrereleaseWithPrefix: "ab",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.current, func(t *testing.T) {
+			c, err := version.NewVersion(test.current)
+			assert.NoError(t, err)
+			e, err := version.NewVersion(test.expected)
+			assert.NoError(t, err)
+
+			got, err := test.ReleaseOptions.bumpReleaseVersion(c)
+			assert.NoError(t, err)
+
+			assert.Equal(t, e.Original(), got.Original())
+		})
+	}
+}
+
+func TestGetCurrentVersionFromTag(t *testing.T) {
+	o := ReleaseOptions{
+		Logger: log.New(log.Writer(), "test: ", log.LstdFlags|log.Lmsgprefix),
+	}
+
+	tests := []struct {
+		existing []string
+		expected string
+	}{
+		{existing: nil, expected: "v0.0.0"},
+		{existing: []string{"v1.2.3ab1", "v1.2.3ab2"}, expected: "v1.2.3ab2"},
+		{existing: []string{"v1.2.3ab2", "v1.2.3ab1"}, expected: "v1.2.3ab2"},
+		{existing: []string{"v1.2.4cg9", "v1.2.4cg10"}, expected: "v1.2.4cg10"},
+		{existing: []string{"v1.2.4cg10", "v1.2.4cg9"}, expected: "v1.2.4cg10"},
+	}
+	for _, test := range tests {
+		t.Run(test.expected, func(t *testing.T) {
+			dir := t.TempDir()
+			setupTestRepo(t, dir)
+
+			o.Dir = dir
+
+			for _, tag := range test.existing {
+				err := o.createTag(tag, "test", "test@tester.com")
+				assert.NoError(t, err)
+			}
+
+			current, err := o.getCurrentVersionFromTag()
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.expected, current.Original())
+		})
+	}
+}
+
+func setupTestRepo(t *testing.T, dir string) *git.Repository {
+	fs := osfs.New(dir)
+
+	storage := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	wt, err := fs.Chroot("test")
+	assert.NoError(t, err)
+
+	r, err := git.Init(storage, wt)
+	assert.NoError(t, err)
+
+	w, err := r.Worktree()
+	assert.NoError(t, err)
+
+	err = util.WriteFile(w.Filesystem, "foo.yaml", []byte("ok"), 0o644)
+	assert.NoError(t, err)
+
+	_, err = w.Add("foo.yaml")
+	assert.NoError(t, err)
+
+	_, err = w.Commit("initial test checkin", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "John Doe",
+			Email: "john@doe.org",
+			When:  time.Now(),
+		},
+	})
+	assert.NoError(t, err)
+
+	return r
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,7 +1,13 @@
 package git
 
 import (
+	"fmt"
+	"net/url"
 	"os"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/wolfi-dev/wolfictl/pkg/stringhelpers"
 
 	gitHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
@@ -13,4 +19,60 @@ func GetGitAuth() *gitHttp.BasicAuth {
 		Username: "abc123",
 		Password: gitToken,
 	}
+}
+
+type URL struct {
+	Scheme       string
+	Host         string
+	Organisation string
+	Name         string
+}
+
+func GetRemoteURL(repo *git.Repository) (*URL, error) {
+	remote, err := repo.Remote("origin")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find git origin URL: %w", err)
+	}
+
+	if len(remote.Config().URLs) == 0 {
+		return nil, fmt.Errorf("no remote config URLs found for remote origin")
+	}
+
+	return ParseGitURL(remote.Config().URLs[0])
+}
+
+// ParseGitURL returns owner, repo name, errors
+func ParseGitURL(rawURL string) (*URL, error) {
+	gitURL := &URL{}
+
+	rawURL = strings.TrimSuffix(rawURL, ".git")
+
+	// handle git@ kinds of URIs
+	if strings.HasPrefix(rawURL, "git@") {
+		t := strings.TrimPrefix(rawURL, "git@")
+		t = strings.TrimPrefix(t, "/")
+		t = strings.TrimPrefix(t, "/")
+		t = strings.TrimSuffix(t, "/")
+
+		arr := stringhelpers.RegexpSplit(t, ":|/")
+		if len(arr) >= 3 {
+			gitURL.Scheme = "git"
+			gitURL.Host = arr[0]
+			gitURL.Organisation = arr[1]
+			gitURL.Name = arr[len(arr)-1]
+			return gitURL, nil
+		}
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return gitURL, fmt.Errorf("failed to parse git url %s: %w", rawURL, err)
+	}
+	gitURL.Scheme = parsedURL.Scheme
+	gitURL.Host = parsedURL.Host
+	parts := strings.Split(parsedURL.Path, "/")
+	gitURL.Organisation = parts[1]
+	gitURL.Name = parts[2]
+
+	return gitURL, nil
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGitURL(t *testing.T) {
+	tests := []struct {
+		rawURL   string
+		scheme   string
+		org      string
+		repoName string
+	}{
+		{
+			rawURL:   "https://github.com/foo/bar",
+			scheme:   "https",
+			org:      "foo",
+			repoName: "bar",
+		},
+		{
+			rawURL:   "https://github.com/foo/bar.git",
+			scheme:   "https",
+			org:      "foo",
+			repoName: "bar",
+		},
+		{
+			rawURL:   "git@github.com:cheese/wine.git",
+			scheme:   "git",
+			org:      "cheese",
+			repoName: "wine",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.rawURL, func(t *testing.T) {
+			got, err := ParseGitURL(test.rawURL)
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.scheme, got.Scheme)
+			assert.Equal(t, test.org, got.Organisation)
+			assert.Equal(t, test.repoName, got.Name)
+		})
+	}
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,4 +1,4 @@
-package update
+package http
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 // RLHTTPClient Rate Limited HTTP Client
 type RLHTTPClient struct {
-	client      *http.Client
+	Client      *http.Client
 	Ratelimiter *rate.Limiter
 }
 
@@ -21,7 +21,7 @@ func (c *RLHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func (c *RLHTTPClient) Do(req *http.Request) (*http.Response, error) {
 // NewClient return rate_limitted_http client with a ratelimiter
 func NewClient(rl *rate.Limiter) *RLHTTPClient {
 	c := &RLHTTPClient{
-		client:      http.DefaultClient,
+		Client:      http.DefaultClient,
 		Ratelimiter: rl,
 	}
 	return c

--- a/pkg/stringhelpers/strings.go
+++ b/pkg/stringhelpers/strings.go
@@ -1,0 +1,17 @@
+package stringhelpers
+
+import "regexp"
+
+// RegexpSplit splits a string into an array using the regexSep as a separator
+func RegexpSplit(text, regexSeperator string) []string {
+	reg := regexp.MustCompile(regexSeperator)
+	indexes := reg.FindAllStringIndex(text, -1)
+	lastIdx := 0
+	result := make([]string, len(indexes)+1)
+	for i, element := range indexes {
+		result[i] = text[lastIdx:element[0]]
+		lastIdx = element[1]
+	}
+	result[len(indexes)] = text[lastIdx:]
+	return result
+}

--- a/pkg/stringhelpers/strings_test.go
+++ b/pkg/stringhelpers/strings_test.go
@@ -1,0 +1,28 @@
+package stringhelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexpSplit(t *testing.T) {
+	tests := []struct {
+		input     string
+		separator string
+		expected  []string
+	}{
+		{
+			"foo/bar", ":|/", []string{"foo", "bar"},
+		},
+		{
+			"foo:bar", ":|/", []string{"foo", "bar"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			actual := RegexpSplit(test.input, test.separator)
+			assert.Equal(t, test.expected, actual, "split did not match for input %s with separator %s", test.input, test.separator)
+		})
+	}
+}

--- a/pkg/update/githubReleases.go
+++ b/pkg/update/githubReleases.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/wolfi-dev/wolfictl/pkg/melange"
+	wolfiversions "github.com/wolfi-dev/wolfictl/pkg/versions"
 	"golang.org/x/exp/maps"
 )
 
@@ -227,7 +228,7 @@ func (o GitHubReleaseOptions) parseGitHubReleases(repos []Repository) (results m
 		// not all projects use the github latest release tag properly so could
 		// end up with older versions
 		if len(versions) > 0 {
-			sort.Sort(VersionsByLatest(versions))
+			sort.Sort(wolfiversions.ByLatest(versions))
 
 			latestVersionSemver := versions[len(versions)-1]
 
@@ -314,29 +315,3 @@ func printJSON(v interface{}) {
 		panic(err)
 	}
 }
-
-type Interface interface {
-	// Len is the number of elements in the collection.
-	Len() int
-
-	// Less reports whether the element with index i must sort before the element with index j.
-	// If both Less(i, j) and Less(j, i) are false, then the elements at index i and j are considered equal.
-	Less(i, j int) bool
-
-	// Swap swaps the elements with indexes i and j.
-	Swap(i, j int)
-}
-
-func (u VersionsByLatest) Len() int {
-	return len(u)
-}
-
-func (u VersionsByLatest) Swap(i, j int) {
-	u[i], u[j] = u[j], u[i]
-}
-
-func (u VersionsByLatest) Less(i, j int) bool {
-	return u[i].LessThan(u[j])
-}
-
-type VersionsByLatest []*version.Version

--- a/pkg/update/githubReleases_test.go
+++ b/pkg/update/githubReleases_test.go
@@ -6,10 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
-
-	"github.com/hashicorp/go-version"
 
 	"chainguard.dev/melange/pkg/build"
 
@@ -99,51 +96,4 @@ func TestGitHubReleases_GetRepoList(t *testing.T) {
 	assert.Equal(t, 4, len(rs))
 	assert.Equal(t, len(rs[0]), 100)
 	assert.Equal(t, len(rs[3]), 50)
-}
-
-func TestGitHubReleases_SortVersions(t *testing.T) {
-	baseVersions := []string{"1.2.3", "1.1.1", "2.3.4", "0.1.3"}
-
-	tests := []struct {
-		name                  string
-		baseVersions          []string
-		testVersions          []string
-		expectedLatestVersion string
-	}{
-		{
-			name:                  "simple",
-			baseVersions:          baseVersions,
-			testVersions:          []string{"4.0.1"},
-			expectedLatestVersion: "4.0.1",
-		},
-		{
-			name:                  "fork",
-			baseVersions:          baseVersions,
-			testVersions:          []string{"4.0.1ab2", "4.0.1ab3", "4.0.1ab1"},
-			expectedLatestVersion: "4.0.1ab3",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var versions []*version.Version
-
-			// add test versions to the list first
-			for _, v := range test.testVersions {
-				semver, err := version.NewVersion(v)
-				assert.NoError(t, err)
-				versions = append(versions, semver)
-			}
-
-			// next add base versions
-			for _, v := range test.baseVersions {
-				semver, err := version.NewVersion(v)
-				assert.NoError(t, err)
-				versions = append(versions, semver)
-			}
-
-			sort.Sort(VersionsByLatest(versions))
-
-			assert.Equal(t, test.expectedLatestVersion, versions[len(versions)-1].Original())
-		})
-	}
 }

--- a/pkg/update/releaseMonitor.go
+++ b/pkg/update/releaseMonitor.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 
+	http2 "github.com/wolfi-dev/wolfictl/pkg/http"
+
 	"github.com/wolfi-dev/wolfictl/pkg/melange"
 
 	"github.com/hashicorp/go-version"
@@ -15,8 +17,8 @@ import (
 )
 
 type MonitorService struct {
-	Client           *RLHTTPClient
-	GitHubHTTPClient *RLHTTPClient
+	Client           *http2.RLHTTPClient
+	GitHubHTTPClient *http2.RLHTTPClient
 	Logger           *log.Logger
 	DataMapperURL    string
 }

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -27,25 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_parseGitURL(t *testing.T) {
-	tests := []struct {
-		rawURL string
-		owner  string
-		repo   string
-	}{
-		{rawURL: "https://github.com/cheese/wine", owner: "cheese", repo: "wine"},
-		{rawURL: "https://github.com/cheese/wine.git", owner: "cheese", repo: "wine"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.rawURL, func(t *testing.T) {
-			owner, repo, err := parseGitURL(tt.rawURL)
-			assert.NoError(t, err)
-			assert.Equalf(t, tt.owner, owner, "parseGitURL(%v)", tt.rawURL)
-			assert.Equalf(t, tt.repo, repo, "parseGitURL(%v)", tt.rawURL)
-		})
-	}
-}
-
 // a bit more than a typical unit test but is useful to test a git branch with melange bump
 func TestMonitorService_updatePackagesGitRepository(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -1,0 +1,77 @@
+package versions
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+)
+
+type Interface interface {
+	// Len is the number of elements in the collection.
+	Len() int
+
+	// Less reports whether the element with index i must sort before the element with index j.
+	// If both Less(i, j) and Less(j, i) are false, then the elements at index i and j are considered equal.
+	Less(i, j int) bool
+
+	// Swap swaps the elements with indexes i and j.
+	Swap(i, j int)
+}
+
+func (u ByLatest) Len() int {
+	return len(u)
+}
+
+func (u ByLatest) Swap(i, j int) {
+	u[i], u[j] = u[j], u[i]
+}
+
+func (u ByLatest) Less(i, j int) bool {
+	// we need to override the default prerelease version comparison as we use 1.2.3ab1 rather than 1.2.3-ab1
+	// we use this version format so we can use the same version in melange configs and have apk resolve correct versions
+	if equal(u[i].Segments(), u[j].Segments()) {
+		//nolint:gosimple // incorrect behaviour if using ``
+		re := regexp.MustCompile("\\d+|\\D+")
+		iparts := re.FindAllString(u[i].Prerelease(), -1)
+		if len(iparts) != 2 {
+			return false
+		}
+		jparts := re.FindAllString(u[j].Prerelease(), -1)
+		if len(jparts) != 2 {
+			return false
+		}
+		// compare the string prefixes
+		if strings.Compare(iparts[0], jparts[0]) == -1 {
+			return true
+		}
+
+		// compare the integer suffixes
+		isuffix, err := strconv.Atoi(iparts[1])
+		if err != nil {
+			return false
+		}
+		jsuffix, err := strconv.Atoi(jparts[1])
+		if err != nil {
+			return false
+		}
+
+		return isuffix < jsuffix
+	}
+	return u[i].LessThan(u[j])
+}
+
+type ByLatest []*version.Version
+
+func equal(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/versions/versions_test.go
+++ b/pkg/versions/versions_test.go
@@ -1,0 +1,61 @@
+package versions
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitHubReleases_SortVersions(t *testing.T) {
+	baseVersions := []string{"1.2.3", "1.1.1", "2.3.4", "0.1.3"}
+
+	tests := []struct {
+		name                  string
+		baseVersions          []string
+		testVersions          []string
+		expectedLatestVersion string
+	}{
+		{
+			name:                  "simple",
+			baseVersions:          baseVersions,
+			testVersions:          []string{"4.0.1"},
+			expectedLatestVersion: "4.0.1",
+		},
+		{
+			name:                  "fork",
+			baseVersions:          baseVersions,
+			testVersions:          []string{"4.0.1ab2", "4.0.1ab3", "4.0.1ab1"},
+			expectedLatestVersion: "4.0.1ab3",
+		},
+		{
+			name:                  "large",
+			testVersions:          []string{"v1.2.3", "v1.2.3ab1", "v1.2.3ab2", "v1.2.4ab1", "v1.2.4ab10", "v1.2.4ab2", "v1.2.4ab3", "v1.2.4ab4", "v1.2.4ab5", "v1.2.4ab6", "v1.2.4ab7", "v1.2.4ab8", "v1.2.4ab9"},
+			expectedLatestVersion: "v1.2.4ab10",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var versions []*version.Version
+
+			// add test versions to the list first
+			for _, v := range test.testVersions {
+				semver, err := version.NewVersion(v)
+				assert.NoError(t, err)
+				versions = append(versions, semver)
+			}
+
+			// next add base versions
+			for _, v := range test.baseVersions {
+				semver, err := version.NewVersion(v)
+				assert.NoError(t, err)
+				versions = append(versions, semver)
+			}
+
+			sort.Sort(ByLatest(versions))
+
+			assert.Equal(t, test.expectedLatestVersion, versions[len(versions)-1].Original())
+		})
+	}
+}


### PR DESCRIPTION
…nd create a github release

Examples:

wolfictl gh release --bump-major
wolfictl gh release --bump-minor
wolfictl gh release --bump-patch
wolfictl gh release --bump-prerelease-with-prefix rc

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>