### PR TITLE
pod: don't cache APKINDEX when copying to GCS

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -269,7 +269,7 @@ done
 
 # Don't cache the APKINDEX.
 gcloud --quiet storage cp \
-	--cache-control=off \
+	--cache-control=no-store \
 	"./packages/**/APKINDEX.tar.gz" gs://{{.bucket}}/os/{{.arch}}/ || true
 
 # apks will be cached in CDN for an hour by default.


### PR DESCRIPTION
Following on from https://github.com/wolfi-dev/os/pull/866 and https://github.com/wolfi-dev/os/pull/901, this makes the ~same change in our Arm builds.