### PR TITLE
Add apk and index subcommands

### DIFF
--- a/pkg/cli/apk.go
+++ b/pkg/cli/apk.go
@@ -18,7 +18,7 @@ func Apk() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := fmt.Sprintf("https://packages.wolfi.dev/os/%s/%s", arch, args[0])
-			resp, err := http.Get(url)
+			resp, err := http.Get(url) //nolint:gosec
 			if err != nil {
 				return err
 			}
@@ -51,7 +51,7 @@ func Index() *cobra.Command {
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := fmt.Sprintf("https://packages.wolfi.dev/os/%s/APKINDEX.tar.gz", arch)
-			resp, err := http.Get(url)
+			resp, err := http.Get(url) //nolint:gosec
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/apk.go
+++ b/pkg/cli/apk.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+	"gitlab.alpinelinux.org/alpine/go/repository"
+)
+
+func Apk() *cobra.Command {
+	var arch string
+	cmd := &cobra.Command{
+		Use:  "apk",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			url := fmt.Sprintf("https://packages.wolfi.dev/os/%s/%s", arch, args[0])
+			resp, err := http.Get(url)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				b, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("GET %s (%d): %s", url, resp.StatusCode, b)
+			}
+
+			pkg, err := repository.ParsePackage(resp.Body)
+			if err != nil {
+				return err
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(pkg)
+		},
+	}
+	cmd.Flags().StringVar(&arch, "arch", "x86_64", "arch of package to get")
+	return cmd
+}
+
+func Index() *cobra.Command {
+	var arch string
+	cmd := &cobra.Command{
+		Use:  "index",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			url := fmt.Sprintf("https://packages.wolfi.dev/os/%s/APKINDEX.tar.gz", arch)
+			resp, err := http.Get(url)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				b, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("GET %s (%d): %s", url, resp.StatusCode, b)
+			}
+
+			idx, err := repository.IndexFromArchive(resp.Body)
+			if err != nil {
+				return err
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(idx)
+		},
+	}
+	cmd.Flags().StringVar(&arch, "arch", "x86_64", "arch of package to get")
+	return cmd
+}

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -19,6 +19,8 @@ func New() *cobra.Command {
 		Advisory(),
 		Bump(),
 		Gh(),
+		Apk(),
+		Index(),
 	)
 
 	return cmd


### PR DESCRIPTION
Commands to pull remote apks and APKINDEX and print information about them to stdout as JSON, so you can `jq` it.

```
$ go run . apk busybox-1.36.0-r0.apk | jq -r .RepoCommit
8d3ed829b595b36d679fe91a1843685f0256c2b8
```

```
$ go run . index | jq -r '.Packages[].Name' | head -n 10
bash-doc
pkgconf-doc
wolfi-baselayout
glibc-locale-nso
lz4-dev
automake-doc
glibc-locale-rw
libxi-dev
libev-dev
glibc-locale-syr
```


If other output formats are useful we can add them. If a more interactive apk picker is useful we can add that too. If we want to support other package repos, we can. The world is our oyster 🦪 


Signed-off-by: Jason Hall <jason@chainguard.dev>