### PR TITLE
Fix directory descension for configs index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace knative.dev/pkg => knative.dev/pkg v0.0.0-20220407210145-4d62e1dbb943
 
 require (
 	chainguard.dev/apko v0.7.4-0.20230413153940-a8d76b8a9e82
-	chainguard.dev/melange v0.3.1-0.20230417103038-c78631d54200
+	chainguard.dev/melange v0.3.1-0.20230419164506-48e21af3b9d2
 	cloud.google.com/go/storage v1.30.1
 	github.com/chainguard-dev/yam v0.0.0-20230411155911-ba3a3357c32e
 	github.com/charmbracelet/bubbles v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 chainguard.dev/apko v0.7.4-0.20230413153940-a8d76b8a9e82 h1:p7hbWTwpwqNYu5mW7PzLZswqRQjPdZvxUTY7/xOv/Fo=
 chainguard.dev/apko v0.7.4-0.20230413153940-a8d76b8a9e82/go.mod h1:+/nr2VHPIDEJqsUpY/WvYDrkzCe7WoL5RBW28NQVKUs=
-chainguard.dev/melange v0.3.1-0.20230417103038-c78631d54200 h1:5kKhAK1TJviHtb7pKRtoKhxsK0iW/n9kLuDs8tbK9x8=
-chainguard.dev/melange v0.3.1-0.20230417103038-c78631d54200/go.mod h1:7+tIGAXkwl7x5h+XbfO+gqxK9JV05gEbGAhda73MnRs=
+chainguard.dev/melange v0.3.1-0.20230419164506-48e21af3b9d2 h1:M/sQHlp00S8JeZNo/JiY7eAMl6fLGgaPx/by/XFocbM=
+chainguard.dev/melange v0.3.1-0.20230419164506-48e21af3b9d2/go.mod h1:7+tIGAXkwl7x5h+XbfO+gqxK9JV05gEbGAhda73MnRs=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/configs/index.go
+++ b/pkg/configs/index.go
@@ -43,6 +43,10 @@ func NewIndex(fsys rwfs.FS) (*Index, error) {
 			return nil
 		}
 
+		if strings.HasPrefix(d.Name(), ".") {
+			return nil
+		}
+
 		if !strings.HasSuffix(d.Name(), ".yaml") {
 			return nil
 		}

--- a/pkg/configs/index.go
+++ b/pkg/configs/index.go
@@ -202,7 +202,7 @@ func (i *Index) process(path string) (*entry, error) {
 		return nil, fmt.Errorf("unable to decode YAML at %q: %w", path, err)
 	}
 
-	cfg, err := build.ParseConfiguration(path)
+	cfg, err := build.ParseConfiguration(path, build.WithFS(i.fsys))
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse configuration at %q: %w", path, err)
 	}

--- a/pkg/configs/index.go
+++ b/pkg/configs/index.go
@@ -35,7 +35,7 @@ func NewIndex(fsys rwfs.FS) (*Index, error) {
 			return err
 		}
 
-		if d.Type().IsDir() && path != "." && strings.HasPrefix(d.Name(), ".") {
+		if d.Type().IsDir() && path != "." {
 			return fs.SkipDir
 		}
 

--- a/pkg/configs/index_test.go
+++ b/pkg/configs/index_test.go
@@ -1,0 +1,21 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+)
+
+func TestNewIndex(t *testing.T) {
+	t.Run("skips configs in subdirectories", func(t *testing.T) {
+		fsys := rwos.DirFS("testdata/index-1")
+
+		index, err := NewIndex(fsys)
+		require.NoError(t, err)
+
+		assert.Contains(t, index.paths, "config-1.yaml")
+		assert.NotContains(t, index.paths, "subdir/not-a-config.yaml")
+	})
+}

--- a/pkg/configs/index_test.go
+++ b/pkg/configs/index_test.go
@@ -9,13 +9,20 @@ import (
 )
 
 func TestNewIndex(t *testing.T) {
-	t.Run("skips configs in subdirectories", func(t *testing.T) {
-		fsys := rwos.DirFS("testdata/index-1")
+	fsys := rwos.DirFS("testdata/index-1")
 
-		index, err := NewIndex(fsys)
-		require.NoError(t, err)
+	index, err := NewIndex(fsys)
+	require.NoError(t, err)
 
+	t.Run("includes real configs", func(t *testing.T) {
 		assert.Contains(t, index.paths, "config-1.yaml")
+	})
+
+	t.Run("skips configs in subdirectories", func(t *testing.T) {
 		assert.NotContains(t, index.paths, "subdir/not-a-config.yaml")
+	})
+
+	t.Run("skips hidden files", func(t *testing.T) {
+		assert.NotContains(t, index.paths, ".not-a-config.yaml")
 	})
 }

--- a/pkg/configs/testdata/index-1/.not-a-config.yaml
+++ b/pkg/configs/testdata/index-1/.not-a-config.yaml
@@ -1,0 +1,5 @@
+this:
+  is:
+    not:
+      a:
+        config

--- a/pkg/configs/testdata/index-1/config-1.yaml
+++ b/pkg/configs/testdata/index-1/config-1.yaml
@@ -1,0 +1,4 @@
+package:
+  name: awesome-tool
+  version: 0.61.0
+  epoch: 1

--- a/pkg/configs/testdata/index-1/subdir/not-a-config.yaml
+++ b/pkg/configs/testdata/index-1/subdir/not-a-config.yaml
@@ -1,0 +1,3 @@
+package:
+  delivered-by: ups
+  priority: overnight


### PR DESCRIPTION
(needs to bring in changes from https://github.com/chainguard-dev/melange/pull/395 before it's ready)

This fixes an issue where a configs index was being built to include YAML files from subdirectories when it shouldn't.

This also adds tests around the `NewIndex` function to make sure the right YAML files are getting included or not included.