### PR TITLE
Only read melange configs in the directory the command is being execu…

### DIFF
--- a/pkg/melange/melange.go
+++ b/pkg/melange/melange.go
@@ -68,6 +68,9 @@ func ReadAllPackagesFromRepo(dir string) (map[string]Packages, error) {
 
 	var fileList []string
 	err := filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
+		if fi.IsDir() && path != dir {
+			return filepath.SkipDir
+		}
 		if filepath.Ext(path) == ".yaml" {
 			fileList = append(fileList, path)
 		}

--- a/pkg/melange/melange_test.go
+++ b/pkg/melange/melange_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 // make sure apko yaml files are skipped and no errors
-func TestMelange_readPackageConfigs(t *testing.T) {
+func TestMelange_readPackageConfigsNotSubFolders(t *testing.T) {
 	packages, err := ReadPackageConfigs([]string{}, filepath.Join("testdata", "melange_dir"))
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(packages))
+	assert.Equal(t, 1, len(packages))
 }


### PR DESCRIPTION
…ted from

This was the original behavoiur but changed in https://github.com/wolfi-dev/wolfictl/pull/31/files to handle sub folders containing melange configs.

We decided not to take this approach and moved the configs out into the root.

Instead if a melange config exists in a sub folder then lint and update commands should run in these specific folders.