### PR TITLE
apk,index: support repo flag, append .apk if absent

### DIFF
--- a/pkg/cli/apk.go
+++ b/pkg/cli/apk.go
@@ -6,18 +6,35 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
+var repos = map[string]string{
+	"wolfi":  "https://packages.wolfi.dev/os",
+	"stage1": "https://packages.wolfi.dev/bootstrap/stage1",
+	"stage2": "https://packages.wolfi.dev/bootstrap/stage2",
+	"stage3": "https://packages.wolfi.dev/bootstrap/stage3",
+}
+
 func Apk() *cobra.Command {
-	var arch string
+	var arch, repo string
 	cmd := &cobra.Command{
 		Use:  "apk",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			url := fmt.Sprintf("https://packages.wolfi.dev/os/%s/%s", arch, args[0])
+			if !strings.HasSuffix(args[0], ".apk") {
+				args[0] += ".apk"
+			}
+
+			// Map a friendly string like "wolfi" to its repo URL.
+			if got, found := repos[repo]; found {
+				repo = got
+			}
+
+			url := fmt.Sprintf("%s/%s/%s", repo, arch, args[0])
 			resp, err := http.Get(url) //nolint:gosec
 			if err != nil {
 				return err
@@ -41,16 +58,22 @@ func Apk() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&arch, "arch", "x86_64", "arch of package to get")
+	cmd.Flags().StringVar(&repo, "repo", "wolfi", "repo to get packages from")
 	return cmd
 }
 
 func Index() *cobra.Command {
-	var arch string
+	var arch, repo string
 	cmd := &cobra.Command{
 		Use:  "index",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			url := fmt.Sprintf("https://packages.wolfi.dev/os/%s/APKINDEX.tar.gz", arch)
+			// Map a friendly string like "wolfi" to its repo URL.
+			if got, found := repos[repo]; found {
+				repo = got
+			}
+
+			url := fmt.Sprintf("%s/%s/APKINDEX.tar.gz", repo, arch)
 			resp, err := http.Get(url) //nolint:gosec
 			if err != nil {
 				return err
@@ -74,5 +97,6 @@ func Index() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&arch, "arch", "x86_64", "arch of package to get")
+	cmd.Flags().StringVar(&repo, "repo", "wolfi", "repo to get packages from")
 	return cmd
 }


### PR DESCRIPTION
```
$ wolfictl apk cross-linux-headers-5.16.9-r0 --repo=stage1
{
  "Name": "cross-linux-headers",
  "Version": "5.16.9-r0",
  "Arch": "x86_64",
  "Description": "the Linux kernel headers (cross compilation)",
...
```

```
$ wolfictl index --repo=stage1
{
  "Signature": "...",
  "Description": "",
  "Packages": [
    {
      "Name": "cross-linux-headers",
...
```

In addition to the handful of known repos we care about, the `--repo` flag accepts a URL prefix, in case you have any other APK repos you want to query:

```
$ wolfictl index --repo=https://dl-cdn.alpinelinux.org/alpine/edge/main
{
  "Signature": "...",
  "Description": "v3.17.0-5638-g1149277d63",
  "Packages": [
    {
      "Name": "bacula-libs",
```

Signed-off-by: Jason Hall <jason@chainguard.dev>