### PR TITLE
fix: remove duplicate /os/ from GCS upload location

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -270,11 +270,11 @@ done
 # Don't cache the APKINDEX.
 gcloud --quiet storage cp \
 	--cache-control=no-store \
-	"./packages/**/APKINDEX.tar.gz" gs://{{.bucket}}/os/{{.arch}}/ || true
+	"./packages/**/APKINDEX.tar.gz" gs://{{.bucket}}{{.arch}}/ || true
 
 # apks will be cached in CDN for an hour by default.
 gcloud --quiet storage cp \
-	"./packages/**/*.apk" gs://{{.bucket}}/os/{{.arch}}/ || true
+	"./packages/**/*.apk" gs://{{.bucket}}{{.arch}}/ || true
 `, map[string]string{"bucket": bucket, "arch": arch}),
 					},
 					VolumeMounts: []corev1.VolumeMount{{


### PR DESCRIPTION
`--bucket` is passed with the `/os/` component -- [_including the trailing slash_](https://github.com/wolfi-dev/os/blob/f36f5e610a342a4dfbd550478cb0a0ed7000757f/.github/workflows/dag-push-production.yaml#L15) -- so this should produce something like:

```
gcloud storage cp "./packages/**/APKINDEX.tar.gz" gs://wolfi-blah-bucket/os/aarch64/ || true
```