### PR TITLE
Add new command for checking that config YAML files are formatted correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	chainguard.dev/apko v0.7.4-0.20230402102107-ddb6145f674f
 	chainguard.dev/melange v0.3.1-0.20230404103643-34643adbdff2
 	cloud.google.com/go/storage v1.30.1
-	github.com/chainguard-dev/yam v0.0.0-20230116015213-e93efc9df467
+	github.com/chainguard-dev/yam v0.0.0-20230411155911-ba3a3357c32e
 	github.com/charmbracelet/bubbles v0.15.0
 	github.com/charmbracelet/bubbletea v0.23.2
 	github.com/charmbracelet/lipgloss v0.7.1
@@ -40,6 +40,7 @@ require (
 	github.com/openvex/vexctl v0.2.1-0.20230123203902-a37dcd068257
 	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a
 	github.com/pkg/errors v0.9.1
+	github.com/samber/lo v1.38.1
 	github.com/sigstore/cosign/v2 v2.0.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -57,6 +58,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/utils v0.0.0-20230115233650-391b47cb4029
 	sigs.k8s.io/release-sdk v0.10.0
+	sigs.k8s.io/release-utils v0.7.3
 )
 
 require (
@@ -282,7 +284,6 @@ require (
 	knative.dev/pkg v0.0.0-20230125083639-408ad0773f47 // indirect
 	mvdan.cc/sh/v3 v3.5.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-	sigs.k8s.io/release-utils v0.7.3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
-github.com/chainguard-dev/yam v0.0.0-20230116015213-e93efc9df467 h1:gi3YegWmNaLnyQwQPwPEi5cZEIBw1qCOkCXGGd/+4QA=
-github.com/chainguard-dev/yam v0.0.0-20230116015213-e93efc9df467/go.mod h1:UKmsa6j+6qz6JyYMPkLPtOvBRO1KhHYNYc+z+Onk8pE=
+github.com/chainguard-dev/yam v0.0.0-20230411155911-ba3a3357c32e h1:TlpfdSUjQkrq2yh+bySzoOmPKspeaxmOr1fmsNCfNXM=
+github.com/chainguard-dev/yam v0.0.0-20230411155911-ba3a3357c32e/go.mod h1:sfV9rXdvBVe0PDTLWzPh4IpapowZ9CDROjMUN2etRrk=
 github.com/charmbracelet/bubbles v0.15.0 h1:c5vZ3woHV5W2b8YZI1q7v4ZNQaPetfHuoHzx+56Z6TI=
 github.com/charmbracelet/bubbles v0.15.0/go.mod h1:Y7gSFbBzlMpUDR/XM9MhZI374Q+1p1kluf1uLl8iK74=
 github.com/charmbracelet/bubbletea v0.23.1/go.mod h1:JAfGK/3/pPKHTnAS8JIE2u9f61BjWTQY57RbT25aMXU=
@@ -817,6 +817,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
+github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sassoftware/go-rpmutils v0.1.1/go.mod h1:euhXULoBpvAxqrBHEyJS4Tsu3hHxUmQWNymxoJbzgUY=
 github.com/sassoftware/relic v0.0.0-20210427151427-dfb082b79b74 h1:sUNzanSKA9z/h8xXl+ZJoxIYZL0Qx306MmxqRrvUgr0=
 github.com/sassoftware/relic v0.0.0-20210427151427-dfb082b79b74/go.mod h1:YlB8wFIZmFLZ1JllNBfSURzz52fBxbliNgYALk1UDmk=

--- a/pkg/cli/lint.go
+++ b/pkg/cli/lint.go
@@ -32,6 +32,9 @@ func Lint() *cobra.Command {
 	cmd.Flags().BoolVarP(&o.verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVarP(&o.list, "list", "l", false, "prints the all of available rules and exits")
 	cmd.Flags().StringArrayVarP(&o.skipRules, "skip-rule", "", []string{}, "list of rules to skip")
+
+	cmd.AddCommand(LintYam())
+
 	return cmd
 }
 

--- a/pkg/cli/lint_yam.go
+++ b/pkg/cli/lint_yam.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/chainguard-dev/yam/pkg/yam"
+	"github.com/chainguard-dev/yam/pkg/yam/formatted"
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+)
+
+func LintYam() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "yam [file]...",
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fsys := os.DirFS(".")
+			paths := lo.Map(args, toCleanPath)
+
+			encodeOptions, err := formatted.ReadConfig()
+			if err != nil {
+				return fmt.Errorf("unable to load yam config: %w", err)
+			}
+
+			formatOptions := yam.FormatOptions{
+				EncodeOptions:          *encodeOptions,
+				FinalNewline:           true,
+				TrimTrailingWhitespace: true,
+			}
+
+			err = yam.Lint(fsys, paths, yam.ExecDiff, formatOptions)
+			if err != nil {
+				if errors.Is(err, yam.ErrDidNotPassLintCheck) {
+					fmt.Println("\nYAML needs to be formatted. 👻")
+					fmt.Println("Run `yam` to fix automatically. For more information, see https://github.com/chainguard-dev/yam")
+					fmt.Println()
+				}
+
+				return err
+			}
+
+			fmt.Println("YAML is formatted correctly! 🎉")
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func toCleanPath(p string, _ int) string {
+	return filepath.Clean(p)
+}

--- a/pkg/configs/yaml.go
+++ b/pkg/configs/yaml.go
@@ -10,8 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const yamlIndent = 2
-
 // A yamlUpdater is a function that mutates a YAML AST. The function is also
 // given a build.Configuration in case implementations require it for context.
 type yamlUpdater func(build.Configuration, *yaml.Node) error
@@ -41,12 +39,8 @@ func (i *Index) newYAMLUpdateFunc(updateYAML yamlUpdater) updateFunc {
 			return fmt.Errorf("unable to update %q: %w", e.Path(), err)
 		}
 
-		encoder := formatted.NewEncoder(file)
-		encoder.SetIndent(yamlIndent)
-		err = encoder.SetGapExpressions(".")
-		if err != nil {
-			return fmt.Errorf("unable to set gap expressions when updating YAML: %w", err)
-		}
+		encoder := formatted.NewEncoder(file).AutomaticConfig()
+
 		err = encoder.Encode(root)
 		if err != nil {
 			return fmt.Errorf("unable to encode updated YAML: %w", err)


### PR DESCRIPTION
The new command is: `wolfictl lint yam`. You can optionally pass one or more file/dir to lint; if no args are provided, the current directory is linted.

This introduces a dependency on the `diff` command, which is used to show the diff between a file's expected state and its actual state.

This also updates the YAML encoder to use the latest version of Yam.

cc: @rawlingsj 