### PR TITLE
wolfi update: get the git commit associated with a tag when updating …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ replace k8s.io/client-go => k8s.io/client-go v0.25.3
 replace knative.dev/pkg => knative.dev/pkg v0.0.0-20220407210145-4d62e1dbb943
 
 require (
-	chainguard.dev/apko v0.7.3
-	chainguard.dev/melange v0.3.2
+	chainguard.dev/apko v0.7.4-0.20230402102107-ddb6145f674f
+	chainguard.dev/melange v0.3.1-0.20230403130111-a011419f8d35
 	cloud.google.com/go/storage v1.30.1
 	github.com/chainguard-dev/yam v0.0.0-20230116015213-e93efc9df467
 	github.com/charmbracelet/bubbles v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-chainguard.dev/apko v0.7.3 h1:cHv+VXbekKwohuUZeeccD1KKMz37j1eOnkhs1iKbEvI=
-chainguard.dev/apko v0.7.3/go.mod h1:R9gu4cvKCRFAW5jpeLJImszKmHYEbLJSHtCVt8fGZ38=
-chainguard.dev/melange v0.3.2 h1:nnyjmtvbQvGohv0SjwrR1ivAVIVyH8bdZvX+Lvm4PU4=
-chainguard.dev/melange v0.3.2/go.mod h1:ZxYtxXWJOWSUGX1GDX+gJdLa6exOYkoSHKoXvsepX4E=
+chainguard.dev/apko v0.7.4-0.20230402102107-ddb6145f674f h1:1G7WI66PTAxSQWGF53mT5iKTAkoFzPuq3n06JKX0oF8=
+chainguard.dev/apko v0.7.4-0.20230402102107-ddb6145f674f/go.mod h1:R9gu4cvKCRFAW5jpeLJImszKmHYEbLJSHtCVt8fGZ38=
+chainguard.dev/melange v0.3.1-0.20230403130111-a011419f8d35 h1:eaPrV8Yt6hDRf3ZU8yte3l7cX4RMX4vtGbTvhIaD55M=
+chainguard.dev/melange v0.3.1-0.20230403130111-a011419f8d35/go.mod h1:WrKboXhOaS7HusHlCpq/z6nP6uN/+VKdtA9SP+X9hGA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/melange/melange.go
+++ b/pkg/melange/melange.go
@@ -155,7 +155,7 @@ func ReadMelangeConfig(filename string) (build.Configuration, error) {
 	return *packageConfig, err
 }
 
-func Bump(configFile, version string) error {
+func Bump(configFile, version, expectedCommit string) error {
 	ctx, err := renovate.New(renovate.WithConfig(configFile))
 	if err != nil {
 		return err
@@ -163,6 +163,7 @@ func Bump(configFile, version string) error {
 
 	bumpRenovator := bump.New(
 		bump.WithTargetVersion(version),
+		bump.WithExpectedCommit(expectedCommit),
 	)
 
 	if err := ctx.Renovate(bumpRenovator); err != nil {

--- a/pkg/update/package.go
+++ b/pkg/update/package.go
@@ -126,7 +126,10 @@ func (o *PackageOptions) UpdatePackageCmd() error {
 	// update melange configs in our cloned git repository with any new package versions
 	v := strings.TrimPrefix(o.Version, "v")
 
-	errorMessage, err := uo.updateGitPackage(repo, o.PackageName, v, ref)
+	nvr := NewVersionResults{
+		Version: v,
+	}
+	errorMessage, err := uo.updateGitPackage(repo, o.PackageName, nvr, ref)
 	if err != nil {
 		return fmt.Errorf("failed to update package in git repository: %w", err)
 	}

--- a/pkg/update/releaseMonitor.go
+++ b/pkg/update/releaseMonitor.go
@@ -36,8 +36,8 @@ const (
 	releaseMonitorURL = "https://release-monitoring.org/api/v2/versions/?project_id=%d"
 )
 
-func (m MonitorService) getLatestReleaseMonitorVersions(melangePackages map[string]*melange.Packages) (packagesToUpdate, errorMessages map[string]string) {
-	packagesToUpdate = make(map[string]string)
+func (m MonitorService) getLatestReleaseMonitorVersions(melangePackages map[string]*melange.Packages) (packagesToUpdate map[string]NewVersionResults, errorMessages map[string]string) {
+	packagesToUpdate = make(map[string]NewVersionResults)
 	errorMessages = make(map[string]string)
 
 	// iterate packages from the target git repo and check if a new version is available
@@ -91,7 +91,7 @@ func (m MonitorService) getLatestReleaseMonitorVersions(melangePackages map[stri
 				"there is a new stable version available %s, current wolfi version %s, new %s",
 				p.Config.Package.Name, p.Config.Package.Version, latestVersion,
 			)
-			packagesToUpdate[p.Config.Package.Name] = latestVersion
+			packagesToUpdate[p.Config.Package.Name] = NewVersionResults{Version: latestVersionSemver.Original()}
 		}
 	}
 	return packagesToUpdate, errorMessages

--- a/pkg/update/testdata/multiple_repos/graphql_versions_results.json
+++ b/pkg/update/testdata/multiple_repos/graphql_versions_results.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "rjenkins": {
+    "r": {
       "owner": {
         "login": "jenkinsci"
       },
@@ -11,7 +11,10 @@
         "nodes": [
           {
             "tag": {
-              "name": "jenkins-2.397"
+              "name": "jenkins-2.397",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/37ceefe983a32b6e193dda8b43ee67661a881994"
+              }
             },
             "name": "2.397",
             "isPrerelease": false,
@@ -20,7 +23,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.396"
+              "name": "jenkins-2.396",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/5789e5c2303f73f5aa3ae891dc315122b598845a"
+              }
             },
             "name": "2.396",
             "isPrerelease": false,
@@ -29,7 +35,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.387.2-rc"
+              "name": "jenkins-2.387.2-rc",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/6fe70e9212e118415eea77fc2ea2380ded11243d"
+              }
             },
             "name": "2.387.2 RC",
             "isPrerelease": true,
@@ -38,7 +47,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.395"
+              "name": "jenkins-2.395",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/45542cc65b17650942214f4e983ec658172cb16a"
+              }
             },
             "name": "2.395",
             "isPrerelease": false,
@@ -47,7 +59,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.394"
+              "name": "jenkins-2.394",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/2fe98001f3ab22c36fe3911253a1e7be658222c4"
+              }
             },
             "name": "2.394",
             "isPrerelease": false,
@@ -56,7 +71,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.387.1"
+              "name": "jenkins-2.387.1",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/c2f94c98ac9768b1108f3890e80b133c06d31562"
+              }
             },
             "name": "2.387.1",
             "isPrerelease": false,
@@ -65,7 +83,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375.4"
+              "name": "jenkins-2.375.4",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/721f445841ca8c6f29cb314e2dedddf0949461ed"
+              }
             },
             "name": "2.375.4",
             "isPrerelease": false,
