### PR TITLE
wolfi check update: ensure update config is provided

### DIFF
--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dprotaso/go-yit"
+
 	version "github.com/wolfi-dev/wolfictl/pkg/versions"
 
 	"github.com/fatih/color"
@@ -44,7 +46,11 @@ func SetupUpdate() (*update.Options, lint.EvalRuleErrors) {
 func (o CheckUpdateOptions) CheckUpdates(files []string) error {
 	updateOpts, checkErrors := SetupUpdate()
 
-	latestVersions, err := updateOpts.GetLatestVersions(o.Dir, GetPackagesToUpdate(files))
+	changedPackages := GetPackagesToUpdate(files)
+
+	validateUpdateConfig(changedPackages, &checkErrors)
+
+	latestVersions, err := updateOpts.GetLatestVersions(o.Dir, changedPackages)
 	if err != nil {
 		addCheckError(&checkErrors, err)
 	}
@@ -64,6 +70,66 @@ func (o CheckUpdateOptions) CheckUpdates(files []string) error {
 
 	return checkErrors.WrapErrors()
 }
+
+// validates update configuration
+func validateUpdateConfig(files []string, checkErrors *lint.EvalRuleErrors) {
+	for _, file := range files {
+		// first need to read raw bytes as unmarshalling a struct without a pointer means update will never be nil
+		if !strings.HasSuffix(file, ".yaml") {
+			file += ".yaml"
+		}
+		yamlData, err := os.ReadFile(file)
+		if err != nil {
+			addCheckError(checkErrors, errors.Wrapf(err, "failed to read %s", file))
+			continue
+		}
+
+		var node yaml.Node
+		err = yaml.Unmarshal(yamlData, &node)
+		if err != nil {
+			addCheckError(checkErrors, errors.Wrapf(err, "failed to unmarshal %s", file))
+			continue
+		}
+
+		if node.Content == nil {
+			addCheckError(checkErrors, fmt.Errorf("config %s has no yaml content", file))
+			continue
+		}
+		// loop over content to ensure an update key exists
+		err = containsKey(node.Content[0], "update")
+		if err != nil {
+			addCheckError(checkErrors, fmt.Errorf("config %s does not have update config provided, see examples in this repository.  Or use update.enabled=false, be aware maintainers may require enabled=true so the package does not become stale", file))
+			continue
+		}
+
+		// now make sure update config is configured
+		c, err := build.ParseConfiguration(file)
+		if err != nil {
+			addCheckError(checkErrors, errors.Wrapf(err, "failed to parse %s", file))
+			continue
+		}
+
+		// ensure a backend has been configured
+		if c.Update.Enabled {
+			if c.Update.ReleaseMonitor == nil && c.Update.GitHubMonitor == nil {
+				addCheckError(checkErrors, fmt.Errorf("config %s has update config enabled but no release-monitor or github backend monitor configured, see examples in this repository", file))
+				continue
+			}
+		}
+	}
+}
+
+func containsKey(parentNode *yaml.Node, key string) error {
+	it := yit.FromNode(parentNode).
+		ValuesForMap(yit.WithValue(key), yit.All)
+
+	if _, ok := it(); ok {
+		return nil
+	}
+
+	return fmt.Errorf("key '%s' not found in mapping", key)
+}
+
 func GetPackagesToUpdate(files []string) []string {
 	packagesToUpdate := []string{}
 	for _, f := range files {

--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -161,6 +161,12 @@ func (o CheckUpdateOptions) processUpdates(latestVersions map[string]update.NewV
 			return err
 		}
 
+		// if manual update is expected then let's not try to validate pipelines
+		if updated.Update.Manual {
+			o.Logger.Println("manual update configured, skipping pipeline validation")
+			continue
+		}
+
 		// download or git clone sources into a temp folder to validate the update config
 		verifyPipelines(o, updated, mutations, checkErrors)
 	}

--- a/pkg/checks/update_test.go
+++ b/pkg/checks/update_test.go
@@ -136,3 +136,35 @@ func createTestRepo(t *testing.T, dir, tag string) string {
 
 	return c.String()
 }
+
+func TestUpdateKeyExists(t *testing.T) {
+	dir := t.TempDir()
+	// create a temporary file with an update key
+	yamlData := []byte("name: cheese\nupdate:\n  foo: true\n")
+	fileContainsUpdate := filepath.Join(dir, "contains.yaml")
+	err := os.WriteFile(fileContainsUpdate, yamlData, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkErrors := make(lint.EvalRuleErrors, 0)
+	// check update key exists
+	validateUpdateConfig([]string{fileContainsUpdate}, &checkErrors)
+
+	assert.Empty(t, checkErrors)
+
+	// create a temporary file without an update key
+	yamlData = []byte("name: cheese\n")
+	fileNoContainsUpdate := filepath.Join(dir, "does_not_contain.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(fileNoContainsUpdate, yamlData, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check the update key does not exist
+	validateUpdateConfig([]string{fileNoContainsUpdate}, &checkErrors)
+	assert.NotEmpty(t, checkErrors)
+}

--- a/pkg/update/githubReleases.go
+++ b/pkg/update/githubReleases.go
@@ -586,6 +586,14 @@ func (o GitHubReleaseOptions) prepareVersion(nameHash, v, id string) (string, er
 	if ghm == nil {
 		return "", fmt.Errorf("no github update config found for package %s", id)
 	}
+
+	// the github graphql query filter matches any occurrence, we want to make that more strict and remove any tags that do not START with the filter
+	if ghm.TagFilter != "" {
+		if !strings.HasPrefix(v, ghm.StripPrefix) {
+			return "", nil
+		}
+	}
+
 	if ghm.StripPrefix != "" {
 		v = strings.TrimPrefix(v, ghm.StripPrefix)
 	}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -672,6 +672,7 @@ func (o *Options) processPullRequests(updates map[string]NewVersionResults, prs 
 		}
 
 		if o.isSameVersion(packageName, v.Version, prTitle) {
+			o.Logger.Printf("pull request %s already exists for %s\n", *pr.HTMLURL, prTitle)
 			delete(updates, packageName)
 			continue
 		}


### PR DESCRIPTION
Now that wolfi has package update config for all packages, let's keep it that way so wolfi is easier to maintain.  It will mean that this is the last time we will need to spend a large amount of time adding update configs to a lot of packages.