### PR TITLE
add lint check for valid versions

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -22,7 +22,13 @@ var (
 	forbiddenKeyrings = []string{
 		"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
 	}
+
+	// versionRegex how to parse versions.
+	// see https://github.com/alpinelinux/apk-tools/blob/50ab589e9a5a84592ee4c0ac5a49506bb6c552fc/src/version.c#
+	versionRegex = regexp.MustCompile(`^([0-9]+)((\.[0-9]+)*)([a-z]?)((_alpha|_beta|_pre|_rc)([0-9]*))?((_cvs|_svn|_git|_hg|_p)([0-9]*))?((-r)([0-9]+))?$`)
 )
+
+func init() { versionRegex.Longest() }
 
 // AllRules is a list of all available rules to evaluate.
 var AllRules = func(l *Linter) Rules {
@@ -182,6 +188,18 @@ var AllRules = func(l *Linter) Rules {
 							return err
 						}
 					}
+				}
+				return nil
+			},
+		},
+		{
+			Name:        "bad-version",
+			Description: "version is malformed",
+			Severity:    SeverityError,
+			LintFunc: func(config build.Configuration) error {
+				version := config.Package.Version
+				if len(versionRegex.FindAllStringSubmatch(version, -1)) == 0 {
+					return fmt.Errorf("invalid version %s, could not parse", version)
 				}
 				return nil
 			},

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -31,7 +31,7 @@ var (
 func init() { versionRegex.Longest() }
 
 // AllRules is a list of all available rules to evaluate.
-var AllRules = func(l *Linter) Rules {
+var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 	return Rules{
 		{
 			Name:        "no-makefile-entry-for-package",

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -126,6 +126,22 @@ func TestLinter_Rules(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			file: "bad-version.yaml",
+			want: EvalResult{
+				File: "bad-version",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "bad-version",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[bad-version]: invalid version 1.0.0rc1, could not parse (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lint/testdata/files/bad-version.yaml
+++ b/pkg/lint/testdata/files/bad-version.yaml
@@ -1,0 +1,15 @@
+package:
+  name: bad-version
+  version: 1.0.0rc1
+  epoch: 0
+  description: "a package with a wrong pipeline fetch uri"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+environment:
+  contents:
+    packages:
+      - foo
+      - bar


### PR DESCRIPTION
This is copied from apko: https://github.com/chainguard-dev/apko/blob/v0.7.0/pkg/apk/impl/version.go#L25-L27, which is itself copied from apk's `version.c`.