### PR TITLE
wolfictl update, fix regex to handle CVE names with hyphen separators

### DIFF
--- a/pkg/update/package.go
+++ b/pkg/update/package.go
@@ -200,7 +200,7 @@ func (o *PackageOptions) updateSecfixes(repo *git.Repository) error {
 	}
 
 	if len(cveFixes) == 0 {
-		o.Logger.Printf("no fixes: CVE### comments found from commits between tags %s and %s, skip creating sec fix advisories\n", previous, o.Version)
+		o.Logger.Printf("no fixes: CVE### comments found from commits between tags %s and %s, skip creating sec fix advisories\n", previous.Original(), o.Version)
 		return nil
 	}
 	// run the equivalent of `wolfictl advisory create ./foo.melange.yaml --vuln 'CVE-2022-31130' --status 'fixed' --fixed-version '7.5.17-r1'`
@@ -237,7 +237,7 @@ func (o *PackageOptions) getFixesCVEList(dir string, previous *version.Version) 
 
 	// parse commit comments for `fixes: CVE###`, (?i) to ignore case
 	//nolint:gosimple
-	r := regexp.MustCompile("(?i)fixes: CVE\\w+")
+	r := regexp.MustCompile("(?i)fixes: CVE-*[0-9]\\d+-*[0-9]?\\d+")
 
 	cves := r.FindAllStringSubmatch(gitLog, -1)
 	for _, commitCVEs := range cves {

--- a/pkg/update/package_test.go
+++ b/pkg/update/package_test.go
@@ -28,6 +28,18 @@ func TestPackageUpdate_getFixesCVEList(t *testing.T) {
 	createTestTag(t, r, "1.2.4")
 	createTestCommit(t, r, "a2", "fixes: CVE456abc and some other text")
 	createTestCommit(t, r, "a3", "FIXES: cve78910qwerty and some other text")
+	createTestCommit(t, r, "a4", "FIXES: cve257 fixes: cve579")
+	createTestCommit(t, r, "a5", `
+fixes: CVE961
+fixes: CVE852
+`)
+	createTestCommit(t, r, "a6", `
+
+    patch foo go modules
+
+    fixes: CVE-2000-1234
+
+`)
 
 	// create a new release tag 1.2.5
 	createTestTag(t, r, "1.2.5")
@@ -43,9 +55,14 @@ func TestPackageUpdate_getFixesCVEList(t *testing.T) {
 	cves, err := o.getFixesCVEList(dir, previousVersion)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 2, len(cves))
-	assert.Equal(t, "CVE78910QWERTY", cves[0])
-	assert.Equal(t, "CVE456ABC", cves[1])
+	assert.Equal(t, 7, len(cves))
+	assert.Contains(t, cves, "CVE78910")
+	assert.Contains(t, cves, "CVE456")
+	assert.Contains(t, cves, "CVE257")
+	assert.Contains(t, cves, "CVE579")
+	assert.Contains(t, cves, "CVE961")
+	assert.Contains(t, cves, "CVE852")
+	assert.Contains(t, cves, "CVE-2000-1234")
 }
 
 func setupTestRepo(t *testing.T, dir string) *git.Repository {


### PR DESCRIPTION
Signed-off-by: James Rawlings <jrawlings@chainguard.dev>