### PR TITLE
checks: so-name: use MkdirTemp instead of TempDir to get a temporary directory

### DIFF
--- a/pkg/checks/so_name.go
+++ b/pkg/checks/so_name.go
@@ -131,8 +131,17 @@ func (o *SoNameOptions) getNewPackages() (map[string]NewApkPackage, error) {
 
 // diff will compare the so name versions between the latest existing apk in a APKINDEX with a newly built local apk
 func (o *SoNameOptions) diff(newPackageName string, newAPK NewApkPackage) error {
-	dirExistingApk := os.TempDir()
-	dirNewApk := os.TempDir()
+	dirExistingApk, err := os.MkdirTemp("", "wolfictl-apk-*")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create temporary dir")
+	}
+	defer os.RemoveAll(dirExistingApk)
+
+	dirNewApk, err := os.MkdirTemp("", "wolfictl-apk-*")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create temporary dir")
+	}
+	defer os.RemoveAll(dirNewApk)
 
 	// read new apk
 	filename := filepath.Join(o.PackagesDir, newAPK.Arch, fmt.Sprintf("%s-%s-r%s.apk", newPackageName, newAPK.Version, newAPK.Epoch))


### PR DESCRIPTION
`TempDir` returns "/tmp" on UNIX machines, and is not an equivalent to `mktemp(3)`.
`MkdirTemp` returns "/tmp/[pattern]", and is equivalent to `mktemp(3)`.