### PR TITLE
checks: so-name: support subpackages-inclusive packages.log format

### DIFF
--- a/pkg/checks/so_name.go
+++ b/pkg/checks/so_name.go
@@ -18,10 +18,6 @@ import (
 
 	"github.com/wolfi-dev/wolfictl/pkg/lint"
 
-	"golang.org/x/exp/maps"
-
-	"github.com/wolfi-dev/wolfictl/pkg/melange"
-
 	"github.com/wolfi-dev/wolfictl/pkg/apk"
 
 	"github.com/pkg/errors"
@@ -107,16 +103,16 @@ func (o *SoNameOptions) getNewPackages() (map[string]NewApkPackage, error) {
 		}
 		parts := strings.Split(scanner.Text(), "|")
 
-		if len(parts) != 3 {
+		if len(parts) != 4 {
 			return rs, fmt.Errorf("expected 3 parts but found %d when scanning %s", len(parts), scanner.Text())
 		}
-		versionParts := strings.Split(parts[2], "-")
+		versionParts := strings.Split(parts[3], "-")
 		if len(versionParts) != 2 {
 			return rs, fmt.Errorf("expected 2 version parts but found %d", len(versionParts))
 		}
 
 		arch := parts[0]
-		packageName := parts[1]
+		packageName := parts[2]
 		version := versionParts[0]
 
 		epoch := versionParts[1]
@@ -130,27 +126,7 @@ func (o *SoNameOptions) getNewPackages() (map[string]NewApkPackage, error) {
 		}
 	}
 
-	rs = o.addSubpackages(rs)
 	return rs, nil
-}
-
-func (o *SoNameOptions) addSubpackages(m map[string]NewApkPackage) map[string]NewApkPackage {
-	packagesAndSubpackages := make(map[string]NewApkPackage)
-	maps.Copy(packagesAndSubpackages, m)
-
-	for melangePackageName, apkPackage := range m {
-		filename := filepath.Join(o.Dir, melangePackageName+".yaml")
-		c, err := melange.ReadMelangeConfig(filename)
-		if err != nil {
-			log.Printf("failed to read melange config %s", filename)
-			continue
-		}
-
-		for i := 0; i < len(c.Subpackages); i++ {
-			packagesAndSubpackages[c.Subpackages[i].Name] = apkPackage
-		}
-	}
-	return packagesAndSubpackages
 }
 
 // diff will compare the so name versions between the latest existing apk in a APKINDEX with a newly built local apk

--- a/pkg/checks/so_name_test.go
+++ b/pkg/checks/so_name_test.go
@@ -39,6 +39,10 @@ func TestChecks_sonameParsePackages(t *testing.T) {
 	assert.Equal(t, "1.2.3", packages["bind-doc"].Version)
 	assert.Equal(t, "1.2.3", packages["bind-dev"].Version)
 	assert.Equal(t, "1.2.3", packages["grape-utils"].Version)
+
+	// if-conditional subpackages might not be built
+	_, ok := packages["foo-utils"]
+	assert.False(t, ok, "foo-utils should not be present")
 }
 
 func TestChecks_getSonameFiles(t *testing.T) {

--- a/pkg/checks/testdata/packages.log
+++ b/pkg/checks/testdata/packages.log
@@ -1,3 +1,6 @@
-aarch64|bind|1.2.3-r0
-aarch64|gnupg|2.2.41-r0
-aarch64|gnutls-c++|3.7.8-r0
+aarch64|bind|bind|1.2.3-r0
+aarch64|bind|bind-doc|1.2.3-r0
+aarch64|bind|bind-dev|1.2.3-r0
+aarch64|bind|grape-utils|1.2.3-r0
+aarch64|gnupg|gnupg|2.2.41-r0
+aarch64|gnutls-c++|gnutls-c++|3.7.8-r0

--- a/pkg/checks/testdata/subpackages_melange.yaml
+++ b/pkg/checks/testdata/subpackages_melange.yaml
@@ -19,4 +19,9 @@ subpackages:
       - runs:  |
           mkdir -p "${{targets.destdir}}"/foo
           echo cheese > "${{targets.subpkgdir}}"/foo/cheese
-
+  - if: ${{options.foo.enabled}} == 'true'
+    name: "foo-utils"
+    description: "foo utility"
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/foo
+          echo cheese > "${{targets.subpkgdir}}"/foo/cheese


### PR DESCRIPTION
I changed Melange's `packages.log` to emit origin + subpackage fields, e.g.

```
aarch64|openssl|openssl-provider-legacy|3.1.0-r4
```

This chases that format update.