### PR TITLE
Add a new lint rule that allows us to force comments to be checked du…

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -217,6 +218,38 @@ func TestLinter_Rules(t *testing.T) {
 							Severity: SeverityError,
 						},
 						Error: fmt.Errorf("[contains-epoch]: config testdata/files/no-epoch.yaml has no package.epoch (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			file: "check-version-matches.yaml",
+			want: EvalResult{
+				File: "check-version-matches",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "check-when-version-changes",
+							Severity: SeverityError,
+						},
+						Error: errors.New("[check-when-version-changes]: version in comment: 1.0.0 does not match version in package: 1.0.1, check that it can be updated and update the comment (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			file: "check-subpipeline-version-matches.yaml",
+			want: EvalResult{
+				File: "check-version-matches",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "check-when-version-changes",
+							Severity: SeverityError,
+						},
+						Error: errors.New("[check-when-version-changes]: version in comment: 0.8.0 does not match version in package: 0.9.0, check that it can be updated and update the comment (ERROR)"),
 					},
 				},
 			},

--- a/pkg/lint/testdata/files/check-subpipeline-version-matches.yaml
+++ b/pkg/lint/testdata/files/check-subpipeline-version-matches.yaml
@@ -1,0 +1,22 @@
+package:
+  name: check-version-matches
+  version: 0.9.0
+  epoch: 0
+  description: "a package with an out of date comment"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+pipeline:
+  - runs: |
+      # CHECK-WHEN-VERSION-CHANGES: 0.9.0
+      echo "this should be checked each time the version is bumped"
+
+subpackages:
+  - name: subpackage
+    description: "a package with an out of date comment"
+    pipeline:
+      - runs: |
+          # CHECK-WHEN-VERSION-CHANGES: 0.8.0
+          echo "this should be checked each time the version is bumped"

--- a/pkg/lint/testdata/files/check-version-matches.yaml
+++ b/pkg/lint/testdata/files/check-version-matches.yaml
@@ -1,0 +1,14 @@
+package:
+  name: check-version-matches
+  version: 1.0.1
+  epoch: 0
+  description: "a package with an out of date comment"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+pipeline:
+  - runs: |
+      # CHECK-WHEN-VERSION-CHANGES: 1.0.0
+      echo "this should be checked each time the version is bumped"


### PR DESCRIPTION
…ring bumps.

We often have comments like "when bumping, check if CVE mitigations can be removed", but we don't have any way to check that this actually happens. As we further automate package bumps, this is more and more likely to cause us to miss things.

This introduces a simple check that lets maintainers define comments with *hardcoded* version strings. When automation bumps the package.version variable, these will get out of data and the lint will fail.