### PR TITLE
wolfi check soname: only return the base filename rather than the who…

### DIFF
--- a/pkg/checks/so_name.go
+++ b/pkg/checks/so_name.go
@@ -153,13 +153,14 @@ func (o *SoNameOptions) getSonameFiles(dir string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		s := reg.FindString(filepath.Base(path))
+		basePath := filepath.Base(path)
+		s := reg.FindString(basePath)
 		if s != "" {
-			fileList = append(fileList, path)
+			fileList = append(fileList, basePath)
 		}
 
 		// also check for DT_SONAME
-		ef, err := elf.Open(filepath.Join(dir, path))
+		ef, err := elf.Open(filepath.Join(dir, basePath))
 		if err != nil {
 			return nil
 		}

--- a/pkg/checks/so_name_test.go
+++ b/pkg/checks/so_name_test.go
@@ -138,3 +138,23 @@ func TestSoNameOptions_checkSonamesMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestSoNameOptions_checkSonamesSubFolders(t *testing.T) {
+	o := SoNameOptions{}
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "foo")
+	err := os.Mkdir(subDir, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(subDir, "bar.so.1.2.3"), []byte("test"), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := o.getSonameFiles(dir)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "bar.so.1.2.3", got[0])
+}


### PR DESCRIPTION
…le path

I noticed this when updating libpaper and diff'ing the contents