@@ -74,7 +95,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.393"
+              "name": "jenkins-2.393",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/9044b4379cd7bbede8dbccc20f15a02eafd7a97e"
+              }
             },
             "name": "2.393",
             "isPrerelease": false,
@@ -83,7 +107,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.392"
+              "name": "jenkins-2.392",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/936e9f83dba2f8ce74c8495b6b1b101282414890"
+              }
             },
             "name": "2.392",
             "isPrerelease": false,
@@ -92,7 +119,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.387.1-rc"
+              "name": "jenkins-2.387.1-rc",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/bf418c7c9f793927861124b011eb9e0002fb018e"
+              }
             },
             "name": "2.387.1 RC",
             "isPrerelease": true,
@@ -101,7 +131,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.391"
+              "name": "jenkins-2.391",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/f8e69628ac8048b6d50f9f111a3b183507b47a12"
+              }
             },
             "name": "2.391",
             "isPrerelease": false,
@@ -110,7 +143,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375.3"
+              "name": "jenkins-2.375.3",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/2caf8dcac49d5e7d67b3f50d780722a67adde107"
+              }
             },
             "name": "2.375.3",
             "isPrerelease": false,
@@ -119,7 +155,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.390"
+              "name": "jenkins-2.390",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/3c46e8665f850ec3cbad6f9d45f5f7e4c7649761"
+              }
             },
             "name": "2.390",
             "isPrerelease": false,
@@ -128,7 +167,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.389"
+              "name": "jenkins-2.389",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/abdae6c27109cfa96c54df89e45783555318761b"
+              }
             },
             "name": "2.389",
             "isPrerelease": false,
@@ -137,7 +179,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.388"
+              "name": "jenkins-2.388",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/b2f4d1111422f70d2307534b288c83b15e8834f7"
+              }
             },
             "name": "2.388",
             "isPrerelease": false,
@@ -146,7 +191,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375.3-rc"
+              "name": "jenkins-2.375.3-rc",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/00973b768ef97c806a57364418332f815485599a"
+              }
             },
             "name": "2.375.3 RC",
             "isPrerelease": true,
@@ -155,7 +203,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.387"
+              "name": "jenkins-2.387",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/8c774b6e633f59bf9c807ebc14d712d5b6629fc8"
+              }
             },
             "name": "2.387",
             "isPrerelease": false,
@@ -164,7 +215,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375.2"
+              "name": "jenkins-2.375.2",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/544889a9617ae58520910989eba56d253d99cbea"
+              }
             },
             "name": "2.375.2",
             "isPrerelease": false,
@@ -173,7 +227,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.386"
+              "name": "jenkins-2.386",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/5cecd13ec34c7a710b782db1a5d9f751d3e1c07c"
+              }
             },
             "name": "2.386",
             "isPrerelease": false,
@@ -182,7 +239,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.385"
+              "name": "jenkins-2.385",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/36457c6d5fdb8c51605e52215511074468cd8abc"
+              }
             },
             "name": "2.385",
             "isPrerelease": false,
@@ -191,7 +251,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.384"
+              "name": "jenkins-2.384",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/ce7e5d70373a36c8d26d4117384a9c5cb57ff1c1"
+              }
             },
             "name": "2.384",
             "isPrerelease": false,
@@ -200,7 +263,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.383"
+              "name": "jenkins-2.383",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/c03ccfd0c3b34b8b9ee4720b92bed121d619610f"
+              }
             },
             "name": "2.383",
             "isPrerelease": false,
@@ -209,7 +275,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375.2-rc"
+              "name": "jenkins-2.375.2-rc",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/9098ec4d3a01c9a3f5490562b1fb4092299551c2"
+              }
             },
             "name": "2.375.2 RC",
             "isPrerelease": true,
@@ -218,7 +287,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.382"
+              "name": "jenkins-2.382",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/bcdb87773db6899adc602f80a3a6a1010d187c62"
+              }
             },
             "name": "2.382",
             "isPrerelease": false,
@@ -227,7 +299,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.381"
+              "name": "jenkins-2.381",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/467d2fd1d8444ce1542c0f3a35353970f5a01a66"
+              }
             },
             "name": "2.381",
             "isPrerelease": false,
@@ -236,7 +311,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375.1"
+              "name": "jenkins-2.375.1",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/6412c44cbf23a51dca952a19a2d1ced7b291e680"
+              }
             },
             "name": "2.375.1",
             "isPrerelease": false,
@@ -245,7 +323,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.380"
+              "name": "jenkins-2.380",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/d34df8b5e5f885443d83af6e263afe3ae5cb1eb3"
+              }
             },
             "name": "2.380",
             "isPrerelease": false,
@@ -254,7 +335,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.379"
+              "name": "jenkins-2.379",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/d8da52694f9e52d6dca3820409fc99585c722abd"
+              }
             },
             "name": "2.379",
             "isPrerelease": false,
@@ -263,7 +347,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.378"
+              "name": "jenkins-2.378",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/124d4b73fc983ece9b8fc43830abcf958befddcf"
+              }
             },
             "name": "2.378",
             "isPrerelease": false,
@@ -272,7 +359,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.361.4"
+              "name": "jenkins-2.361.4",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/6e53e71a1358372a46c9b78e453802ceee1c73c5"
+              }
             },
             "name": "2.361.4",
             "isPrerelease": false,
