### PR TITLE
add `wolfictl make` to execute `make` for us

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -25,6 +25,7 @@ func New() *cobra.Command {
 		cmdPod(),
 		cmdSVG(),
 		cmdText(),
+		cmdMake(),
 	)
 
 	return cmd

--- a/pkg/cli/make.go
+++ b/pkg/cli/make.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"chainguard.dev/apko/pkg/build/types"
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/dag"
+)
+
+func cmdMake() *cobra.Command {
+	var dir, arch string
+	var dryrun bool
+	text := &cobra.Command{
+		Use:   "make",
+		Short: "Run make for all targets in order",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			arch := types.ParseArchitecture(arch).ToAPK()
+
+			g, err := dag.NewGraph(os.DirFS(dir), dir)
+			if err != nil {
+				return err
+			}
+
+			all, err := g.Sorted()
+			if err != nil {
+				return err
+			}
+			reverse(all)
+
+			for _, node := range all {
+				target, err := g.MakeTarget(node, arch)
+				if err != nil {
+					return err
+				}
+				if target == "" { // ignore subpackages
+					continue
+				}
+				if dryrun {
+					fmt.Println(target)
+				} else {
+					if err := exec.Command("sh", "-c", target).Run(); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}
+	text.Flags().StringVarP(&dir, "dir", "d", ".", "directory to search for melange configs")
+	text.Flags().StringVarP(&arch, "arch", "a", "x86_64", "architecture to build for")
+	text.Flags().BoolVar(&dryrun, "dryrun", false, "if true, only print `make` commands")
+	return text
+}


### PR DESCRIPTION
Request for feedback, with some remaining TODOs to fix graph generation to handle `provides:`es.

Anyway, the idea is that `wolfictl make` will generate a DAG of targets and build them in order, invoking `make packages/aarch64/helm-3.11.1-r1.apk`, etc.

This wouldn't let us get rid of the Makefile completely, but it _would_ let us drop the hand-curated list of targets which must be kept in order.