### PR TITLE
Revert "wolfi update: add use gitsign flag thats already used for wol…

### DIFF
--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -43,7 +43,6 @@ func Update() *cobra.Command {
 	cmd.Flags().StringVar(&o.pullRequestTitle, "pull-request-title", "%s/%s package update", "the title to use when creating a pull request")
 	cmd.Flags().BoolVar(&o.useGitSign, "use-gitsign", false, "enable gitsign to sign the git commits")
 	cmd.Flags().BoolVar(&o.createIssues, "create-issues", true, "creates GitHub Issues for failed package updates")
-	cmd.Flags().BoolVar(&o.useGitSign, "use-gitsign", false, "enable gitsign to sign the git commits")
 
 	cmd.AddCommand(
 		Package(),


### PR DESCRIPTION
…fictl update package"

flag already exists

This reverts commit a4253f6e042b199aaa18822c466e02fe2b2ebe60.