@@ -281,7 +371,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375.1-rc"
+              "name": "jenkins-2.375.1-rc",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/c76c5e60b0090613da6f34efff1533e38762b92a"
+              }
             },
             "name": "2.375.1 RC",
             "isPrerelease": true,
@@ -290,7 +383,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.377"
+              "name": "jenkins-2.377",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/168e1ddef32fc4d5d4d61d3d96bb178acfd271e0"
+              }
             },
             "name": "2.377",
             "isPrerelease": false,
@@ -299,7 +395,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.361.3"
+              "name": "jenkins-2.361.3",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/07d79f0c7a68e99c77401fc208859fafc7d40f22"
+              }
             },
             "name": "2.361.3",
             "isPrerelease": false,
@@ -308,7 +407,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.376"
+              "name": "jenkins-2.376",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/c641f666b37977f3db6eb32198f4278393bd17dc"
+              }
             },
             "name": "2.376",
             "isPrerelease": false,
@@ -317,7 +419,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.375"
+              "name": "jenkins-2.375",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/2a6b4b6821f84f47e98727490fa24754f4ef4287"
+              }
             },
             "name": "2.375",
             "isPrerelease": false,
@@ -326,7 +431,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.374"
+              "name": "jenkins-2.374",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/c447e86314dd623e9e0f3fecc10d7b2585421592"
+              }
             },
             "name": "2.374",
             "isPrerelease": false,
@@ -335,7 +443,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.361.3-rc"
+              "name": "jenkins-2.361.3-rc",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/1c071ea74a386b9eecb68d54c1c71c3c0e1baaf9"
+              }
             },
             "name": "2.361.3 RC",
             "isPrerelease": true,
@@ -344,7 +455,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.373"
+              "name": "jenkins-2.373",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/2188525757084bdcba584f1a473f0484fa82e690"
+              }
             },
             "name": "2.373",
             "isPrerelease": false,
@@ -353,7 +467,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.361.2"
+              "name": "jenkins-2.361.2",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/e3ab2f9465626d6fe5ecc527dd8ca97ee659d1be"
+              }
             },
             "name": "2.361.2",
             "isPrerelease": false,
@@ -362,7 +479,10 @@
           },
           {
             "tag": {
-              "name": "jenkins-2.372"
+              "name": "jenkins-2.372",
+              "target": {
+                "commitUrl": "https://github.com/jenkinsci/jenkins/commit/2a30d71878928322ad827d10015feb69441b4df3"
+              }
             },
             "name": "2.372",
             "isPrerelease": false,
@@ -372,7 +492,7 @@
         ]
       }
     },
-    "rcosign": {
+    "r1": {
       "owner": {
         "login": "sigstore"
       },
@@ -383,7 +503,10 @@
         "nodes": [
           {
             "tag": {
-              "name": "v2.0.0"
+              "name": "v2.0.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/d6b9001f8e6ed745fb845849d623274c897d55f2"
+              }
             },
             "name": "v2.0.0",
             "isPrerelease": false,
@@ -392,7 +515,10 @@
           },
           {
             "tag": {
-              "name": "v2.0.0-rc.3"
+              "name": "v2.0.0-rc.3",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/5d2964c3d7cb33dada6e945aac2c80008780475d"
+              }
             },
             "name": "v2.0.0-rc.3",
             "isPrerelease": true,
@@ -401,7 +527,10 @@
           },
           {
             "tag": {
-              "name": "v2.0.0-rc.2"
+              "name": "v2.0.0-rc.2",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/f708d3900b41ea69c402c545b6526797bd5e8d1c"
+              }
             },
             "name": "v2.0.0-rc.2",
             "isPrerelease": true,
@@ -410,7 +539,10 @@
           },
           {
             "tag": {
-              "name": "v2.0.0-rc.1"
+              "name": "v2.0.0-rc.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/03468a1498876ccfb72e06f63fdb4f1c562dbca1"
+              }
             },
             "name": "v2.0.0-rc.1",
             "isPrerelease": true,
@@ -419,7 +551,10 @@
           },
           {
             "tag": {
-              "name": "v2.0.0-rc.0"
+              "name": "v2.0.0-rc.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/a827922053c48283fb458b7b6bc51be3f477ec4d"
+              }
             },
             "name": "v2.0.0-rc.0",
             "isPrerelease": true,
@@ -428,7 +563,10 @@
           },
           {
             "tag": {
-              "name": "v1.13.1"
+              "name": "v1.13.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/d1c6336475b4be26bb7fb52d97f56ea0a1767f9f"
+              }
             },
             "name": "v1.13.1",
             "isPrerelease": false,
@@ -437,7 +575,10 @@
           },
           {
             "tag": {
-              "name": "v1.13.0"
+              "name": "v1.13.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/6b9820a68e861c91d07b1d0414d150411b60111f"
+              }
             },
             "name": "v1.13.0",
             "isPrerelease": false,
@@ -446,7 +587,10 @@
           },
           {
             "tag": {
-              "name": "v1.12.1"
+              "name": "v1.12.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/0baa044bea61e7c16d56023be20ead3d9204b24a"
+              }
             },
             "name": "v1.12.1",
             "isPrerelease": false,
@@ -455,7 +599,10 @@
           },
           {
             "tag": {
-              "name": "v1.12.0"
+              "name": "v1.12.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/8483d6c71f153f38f237ba79c88d0fda6306e6e3"
+              }
             },
             "name": "v1.12.0",
             "isPrerelease": false,
@@ -464,7 +611,10 @@
           },
           {
             "tag": {
-              "name": "v1.11.1"
+              "name": "v1.11.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/b3b6ae25362dc2c92c78abf2370ba0342ee86b2f"
+              }
             },
             "name": "v1.11.1",
             "isPrerelease": false,
@@ -473,7 +623,10 @@
           },
           {
             "tag": {
-              "name": "v1.11.0"
+              "name": "v1.11.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/6bfac1a470492d8964778b1b8c41e0056bf5dbdd"
+              }
             },
             "name": "v1.11.0",
             "isPrerelease": false,
