### PR TITLE
support #nolint: to disable rules per-file

### DIFF
--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -82,6 +82,13 @@ func (l *Linter) Lint() (Result, error) {
 				continue
 			}
 
+			if slices.Contains(filesToLint[name].NoLint, rule.Name) {
+				if l.options.Verbose {
+					l.logger.Printf("%s: skipping rule %s because file contains #nolint:%s\n", name, rule.Name, rule.Name)
+				}
+				continue
+			}
+
 			// Evaluate the rule.
 			if err := rule.LintFunc(filesToLint[name].Config); err != nil {
 				msg := fmt.Sprintf("[%s]: %s (%s)", rule.Name, err.Error(), rule.Severity)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLinter_Rules(t *testing.T) {
@@ -142,6 +143,22 @@ func TestLinter_Rules(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			file: "nolint.yaml",
+			want: EvalResult{
+				File: "nolint",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "valid-copyright-header",
+							Severity: SeverityInfo,
+						},
+						Error: fmt.Errorf("[valid-copyright-header]: copyright header is missing (INFO)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -154,14 +171,14 @@ func TestLinter_Rules(t *testing.T) {
 			}
 
 			// Always should be a single element array.
-			assert.Len(t, got, 1)
+			require.Len(t, got, 1)
 
 			g := got[0]
 
 			// Ensure we're testing the right file.
 			assert.Equal(t, tt.want.File, g.File)
 			// Fast-fail if lengths don't match.
-			assert.Len(t, g.Errors, len(tt.want.Errors))
+			require.Len(t, g.Errors, len(tt.want.Errors))
 
 			for i, e := range g.Errors {
 				assert.Equal(t, e.Error, tt.want.Errors[i].Error, "Lint(): Error: got = %v, want %v", e.Error, tt.want.Errors[i].Error)

--- a/pkg/lint/testdata/files/nolint.yaml
+++ b/pkg/lint/testdata/files/nolint.yaml
@@ -1,0 +1,13 @@
+#nolint:bad-version,no-repeated-deps
+package:
+  name: nolint
+  version: 1.0.0rc1
+  epoch: 0
+  description: "a package that fails (but skips) two lint checks, and fails (and doesn't skip) one"
+  # also no copyright
+environment:
+  contents:
+    packages:
+      - foo
+      - bar
+      - foo


### PR DESCRIPTION
Related to #81 I'd like to be able to require a lint check across the repo, but also allow some files to opt out of specific rules.

If a file contains a line that starts with `#nolint:` (no spaces), any lint rules that follow, comma-separated, are ignored (see added test file). Only the first `#nolint:` line is considered.

