### PR TITLE
wolfictl lint: ensure packages have an epoch set

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -206,6 +206,22 @@ func TestLinter_Rules(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			file: "no-epoch.yaml",
+			want: EvalResult{
+				File: "no-epoch",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "contains-epoch",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[contains-epoch]: config testdata/files/no-epoch.yaml has no package.epoch (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lint/testdata/files/no-epoch.yaml
+++ b/pkg/lint/testdata/files/no-epoch.yaml
@@ -1,0 +1,9 @@
+package:
+  name: no-epoch
+  version: 1.2.3
+  description: "a package that fails as no epoch"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only


### PR DESCRIPTION
The melange struct for epoch doesn't have an `omitempty` yaml annotation which means it is always 0 when unmarshalling configs.  This lint check validates the raw yaml to make sure epoch is set.

This will help avoid these issues https://github.com/wolfi-dev/os/issues/1569