### PR TITLE
Fix panic caused by dag Graph and new logger interaction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace knative.dev/pkg => knative.dev/pkg v0.0.0-20220407210145-4d62e1dbb943
 
 require (
 	chainguard.dev/apko v0.7.4-0.20230411143434-39b16b590291
-	chainguard.dev/melange v0.3.1-0.20230411200053-f19dc44a617a
+	chainguard.dev/melange v0.3.1-0.20230412184805-225b6a2a6e78
 	cloud.google.com/go/storage v1.30.1
 	github.com/chainguard-dev/yam v0.0.0-20230411155911-ba3a3357c32e
 	github.com/charmbracelet/bubbles v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ chainguard.dev/apko v0.7.4-0.20230411143434-39b16b590291 h1:Rdk8l9xGjThnqu+jiEMo
 chainguard.dev/apko v0.7.4-0.20230411143434-39b16b590291/go.mod h1:+/nr2VHPIDEJqsUpY/WvYDrkzCe7WoL5RBW28NQVKUs=
 chainguard.dev/melange v0.3.1-0.20230411200053-f19dc44a617a h1:4z7mMFkodLEq+TZUQgc5TlLu7RzCTZ0/lbgF0Wy4KYE=
 chainguard.dev/melange v0.3.1-0.20230411200053-f19dc44a617a/go.mod h1:rw+fFeyUCTkc2a769KyNdkzzBQr+2jM8TjgE2hsIbhU=
+chainguard.dev/melange v0.3.1-0.20230412184805-225b6a2a6e78 h1:nPC0PDERqsz1L0eniOquvwSPItN/gxV8fEdZAVtGb/k=
+chainguard.dev/melange v0.3.1-0.20230412184805-225b6a2a6e78/go.mod h1:rw+fFeyUCTkc2a769KyNdkzzBQr+2jM8TjgE2hsIbhU=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/dag/graph_test.go
+++ b/pkg/dag/graph_test.go
@@ -1,0 +1,20 @@
+package dag
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDir = "testdata"
+
+func TestNewGraph(t *testing.T) {
+	t.Run("does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			_, err := NewGraph(os.DirFS(testDir), testDir)
+			require.NoError(t, err)
+		})
+	})
+}

--- a/pkg/dag/testdata/busybox.yaml
+++ b/pkg/dag/testdata/busybox.yaml
@@ -1,0 +1,74 @@
+package:
+  name: busybox
+  version: 1.36.0
+  epoch: 0
+  description: "swiss-army knife for embedded systems"
+  copyright:
+    - license: GPL-2.0-only
+  scriptlets:
+    trigger:
+      paths:
+        - /bin
+        - /sbin
+        - /usr/bin
+        - /usr/sbin
+      script: |
+        #!/bin/busybox sh
+        /bin/busybox --install -s
+secfixes:
+  1.35.0-r3:
+    - CVE-2022-28391
+    - CVE-2022-30065
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/bootstrap/stage3
+    keyring:
+      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://distfiles.alpinelinux.org/distfiles/edge/busybox-1.36.0.tar.bz2
+      expected-sha256: 542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5
+  - uses: patch
+    with:
+      patches: CVE-2022-28391-1.patch
+  - uses: patch
+    with:
+      patches: CVE-2022-28391-2.patch
+  - name: Configure
+    runs: |
+      cp busyboxconfig .config
+  - runs: |
+      make CC="${{host.triplet.gnu}}-gcc" V=1 -j$(nproc)
+  - name: Install
+    runs: |
+      mkdir -p "${{targets.destdir}}"/usr/sbin
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      mkdir -p "${{targets.destdir}}"/tmp
+      mkdir -p "${{targets.destdir}}"/var/cache/misc
+      mkdir -p "${{targets.destdir}}"/bin
+      mkdir -p "${{targets.destdir}}"/sbin
+      mkdir -p "${{targets.destdir}}"/etc
+      mkdir -p "${{targets.destdir}}"/usr/share/man/man1
+      chmod 1777 "${{targets.destdir}}"/tmp
+      install -m755 busybox "${{targets.destdir}}"/bin/busybox
+      install -m644 securetty "${{targets.destdir}}"/etc/securetty
+  - uses: strip
+advisories:
+  CVE-2022-28391:
+    - timestamp: 2022-10-11T20:37:21+00:00
+      status: fixed
+      fixed-version: 1.35.0-r3
+  CVE-2022-30065:
+    - timestamp: 2022-10-11T20:37:21+00:00
+      status: fixed
+      fixed-version: 1.35.0-r3
+update:
+  enabled: false
+  release-monitor:
+    identifier: 230


### PR DESCRIPTION
This is causing the "Dependency analysis" CI check to fail in Wolfi.