@@ -482,7 +635,10 @@
           },
           {
             "tag": {
-              "name": "v1.10.1"
+              "name": "v1.10.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/a39ce91fadc582e0efce3321744a79ccd3c8b39c"
+              }
             },
             "name": "v1.10.1",
             "isPrerelease": false,
@@ -491,7 +647,10 @@
           },
           {
             "tag": {
-              "name": "v1.10.0"
+              "name": "v1.10.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/3a6088d03d7c053f9b3bd61ed07fba92133579cf"
+              }
             },
             "name": "v1.10.0",
             "isPrerelease": false,
@@ -500,7 +659,10 @@
           },
           {
             "tag": {
-              "name": "v1.10.0-rc.1"
+              "name": "v1.10.0-rc.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/6a902ec76ff82c0e562875a997096bf0dab9088a"
+              }
             },
             "name": "v1.10.0-rc.1",
             "isPrerelease": true,
@@ -509,7 +671,10 @@
           },
           {
             "tag": {
-              "name": "v1.9.0"
+              "name": "v1.9.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/a4cb262dc3d45a283a6a7513bb767a38a2d3f448"
+              }
             },
             "name": "v1.9.0",
             "isPrerelease": false,
@@ -518,7 +683,10 @@
           },
           {
             "tag": {
-              "name": "v1.8.0"
+              "name": "v1.8.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/9ef6b207218572b3257a5b4251418d75569baaae"
+              }
             },
             "name": "v1.8.0",
             "isPrerelease": false,
@@ -527,7 +695,10 @@
           },
           {
             "tag": {
-              "name": "v1.7.2"
+              "name": "v1.7.2",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/1b1bca3280994eebe38d35e03bbd66af6214f0f1"
+              }
             },
             "name": "v1.7.2",
             "isPrerelease": false,
@@ -536,7 +707,10 @@
           },
           {
             "tag": {
-              "name": "v1.7.1"
+              "name": "v1.7.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/53c28e44f10548c8839d4c72e5909fa74e08b5f6"
+              }
             },
             "name": "v1.7.1",
             "isPrerelease": false,
@@ -545,7 +719,10 @@
           },
           {
             "tag": {
-              "name": "v1.6.0"
+              "name": "v1.6.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/4b2c3c0c8ee97f31b9dac3859b40e0a48b8648ee"
+              }
             },
             "name": "v1.6.0",
             "isPrerelease": false,
@@ -554,7 +731,10 @@
           },
           {
             "tag": {
-              "name": "v1.5.2"
+              "name": "v1.5.2",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/8ffcd1228c463e1ad26ccce68ae16deeca2960b4"
+              }
             },
             "name": "v1.5.2 - CVE-2022-23649",
             "isPrerelease": false,
@@ -563,7 +743,10 @@
           },
           {
             "tag": {
-              "name": "v1.5.1"
+              "name": "v1.5.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/c3e4d8b7cd2f6f065941510b260f173b70c695fa"
+              }
             },
             "name": "v1.5.1",
             "isPrerelease": false,
@@ -572,7 +755,10 @@
           },
           {
             "tag": {
-              "name": "v1.5.0"
+              "name": "v1.5.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/757252063bf4724f11a52336ef13a724059a39b6"
+              }
             },
             "name": "v1.5.0",
             "isPrerelease": false,
@@ -581,7 +767,10 @@
           },
           {
             "tag": {
-              "name": "v1.4.1"
+              "name": "v1.4.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/934567a4c606cf59e6ab17af889b4db3ee0a3f0b"
+              }
             },
             "name": "v1.4.1",
             "isPrerelease": false,
@@ -590,7 +779,10 @@
           },
           {
             "tag": {
-              "name": "v1.4.0"
+              "name": "v1.4.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/50315fcc82a3d07d6983515bbfa0f2a6c39f7c31"
+              }
             },
             "name": "v1.4.0",
             "isPrerelease": false,
@@ -599,7 +791,10 @@
           },
           {
             "tag": {
-              "name": "v1.3.1"
+              "name": "v1.3.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/645ebf09fc555762a0494baa30edc08c38435368"
+              }
             },
             "name": "v1.3.1",
             "isPrerelease": false,
@@ -608,7 +803,10 @@
           },
           {
             "tag": {
-              "name": "v1.3.0"
+              "name": "v1.3.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/a91aa202a01b830dafa969bb46f168e9c44580bd"
+              }
             },
             "name": "v1.3.0",
             "isPrerelease": false,
@@ -617,7 +815,10 @@
           },
           {
             "tag": {
-              "name": "v1.2.1"
+              "name": "v1.2.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/96d39a9f1d1861657c6d89aed9aa1903b42ea2f2"
+              }
             },
             "name": "v1.2.1",
             "isPrerelease": false,
@@ -626,7 +827,10 @@
           },
           {
             "tag": {
-              "name": "v1.2.0"
+              "name": "v1.2.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/aa5d23b86d09c2275dd3a7317b7c98cc30a8eee7"
+              }
             },
             "name": "v1.2.0",
             "isPrerelease": false,
@@ -635,7 +839,10 @@
           },
           {
             "tag": {
-              "name": "cosigned-v0.0.3-dev"
+              "name": "cosigned-v0.0.3-dev",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/36fa588ceb589d192753364e77756fb1431e8267"
+              }
             },
             "name": "cosigned-v0.0.3-dev",
             "isPrerelease": true,
@@ -644,7 +851,10 @@
           },
           {
             "tag": {
-              "name": "cosigned-v0.0.2-dev"
+              "name": "cosigned-v0.0.2-dev",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/fe21c9f008f83af7ce4cef26670faa930a2daeb3"
+              }
             },
             "name": "cosigned-v0.0.2-dev",
             "isPrerelease": true,
@@ -653,7 +863,10 @@
           },
           {
             "tag": {
-              "name": "cosigned-v0.0.1-dev"
+              "name": "cosigned-v0.0.1-dev",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/30fa296b85bad44c8f84a04fdd29b770b02d733b"
+              }
             },
             "name": "cosigned-v0.0.1-dev",
             "isPrerelease": true,
