### PR TITLE
add option to enable gitsign to sign the commits

### DIFF
--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -19,6 +19,7 @@ type options struct {
 	dryRun                 bool
 	githubReleaseQuery     bool
 	releaseMonitoringQuery bool
+	useGitSign             bool
 }
 
 func Update() *cobra.Command {
@@ -41,6 +42,7 @@ func Update() *cobra.Command {
 	cmd.Flags().StringVar(&o.pullRequestBaseBranch, "pull-request-base-branch", "main", "base branch to create a pull request against")
 	cmd.Flags().StringVar(&o.pullRequestTitle, "pull-request-title", "%s/%s package update", "the title to use when creating a pull request")
 	cmd.Flags().StringVar(&o.dataMapperURL, "data-mapper-url", "https://raw.githubusercontent.com/wolfi-dev/wolfi-update-mapper/main/DATA.md", "URL to use for mapping packages to source update service")
+	cmd.Flags().BoolVar(&o.useGitSign, "use-gitsign", false, "enable gitsign to sign the git commits")
 
 	cmd.AddCommand(
 		Package(),
@@ -67,6 +69,7 @@ func (o options) UpdateCmd(ctx context.Context, repoURI string) error {
 	updateContext.PullRequestTitle = o.pullRequestTitle
 	updateContext.ReleaseMonitoringQuery = o.releaseMonitoringQuery
 	updateContext.GithubReleaseQuery = o.githubReleaseQuery
+	updateContext.UseGitSign = o.useGitSign
 
 	if err := updateContext.Update(); err != nil {
 		return fmt.Errorf("creating updates: %w", err)

--- a/pkg/cli/update_package.go
+++ b/pkg/cli/update_package.go
@@ -33,6 +33,7 @@ func Package() *cobra.Command {
 	cmd.Flags().StringVar(&o.TargetRepo, "target-repo", "https://github.com/wolfi-dev/os", "target git repository containing melange configuration to update")
 	cmd.Flags().StringVar(&o.Version, "version", "", "version to bump melange package to")
 	cmd.Flags().StringVar(&o.Epoch, "epoch", "0", "the epoch used to identify fix, defaults to 0 as this command is expected to run in a release pipeline that's creating a new version so epoch will be 0")
+	cmd.Flags().BoolVar(&o.UseGitSign, "use-gitsign", false, "enable gitsign to sign the git commits")
 
 	return cmd
 }


### PR DESCRIPTION
- add option to enable gitsign to sign the commits

this will enable us to sign the commits using gitsign
related to https://github.com/wolfi-dev/tools/pull/7

tested locally 

```shell
$ /Users/cpanato/code/src/github.com/wolfi-dev/wolfictl/wolfictl update package grafana --version v0.0.4 --target-repo https://github.com/cpanato/enterprise-packages --use-gitsign
Enumerating objects: 50, done.
Counting objects: 100% (50/50), done.
Compressing objects: 100% (44/44), done.
Total 50 (delta 14), reused 29 (delta 3), pack-reused 0
2023/02/15 15:31:39 wolfictl update: no fixes: CVE### comments found from commits between tags v0.0.3 and v0.0.4, skip creating sec fix advisories
2023/02/15 15:31:39 attempting to bump version to 0.0.4
Your browser will now be opened to:
https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&code_challenge=....
tlog entry created with index: 13400910
2023/02/15 15:31:49 wolfictl update: https://github.com/cpanato/enterprise-packages/pull/7
```