### PR TITLE
wolfictl pod: if the initial bucket does not yet exist don't fail when…

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -264,7 +264,7 @@ do
   [ -f start-gsutil-cp ] && break
   sleep $interval
 done
-gsutil -m cp -r "./packages/*" gs://{{.bucket}}`, map[string]string{"bucket": bucket}),
+gsutil -m cp -r "./packages/*" gs://{{.bucket}} || true`, map[string]string{"bucket": bucket}),
 					},
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      "workspace",


### PR DESCRIPTION
… syncing init container, repo will be created later in the process


This is the same approach we take later on in Pod too https://github.com/wolfi-dev/wolfictl/blob/dcc9e27f7a77ce9e916d8b40b1bc0e15c85412a4/pkg/cli/pod.go#L152