### PR TITLE
add schema subcommand for generating json schemas for configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,8 @@ require (
 	sigs.k8s.io/release-utils v0.7.3
 )
 
+require github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
+
 require (
 	cloud.google.com/go v0.110.0 // indirect
 	cloud.google.com/go/compute v1.19.1 // indirect
@@ -178,6 +180,7 @@ require (
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/in-toto/in-toto-golang v0.7.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/invopop/jsonschema v0.7.0
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20211028175153-1c139d1cc84b // indirect
 	github.com/jinzhu/copier v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -657,6 +657,8 @@ github.com/hashicorp/vault/api v1.9.1 h1:LtY/I16+5jVGU8rufyyAkwopgq/HpUnxFBg+QLO
 github.com/honeycombio/beeline-go v1.10.0 h1:cUDe555oqvw8oD76BQJ8alk7FP0JZ/M/zXpNvOEDLDc=
 github.com/honeycombio/libhoney-go v1.16.0 h1:kPpqoz6vbOzgp7jC6SR7SkNj7rua7rgxvznI6M3KdHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -669,6 +671,8 @@ github.com/in-toto/in-toto-golang v0.7.1/go.mod h1:m7HiDiYvPz+7SkqU9Tnt9hNgJfA31
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.7.0 h1:2vgQcBz1n256N+FpX3Jq7Y17AjYt46Ig3zIWyy770So=
+github.com/invopop/jsonschema v0.7.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedisct1/go-minisign v0.0.0-20211028175153-1c139d1cc84b h1:ZGiXF8sz7PDk6RgkP+A/SFfUD0ZR/AgG6SpRNEDKZy8=
@@ -985,6 +989,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -28,6 +28,7 @@ func New() *cobra.Command {
 		Lint(),
 		Update(),
 		VEX(),
+		Schema(),
 		version.Version(),
 	)
 

--- a/pkg/cli/schema.go
+++ b/pkg/cli/schema.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/melange/pkg/build"
+	"github.com/invopop/jsonschema"
+	"github.com/spf13/cobra"
+)
+
+type schemaOpts struct {
+	// File path to write output to
+	OutFile string
+}
+
+type sourceType string
+
+var (
+	melangeSource sourceType = "melange"
+	apkoSource    sourceType = "apko"
+)
+
+func Schema() *cobra.Command {
+	o := &schemaOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Generate json schema for melange/apko.",
+		Example: `
+	  wolfictl schema > melange.schema.json
+	  `,
+		SilenceErrors: true,
+		Args:          cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Cmd(cmd.Context(), sourceType(args[0]))
+		},
+	}
+	return cmd
+}
+
+func (o schemaOpts) Cmd(ctx context.Context, source sourceType) error {
+	r := new(jsonschema.Reflector)
+
+	var s *jsonschema.Schema
+	switch source {
+	case melangeSource:
+		r.AddGoComments("chainguard.dev/melange", "./")
+		s = r.Reflect(&build.Configuration{})
+
+	case apkoSource:
+		r.AddGoComments("chainguard.dev/apko", "./")
+		s = r.Reflect(&types.ImageConfiguration{})
+
+	default:
+		return fmt.Errorf("unknown schema source: %s", source)
+	}
+
+	// Match the format of those in: https://github.com/SchemaStore/schemastore/tree/master/src/schemas/json
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	w := os.Stdout
+	if o.OutFile != "" {
+		f, err := os.Create(o.OutFile)
+		if err != nil {
+			return fmt.Errorf("creating output file: %v", err)
+		}
+		w = f
+	}
+
+	_, err = fmt.Fprintf(w, "%s", data)
+	return err
+}


### PR DESCRIPTION
NOTE: While this works as is, it will __not__ produce the desired schema as is. Several upstream changes need to happen before this creates what we'll ultimately submit to `schemastore`.

- apko config
- melange config