### PR TITLE
Don't log existing advisories during discovery

### DIFF
--- a/pkg/advisory/advisory.go
+++ b/pkg/advisory/advisory.go
@@ -165,7 +165,7 @@ func Discover(options DiscoverOptions) error {
 			if exists {
 				// TODO: Should we allow for updating existing advisories if previously read vuln
 				// data has been updated?
-				log.Printf("skipping advisory creation for %s in %q: advisory already exists", vulnID, cfg.Package.Name)
+
 				continue
 			}
 


### PR DESCRIPTION
This is a super minor change — but it makes it a bit easier to tell when a run of `wolfictl advisory discover` has come up with net new vulnerabilities to address, since the only log entries are now for actionable vulns.