@@ -662,7 +875,10 @@
           },
           {
             "tag": {
-              "name": "v1.1.0"
+              "name": "v1.1.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/67934a685ddc83aa7b0b8a55c911e299117afac5"
+              }
             },
             "name": "v1.1.0",
             "isPrerelease": false,
@@ -671,7 +887,10 @@
           },
           {
             "tag": {
-              "name": "v1.0.0"
+              "name": "v1.0.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/33973d078170f586cf27f2cc464844b3f1fa1abb"
+              }
             },
             "name": "v1.0.0",
             "isPrerelease": false,
@@ -680,7 +899,10 @@
           },
           {
             "tag": {
-              "name": "v0.6.0"
+              "name": "v0.6.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/bbaca4429c11981c877cf279fb3dc740c54903b8"
+              }
             },
             "name": "v0.6.0",
             "isPrerelease": true,
@@ -689,7 +911,10 @@
           },
           {
             "tag": {
-              "name": "v0.5.0"
+              "name": "v0.5.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/5cb21aa7fbf9ef25dbb8179785a05d695e4cef2c"
+              }
             },
             "name": "v0.5.0",
             "isPrerelease": true,
@@ -698,7 +923,10 @@
           },
           {
             "tag": {
-              "name": "v0.4.0"
+              "name": "v0.4.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/2e1191e354cf905b335439916dc8116c3bc362f9"
+              }
             },
             "name": "v0.4.0",
             "isPrerelease": true,
@@ -707,7 +935,10 @@
           },
           {
             "tag": {
-              "name": "v0.3.1"
+              "name": "v0.3.1",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/76fde761a4e016c57293113ee1362f1c24a647cb"
+              }
             },
             "name": "v0.3.1",
             "isPrerelease": true,
@@ -716,7 +947,10 @@
           },
           {
             "tag": {
-              "name": "v0.3.0"
+              "name": "v0.3.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/5f83dcdcbff7f3bfc18981eee1557dc068ccea06"
+              }
             },
             "name": "v0.3.0",
             "isPrerelease": true,
@@ -725,7 +959,10 @@
           },
           {
             "tag": {
-              "name": "v0.2.0"
+              "name": "v0.2.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/64057e11c7cc287c094e879f470769e2bc662f98"
+              }
             },
             "name": "v0.2.0 Release",
             "isPrerelease": true,
