### PR TITLE
wolfictl lint: allow users to skip rules via a CLI flag

### DIFF
--- a/pkg/cli/lint.go
+++ b/pkg/cli/lint.go
@@ -8,9 +8,10 @@ import (
 )
 
 type lintOptions struct {
-	args    []string
-	verbose bool
-	list    bool
+	args      []string
+	verbose   bool
+	list      bool
+	skipRules []string
 }
 
 func Lint() *cobra.Command {
@@ -30,6 +31,7 @@ func Lint() *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&o.verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVarP(&o.list, "list", "l", false, "prints the all of available rules and exits")
+	cmd.Flags().StringArrayVarP(&o.skipRules, "skip-rule", "", []string{}, "list of rules to skip")
 	return cmd
 }
 
@@ -63,5 +65,6 @@ func (o lintOptions) makeLintOptions() []lint.Option {
 	return []lint.Option{
 		lint.WithPath(o.args[0]),
 		lint.WithVerbose(o.verbose),
+		lint.WithSkipRules(o.skipRules),
 	}
 }

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -68,6 +70,14 @@ func (l *Linter) Lint() (Result, error) {
 			if !shouldEvaluate {
 				if l.options.Verbose {
 					l.logger.Printf("%s: skipping rule %s because condition is not met\n", name, rule.Name)
+				}
+				continue
+			}
+
+			// Allow users to override rules when running lint command
+			if slices.Contains(l.options.SkipRules, rule.Name) {
+				if l.options.Verbose {
+					l.logger.Printf("%s: skipping rule %s because --skip-rule flag set\n", name, rule.Name)
 				}
 				continue
 			}

--- a/pkg/lint/options.go
+++ b/pkg/lint/options.go
@@ -7,6 +7,9 @@ type Options struct {
 
 	// Verbose prints the details of the linting errors.
 	Verbose bool
+
+	// Skip rules removes the given slice of rules to be checked
+	SkipRules []string
 }
 
 // Option represents a linter option.
@@ -23,5 +26,12 @@ func WithPath(path string) Option {
 func WithVerbose(verbose bool) Option {
 	return func(o *Options) {
 		o.Verbose = verbose
+	}
+}
+
+// WithSkipRules sets the skip rules option.
+func WithSkipRules(skipRules []string) Option {
+	return func(o *Options) {
+		o.SkipRules = skipRules
 	}
 }

--- a/pkg/melange/melange.go
+++ b/pkg/melange/melange.go
@@ -68,7 +68,6 @@ func ReadAllPackagesFromRepo(dir string) (map[string]Packages, error) {
 
 	var fileList []string
 	err := filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
-
 		if filepath.Ext(path) == ".yaml" {
 			fileList = append(fileList, path)
 		}

--- a/pkg/melange/melange.go
+++ b/pkg/melange/melange.go
@@ -68,6 +68,7 @@ func ReadAllPackagesFromRepo(dir string) (map[string]Packages, error) {
 
 	var fileList []string
 	err := filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
+
 		if filepath.Ext(path) == ".yaml" {
 			fileList = append(fileList, path)
 		}
@@ -85,7 +86,8 @@ func ReadAllPackagesFromRepo(dir string) (map[string]Packages, error) {
 		check := &ConfigCheck{}
 		err = yaml.Unmarshal(data, check)
 		if err != nil {
-			return p, errors.Wrapf(err, "failed to unmarshal file when checking if a melange config %s", fi)
+			// we need certain keys to unmarshal so we can identify this as a melange config, if there's no package name and version assume it is not a melange config
+			continue
 		}
 
 		// skip if this file is not a melange config


### PR DESCRIPTION
This also contains a fix to not be so strict when checking if a yaml file is indeed a melange config.  We are seeing linting being applied to files that are not melange configs, this assumes a bare minimum that package name and package version are set, to indicate a yaml file should be linted.