### PR TITLE
Update Checks - switch Equal to LessThan

### DIFF
--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -175,7 +175,7 @@ func (o CheckUpdateOptions) checkForLatestVersions(latestVersions map[string]upd
 			addCheckError(checkErrors, err)
 			continue
 		}
-		if !currentVersion.Equal(latestVersion) {
+		if currentVersion.LessThan(latestVersion) {
 			addCheckError(checkErrors, fmt.Errorf("package %s: update found newer version %s compared with package.version %s in melange config", k, v.Version, c.Package.Version))
 		}
 	}


### PR DESCRIPTION
@rawlingsj would love your opinion here. The old check was just seeing if the versions weren't equal, but it tripped over an edge case [here](https://github.com/wolfi-dev/os/actions/runs/4758448256/jobs/8456519341?pr=1501#step:5:489). The [melange file](https://github.com/wolfi-dev/os/blob/main/ruby3.2-yajl-ruby.yaml#L56) in question has to use the commit rather than the version because the yajl author released a gem with security fixes but did not cut a tag on GitHub.

The `update` section marks the config to be manually updated, but the version comparison in the update checks only checks if the versions aren't equal which throws an error even if the detected version on GitHub is less than melange. I could see strictly checking if the versions are equal as a good behavior for a linter like this, perhaps a better way to handle it would be

```
if currentVersion.LessThan(latestVersion) {
    // add an error
} else if currentVersion.GreaterThan(latestVersion) {
    // handle as a warning
}
```

I didn't see warnings in the lint types though so would love to get thoughts here