@@ -734,7 +971,10 @@
           },
           {
             "tag": {
-              "name": "v0.1.0"
+              "name": "v0.1.0",
+              "target": {
+                "commitUrl": "https://github.com/sigstore/cosign/commit/083406c6e85284ded34af96048361d1e8c887e50"
+              }
             },
             "name": "v0.1.0",
             "isPrerelease": true,

--- a/pkg/update/testdata/parse_go_tags/graphql_versions_results.json
+++ b/pkg/update/testdata/parse_go_tags/graphql_versions_results.json
@@ -1,350 +1,75 @@
 {
   "data": {
-    "repo_0": {
+    "r": {
       "nameWithOwner": "golang/go",
       "refs": {
         "totalCount": 11,
         "nodes": [
           {
-            "name": "go1.19.7"
+            "name": "go1.19.7",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/7bd22aafe41be40e2174335a3dc55431ca9548ec"
+            }
           },
           {
-            "name": "go1.19.6"
+            "name": "go1.19.6",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/8656c03fee94ce9cdc4da120b831c2fb9fd68d9d"
+            }
           },
           {
-            "name": "go1.19.5"
+            "name": "go1.19.5",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/1e9ff255a130200fcc4ec5e911d28181fce947d5"
+            }
           },
           {
-            "name": "go1.19.4"
+            "name": "go1.19.4",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/dc04f3ba1f25313bc9c97e728620206c235db9ee"
+            }
           },
           {
-            "name": "go1.19.3"
+            "name": "go1.19.3",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/5d5ed57b134b7a02259ff070864f753c9e601a18"
+            }
           },
           {
-            "name": "go1.19.2"
+            "name": "go1.19.2",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/895664482c0ebe5cec4a6935615a1e9610bbf1e3"
+            }
           },
           {
-            "name": "go1.19.1"
+            "name": "go1.19.1",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/4a4127bccc826ebb6079af3252bc6bfeaec187c4"
+            }
           },
           {
-            "name": "go1.19"
+            "name": "go1.19",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/43456202a1e55da55666fac9d56ace7654a65b64"
+            }
           },
           {
-            "name": "go1.19rc2"
+            "name": "go1.19rc2",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/ad672e7ce101cc52e38bae3d7484e4660a20d575"
+            }
           },
           {
-            "name": "go1.19rc1"
+            "name": "go1.19rc1",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/bac4eb53d64ee402af1d52ac18fb9f0ea76c74e2"
+            }
           },
           {
-            "name": "go1.19beta1"
-          }
-        ]
-      }
-    },
-    "repo_1": {
-      "nameWithOwner": "openjdk/jdk11u",
-      "refs": {
-        "totalCount": 100,
-        "nodes": [
-          {
-            "name": "jdk-11.0.19+5"
-          },
-          {
-            "name": "jdk-11.0.19+4"
-          },
-          {
-            "name": "jdk-11.0.19+3"
-          },
-          {
-            "name": "jdk-11.0.19+2"
-          },
-          {
-            "name": "jdk-11.0.19+1"
-          },
-          {
-            "name": "jdk-11.0.18+10"
-          },
-          {
-            "name": "jdk-11.0.18-ga"
-          },
-          {
-            "name": "jdk-11.0.18+9"
-          },
-          {
-            "name": "jdk-11.0.18+8"
-          },
-          {
-            "name": "jdk-11.0.18+7"
-          },
-          {
-            "name": "jdk-11.0.19+0"
-          },
-          {
-            "name": "jdk-11.0.18+6"
-          },
-          {
-            "name": "jdk-11.0.18+5"
-          },
-          {
-            "name": "jdk-11.0.18+4"
-          },
-          {
-            "name": "jdk-11.0.18+3"
-          },
-          {
-            "name": "jdk-11.0.18+2"
-          },
-          {
-            "name": "jdk-11.0.18+1"
-          },
-          {
-            "name": "jdk-11.0.17+8"
-          },
-          {
-            "name": "jdk-11.0.17-ga"
-          },
-          {
-            "name": "jdk-11.0.17+7"
-          },
-          {
-            "name": "jdk-11.0.17+6"
-          },
-          {
-            "name": "jdk-11.0.18+0"
-          },
-          {
-            "name": "jdk-11.0.17+5"
-          },
-          {
-            "name": "jdk-11.0.17+4"
-          },
-          {
-            "name": "jdk-11.0.17+3"
-          },
-          {
-            "name": "jdk-11.0.16.1+1"
-          },
-          {
-            "name": "jdk-11.0.16.1+0"
-          },
-          {
-            "name": "jdk-11.0.16.1-ga"
-          },
-          {
-            "name": "jdk-11.0.17+2"
-          },
-          {
-            "name": "jdk-11.0.17+1"
-          },
-          {
-            "name": "jdk-11.0.16+8"
-          },
-          {
-            "name": "jdk-11.0.16-ga"
-          },
-          {
-            "name": "jdk-11.0.16+7"
-          },
-          {
-            "name": "jdk-11.0.16+6"
-          },
-          {
-            "name": "jdk-11.0.17+0"
-          },
-          {
-            "name": "jdk-11.0.16+5"
-          },
-          {
-            "name": "jdk-11.0.16+4"
-          },
-          {
-            "name": "jdk-11.0.16+3"
-          },
-          {
-            "name": "jdk-11.0.16+2"
-          },
-          {
-            "name": "jdk-11.0.16+1"
-          },
-          {
-            "name": "jdk-11.0.15+10"
-          },
-          {
-            "name": "jdk-11.0.15-ga"
-          },
-          {
-            "name": "jdk-11.0.15+9"
-          },
-          {
-            "name": "jdk-11.0.15+8"
-          },
-          {
-            "name": "jdk-11.0.15+7"
-          },
-          {
-            "name": "jdk-11.0.15+6"
-          },
-          {
-            "name": "jdk-11.0.15+5"
-          },
-          {
-            "name": "jdk-11.0.16+0"
-          },
-          {
-            "name": "jdk-11.0.15+4"
-          },
-          {
-            "name": "jdk-11.0.15+3"
-          },
-          {
-            "name": "jdk-11.0.15+2"
-          },
-          {
-            "name": "jdk-11.0.15+1"
-          },
-          {
-            "name": "jdk-11.0.14.1+1"
-          },
-          {
-            "name": "jdk-11.0.14.1+0"
-          },
-          {
-            "name": "jdk-11.0.14.1-ga"
-          },
-          {
-            "name": "jdk-11.0.14+9"
-          },
-          {
-            "name": "jdk-11.0.14-ga"
-          },
-          {
-            "name": "jdk-11.0.14+8"
-          },
-          {
-            "name": "jdk-11.0.14+7"
-          },
-          {
-            "name": "jdk-11.0.14+6"
-          },
-          {
-            "name": "jdk-11.0.15+0"
-          },
-          {
-            "name": "jdk-11.0.14+5"
-          },
-          {
-            "name": "jdk-11.0.14+4"
-          },
-          {
-            "name": "jdk-11.0.14+3"
-          },
-          {
-            "name": "jdk-11.0.14+2"
-          },
-          {
-            "name": "jdk-11.0.14+1"
-          },
-          {
-            "name": "jdk-11.0.13+8"
-          },
-          {
-            "name": "jdk-11.0.13-ga"
-          },
-          {
-            "name": "jdk-11.0.13+7"
-          },
-          {
-            "name": "jdk-11.0.13+6"
-          },
-          {
-            "name": "jdk-11.0.14+0"
-          },
-          {
-            "name": "jdk-11.0.13+5"
-          },
-          {
-            "name": "jdk-11.0.13+4"
-          },
-          {
-            "name": "jdk-11.0.13+3"
-          },
-          {
-            "name": "jdk-11.0.13+2"
-          },
-          {
-            "name": "jdk-11.0.13+1"
-          },
-          {
-            "name": "jdk-11.0.12+7"
-          },
-          {
-            "name": "jdk-11.0.12-ga"
-          },
-          {
-            "name": "jdk-11.0.12+6"
-          },
-          {
-            "name": "jdk-11.0.13+0"
-          },
-          {
-            "name": "jdk-11.0.12+5"
-          },
-          {
-            "name": "jdk-11.0.12+4"
-          },
-          {
-            "name": "jdk-11.0.12+3"
-          },
-          {
-            "name": "jdk-11.0.12+2"
-          },
-          {
-            "name": "jdk-11.0.12+1"
-          },
-          {
-            "name": "jdk-11.0.11+9"
-          },
-          {
-            "name": "jdk-11.0.11-ga"
-          },
-          {
-            "name": "jdk-11.0.11+8"
-          },
-          {
-            "name": "jdk-11.0.11+7"
-          },
-          {
-            "name": "jdk-11.0.11+6"
-          },
-          {
-            "name": "jdk-11.0.12+0"
-          },
-          {
-            "name": "jdk-11.0.11+5"
-          },
-          {
-            "name": "jdk-11.0.11+4"
-          },
-          {
-            "name": "jdk-11.0.11+3"
-          },
-          {
-            "name": "jdk-11.0.11+2"
-          },
-          {
-            "name": "jdk-11.0.11+1"
-          },
-          {
-            "name": "jdk-11.0.10-ga"
-          },
-          {
-            "name": "jdk-11.0.10+9"
-          },
-          {
-            "name": "jdk-11.0.10+8"
-          },
-          {
-            "name": "jdk-11.0.10+7"
+            "name": "go1.19beta1",
+            "target": {
+              "commitUrl": "https://github.com/golang/go/commit/2cfbef438049fd4c3f73d1562773ad1f93900897"
+            }
           }
         ]
       }

--- a/pkg/update/testdata/parse_java_tags/graphql_versions_results.json
+++ b/pkg/update/testdata/parse_java_tags/graphql_versions_results.json
@@ -1,74 +1,603 @@
 {
   "data": {
-    "repo_0": {
-      "nameWithOwner": "golang/go",
-      "refs": {
-        "totalCount": 11,
-        "nodes": [
-          {
-            "name": "go1.19.7"
-          },
-          {
-            "name": "go1.19.6"
-          },
-          {
-            "name": "go1.19.5"
-          },
-          {
-            "name": "go1.19.4"
-          },
-          {
-            "name": "go1.19.3"
-          },
-          {
-            "name": "go1.19.2"
-          },
-          {
-            "name": "go1.19.1"
-          },
-          {
-            "name": "go1.19"
-          },
-          {
-            "name": "go1.19rc2"
-          },
-          {
-            "name": "go1.19rc1"
-          },
-          {
-            "name": "go1.19beta1"
-          }
-        ]
-      }
-    },
-    "repo_1": {
+    "r": {
       "nameWithOwner": "openjdk/jdk11u",
       "refs": {
         "totalCount": 100,
         "nodes": [
           {
-            "name": "jdk-11.0.19+5"
+            "name": "jdk-11.0.19+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/8a726afcdf653bf3fe7ba6ed3419732edf625b11"
+            }
           },
           {
-            "name": "jdk-11.0.19+4"
+            "name": "jdk-11.0.19+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/5802a9a92604585d5cb7ff03a26926486a50e1e8"
+            }
           },
           {
-            "name": "jdk-11.0.19+3"
+            "name": "jdk-11.0.19+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/bc29f1eb26714ef4a4f1494d9e9cd8aaf9050d7d"
+            }
           },
           {
-            "name": "jdk-11.0.19+2"
+            "name": "jdk-11.0.19+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/c58a06666d93d7c339f9ce3133555083f30ca0e5"
+            }
           },
           {
-            "name": "jdk-11.0.19+1"
+            "name": "jdk-11.0.19+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/ebac392d65ab085369ae1b33cc7601d574778d0f"
+            }
           },
           {
-            "name": "jdk-11.0.18+10"
+            "name": "jdk-11.0.18+10",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/50b3039415616831fdd96c36df0a42f00fea60ea"
+            }
           },
           {
-            "name": "jdk-11.0.18-ga"
+            "name": "jdk-11.0.18-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/50b3039415616831fdd96c36df0a42f00fea60ea"
+            }
           },
           {
-            "name": "jdk-11.0.18+9"
+            "name": "jdk-11.0.18+9",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/445ab521954ba92a0d7435b811bd38ccfccb5b95"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/88954e1e812296abb4e876ed1f37cd6458d00c89"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/6400cdc724f5ffeb03dec742494590a301cb3417"
+            }
+          },
+          {
+            "name": "jdk-11.0.19+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/87c8450c3e776f6b5ad6c01c5cdc5a157c9e84cb"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/87c8450c3e776f6b5ad6c01c5cdc5a157c9e84cb"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b5555c191537c27e6b7dcf7ac15c4dfe2967688e"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/18055b84a4e6d7e9136fd7b02ba68579c4812880"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b7b00f7fb4e6509becdfdb28eb1a336a7b07b315"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/dde20e471dd77528baa922dde484e9ea92c005aa"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b928a88fd564fab88f00086a62c0695ed5cc9353"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/69ce82b96fceb82c0363d0b33b977111685d516a"
+            }
+          },
+          {
+            "name": "jdk-11.0.17-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/69ce82b96fceb82c0363d0b33b977111685d516a"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/2f695bbaad2620507e8427610ae988332aaa001c"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/e9ba915905afa1535e288802765f59b52538f73c"
+            }
+          },
+          {
+            "name": "jdk-11.0.18+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/2f0f34ce4cbe0f51a1bcc3145eb4d7ade9287d5d"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/2f0f34ce4cbe0f51a1bcc3145eb4d7ade9287d5d"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/75e4cb38910948634b816e4f4db36b8525d232c8"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/faf1f86f95117a5e2a0d52b67647dee893311545"
+            }
+          },
+          {
+            "name": "jdk-11.0.16.1+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/63e4b5c8acdb678f17541b755205e0e4feb5809c"
+            }
+          },
+          {
+            "name": "jdk-11.0.16.1+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/edd32ef60b3e3c5002505c4fcf88d6c81e94d355"
+            }
+          },
+          {
+            "name": "jdk-11.0.16.1-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/63e4b5c8acdb678f17541b755205e0e4feb5809c"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/74daa996b5212deddc19c806b07f7f1f924ce1e6"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/954d57ae503e5e25c263d662a8e2eba978bd62b2"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/edd32ef60b3e3c5002505c4fcf88d6c81e94d355"
+            }
+          },
+          {
+            "name": "jdk-11.0.16-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/edd32ef60b3e3c5002505c4fcf88d6c81e94d355"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/1dd942d3541431b21403f39b4cc5943271b59801"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/e996d6fe056e9dfce6928c6ab950421125da7234"
+            }
+          },
+          {
+            "name": "jdk-11.0.17+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/c95c7967bbd1004f23250f8898c7246420da9e83"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/1c93a6e011588ef3c491768d156552681f2480c4"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b2c51c4daa4ef7d57ffeda8f7a5126e5ce4ac70d"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/0056b9b4f91ed9132364984fb45e1ce1ad563af4"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/c95c7967bbd1004f23250f8898c7246420da9e83"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/87e0662a7336cbdb3de30a0c597f1588b44483e9"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+10",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/224e1a3fcb2c9c43e97e7b0e69d7aad66560f6fc"
+            }
+          },
+          {
+            "name": "jdk-11.0.15-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/224e1a3fcb2c9c43e97e7b0e69d7aad66560f6fc"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+9",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/91d65505f779887e9c79d6e7181cd2a81f1ea118"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/487c3344fee3502b4843e7e11acceb77ad16100c"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/9a7bd43d277135ac2bbb9c8289430b9f8dd5af3d"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/f7346f087a14f1878029a00104005e04468d333f"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/1cff5631dcd0a122715a06be38894cd7bff2bcec"
+            }
+          },
+          {
+            "name": "jdk-11.0.16+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/5cad68f586b1d75403ba7339828221ff6f167c53"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/5cad68f586b1d75403ba7339828221ff6f167c53"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/26e599dce20b0ba21273df30ad3cc7242c67a98f"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/eb0708f75aa3c196e41014addfaa5667fd940cc2"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/288c9f7d6ac6057216d3c7756ea667cfb65fc6a3"
+            }
+          },
+          {
+            "name": "jdk-11.0.14.1+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b8cdf1ae18bb8301e289b827751a2e0aa9f3f50b"
+            }
+          },
+          {
+            "name": "jdk-11.0.14.1+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/1453335629e17be9a3b8718ad0c326f26cc68cd7"
+            }
+          },
+          {
+            "name": "jdk-11.0.14.1-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b8cdf1ae18bb8301e289b827751a2e0aa9f3f50b"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+9",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/1453335629e17be9a3b8718ad0c326f26cc68cd7"
+            }
+          },
+          {
+            "name": "jdk-11.0.14-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/1453335629e17be9a3b8718ad0c326f26cc68cd7"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/175e23fdf4cb0929ff1cca9538a884ee3833337d"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/d665a4ec39523630af6f30ad7d732053bb62559e"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/f5664eafd58bb779431f1df1e03cd8e9270f24c1"
+            }
+          },
+          {
+            "name": "jdk-11.0.15+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/22186cb1fe22b4b30fc72c67ce9946cd4f03199d"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/22186cb1fe22b4b30fc72c67ce9946cd4f03199d"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/dcc010d7c84195cdec0844d0e497e57dbc173743"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/3593e1eac182e7ed25a9c5533fd92d37013a1811"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/c406da13284934c11f04146daa9ebc960d0f5f4f"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/36e54fbd936cebfa8e66483d0daa4d22dcc3100a"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/71f2c75111e87091616f0f3b86bea6c4d345dad1"
+            }
+          },
+          {
+            "name": "jdk-11.0.13-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/71f2c75111e87091616f0f3b86bea6c4d345dad1"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/c9c728849c137e21535cc402664dd54ee421b0d3"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/f336c729e35b6793d0910beec167b2c739ec95e7"
+            }
+          },
+          {
+            "name": "jdk-11.0.14+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/63fc945c1d4cdc893d89796804acfe0ce9341860"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/63fc945c1d4cdc893d89796804acfe0ce9341860"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/c55b1e5c064f9929e9bc1c2610a6b1431cd437c5"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/3a32efcd73fb33243bcf6598907b773080be926c"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/5f9429b58f68a2d71b3dae96e15353b780c745a3"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/815d3e1c6cd8272f962eaec80758cafa97c1dda5"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/d1541f3012754e0bbda2524bb865c6a971fc4574"
+            }
+          },
+          {
+            "name": "jdk-11.0.12-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/d1541f3012754e0bbda2524bb865c6a971fc4574"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/bb5b2cb9d3a1cfcd040d295ab6f6b54eaf88483f"
+            }
+          },
+          {
+            "name": "jdk-11.0.13+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/c88fbe60b22a042f3f82089f4a06af390ff571d4"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/e0af8b4a15e271e750596bb8883742dda243b599"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/269b414c31a4ed31fa32f52a5cd89e3bcac35750"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/430d07111fdb0cb9fe4f275f371106a12446474a"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/a8ab8ee610a20a51fee21f2725df0bc9ee190c55"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/d27533f1967411dfd1b50b3fe0f0cebb936f1d3a"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+9",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/96cd8afba66dc13d80b8ebe07df1bd8d8a42660f"
+            }
+          },
+          {
+            "name": "jdk-11.0.11-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/96cd8afba66dc13d80b8ebe07df1bd8d8a42660f"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/78c200a469997b6d8aa7c202d30855104d92068b"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+7",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/d609620d0fc1e68467664e9fd8e15f382fa8697a"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+6",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/d1db307ad5c6ec18f9ed4d4e61411067b1a9a8be"
+            }
+          },
+          {
+            "name": "jdk-11.0.12+0",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/a4f2cc65079328cb428cf0317df39af93472ab1e"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+5",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/520701d4037645083f9721aefc3d3d1cbaf9e791"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+4",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/83efecbcae851da8548107165426e92a5d1a4fab"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+3",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/07c0152fcc4b66418247603cbe34ebdffbf8af67"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+2",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/74ce033c3e3ba9731a2f618394023e42ad186606"
+            }
+          },
+          {
+            "name": "jdk-11.0.11+1",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/92016c1d441170f168ec8fb578f26caa48c98567"
+            }
+          },
+          {
+            "name": "jdk-11.0.10-ga",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b3adcf1ecba07f2d4eff5d463309d52af2be4211"
+            }
+          },
+          {
+            "name": "jdk-11.0.10+9",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/b3adcf1ecba07f2d4eff5d463309d52af2be4211"
+            }
+          },
+          {
+            "name": "jdk-11.0.10+8",
+            "target": {
+              "commitUrl": "https://github.com/openjdk/jdk11u/commit/5a3ad95175d0c383f0be8a07b4065c28dba9e71a"
+            }
           }
         ]
       }

--- a/pkg/update/testdata/query_tags/result
+++ b/pkg/update/testdata/query_tags/result
@@ -6,6 +6,9 @@ query {
       totalCount
       nodes {
         name
+        target {
+          commitUrl
+        }
       }
     }
   }, 
@@ -16,6 +19,9 @@ query {
       totalCount
       nodes {
         name
+        target {
+          commitUrl
+        }
       }
     }
   }

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -56,7 +56,7 @@ func TestMonitorService_updatePackagesGitRepository(t *testing.T) {
 	assert.NoError(t, err)
 
 	// fake a new version available
-	newVersion := map[string]string{"cheese": "1.5.10"}
+	newVersion := map[string]NewVersionResults{"cheese": {Version: "1.5.10"}}
 	errorMessages := make(map[string]string)
 	err = o.updatePackagesGitRepository(r, newVersion)
 	assert.NoError(t, err)


### PR DESCRIPTION
…new versions so we can set expected-commit value in a melange config