### PR TITLE
lint calls make list and checks package names

### DIFF
--- a/pkg/lint/testdata/dir/Makefile
+++ b/pkg/lint/testdata/dir/Makefile
@@ -5,4 +5,5 @@
 # arg 1 = package name
 # arg 2 = package version
 # arg 3 = override source directory, defaults to package name, useful if you want to reuse the same subfolder for multiple packages
-$(eval $(call build-package,valid,1.0.0))
+list:
+	@echo valid


### PR DESCRIPTION
With wolfi-dev/os now changed to use packages in a separate file, rather than in the Makefile, `wolfictl lint` reads the wrong thing and fails.

This PR updates it to call `make list`, using that as an API to report all known packages, and finds them that way.