### PR TITLE
Add a command to generate a security database ("secdb")

### DIFF
--- a/pkg/advisory/db.go
+++ b/pkg/advisory/db.go
@@ -1,16 +1,70 @@
 package advisory
 
 import (
+	"encoding/json"
+
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	"github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
 )
 
+const apkURL = "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk"
+
+// BuildDatabaseOptions contains the options for building a database.
 type BuildDatabaseOptions struct {
 	AdvisoryCfgs *configs.Index[advisory.Document]
+
+	URLPrefix string
+	Archs     []string
+	Repo      string
 }
 
+// BuildDatabase builds a security database from the given options.
 func BuildDatabase(opts BuildDatabaseOptions) ([]byte, error) {
-	// cfgs := opts.AdvisoryCfgs.Select().Configurations()
+	cfgs := opts.AdvisoryCfgs.Select().Configurations()
 
-	return nil, nil
+	var packageEntries []PackageEntry
+
+	for _, cfg := range cfgs {
+		if len(cfg.Secfixes) == 0 {
+			continue
+		}
+
+		pe := PackageEntry{
+			Pkg: Package{
+				Name:     cfg.Package.Name,
+				Secfixes: Secfixes(cfg.Secfixes),
+			},
+		}
+
+		packageEntries = append(packageEntries, pe)
+	}
+
+	db := Database{
+		APKURL:    apkURL,
+		Archs:     opts.Archs,
+		Repo:      opts.Repo,
+		URLPrefix: opts.URLPrefix,
+		Packages:  packageEntries,
+	}
+
+	return json.MarshalIndent(db, "", "  ")
 }
+
+type Database struct {
+	APKURL    string         `json:"apkurl"`
+	Archs     []string       `json:"archs"`
+	Repo      string         `json:"reponame"`
+	URLPrefix string         `json:"urlprefix"`
+	Packages  []PackageEntry `json:"packages"`
+}
+
+type PackageEntry struct {
+	Pkg Package `json:"pkg"`
+}
+
+type Package struct {
+	Name     string   `json:"name"`
+	Secfixes Secfixes `json:"secfixes"`
+}
+
+type Secfixes map[string][]string

--- a/pkg/advisory/db.go
+++ b/pkg/advisory/db.go
@@ -1,0 +1,16 @@
+package advisory
+
+import (
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	"github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+)
+
+type BuildDatabaseOptions struct {
+	AdvisoryCfgs *configs.Index[advisory.Document]
+}
+
+func BuildDatabase(opts BuildDatabaseOptions) ([]byte, error) {
+	// cfgs := opts.AdvisoryCfgs.Select().Configurations()
+
+	return nil, nil
+}

--- a/pkg/advisory/db_test.go
+++ b/pkg/advisory/db_test.go
@@ -17,6 +17,9 @@ func TestBuildDatabase(t *testing.T) {
 
 	opts := BuildDatabaseOptions{
 		AdvisoryCfgs: advisoryCfgs,
+		URLPrefix:    "https://packages.wolfi.dev",
+		Archs:        []string{"x86_64"},
+		Repo:         "os",
 	}
 
 	database, err := BuildDatabase(opts)

--- a/pkg/advisory/db_test.go
+++ b/pkg/advisory/db_test.go
@@ -1,0 +1,31 @@
+package advisory
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+)
+
+func TestBuildDatabase(t *testing.T) {
+	advisoryFsys := rwos.DirFS("./testdata/db/advisories")
+	advisoryCfgs, err := advisoryconfigs.NewIndex(advisoryFsys)
+	require.NoError(t, err)
+
+	opts := BuildDatabaseOptions{
+		AdvisoryCfgs: advisoryCfgs,
+	}
+
+	database, err := BuildDatabase(opts)
+	require.NoError(t, err)
+
+	expectedDatabase, err := os.ReadFile("./testdata/db/security.json")
+	require.NoError(t, err)
+
+	if diff := cmp.Diff(expectedDatabase, database); diff != "" {
+		t.Errorf("BuildDatabase() produced an unexpected database (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/advisory/testdata/db/advisories/brotli.advisories.yaml
+++ b/pkg/advisory/testdata/db/advisories/brotli.advisories.yaml
@@ -1,0 +1,12 @@
+package:
+  name: brotli
+
+secfixes:
+  1.0.9-r0:
+    - CVE-2020-8927
+
+advisories:
+  CVE-2020-8927:
+    - timestamp: 2022-09-15T02:40:18+00:00
+      status: fixed
+      fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/db/advisories/ko.advisories.yaml
+++ b/pkg/advisory/testdata/db/advisories/ko.advisories.yaml
@@ -1,0 +1,36 @@
+package:
+  name: ko
+
+secfixes:
+  0.13.0-r3:
+    - GHSA-33pg-m6jh-5237
+    - GHSA-232p-vwff-86mp
+    - GHSA-hw7c-3rfg-p46j
+    - GHSA-2h5h-59f5-c5x9
+    - GHSA-6wrf-mxfj-pf5p
+
+advisories:
+  GHSA-2h5h-59f5-c5x9:
+    - timestamp: 2023-05-04T10:34:34.169879-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+
+  GHSA-6wrf-mxfj-pf5p:
+    - timestamp: 2023-05-04T10:34:34.141361-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+
+  GHSA-33pg-m6jh-5237:
+    - timestamp: 2023-05-04T10:34:34.117098-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+
+  GHSA-232p-vwff-86mp:
+    - timestamp: 2023-05-04T10:34:34.07704-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+
+  GHSA-hw7c-3rfg-p46j:
+    - timestamp: 2023-05-04T10:34:34.199688-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3

--- a/pkg/advisory/testdata/db/advisories/openssl.advisories.yaml
+++ b/pkg/advisory/testdata/db/advisories/openssl.advisories.yaml
@@ -1,0 +1,109 @@
+package:
+  name: openssl
+
+secfixes:
+  "0":
+    - CVE-2023-0466
+  3.0.7-r0:
+    - CVE-2022-3358
+    - CVE-2022-3602
+    - CVE-2022-3786
+  3.0.7-r1:
+    - CVE-2022-3996
+  3.0.8-r0:
+    - CVE-2023-0286
+    - CVE-2022-4304
+    - CVE-2022-4203
+    - CVE-2023-0215
+    - CVE-2022-4450
+    - CVE-2023-0216
+    - CVE-2023-0217
+    - CVE-2023-0401
+  3.1.0-r1:
+    - CVE-2023-0464
+  3.1.0-r2:
+    - CVE-2023-0465
+  3.1.0-r5:
+    - CVE-2023-1255
+
+advisories:
+  CVE-2022-3358:
+    - timestamp: 2022-11-01T16:49:56Z
+      status: fixed
+      fixed-version: 3.0.7-r0
+
+  CVE-2022-3602:
+    - timestamp: 2022-11-01T16:49:56Z
+      status: fixed
+      fixed-version: 3.0.7-r0
+
+  CVE-2022-3786:
+    - timestamp: 2022-11-01T16:49:56Z
+      status: fixed
+      fixed-version: 3.0.7-r0
+
+  CVE-2022-3996:
+    - timestamp: 2022-12-22T17:26:45Z
+      status: fixed
+      fixed-version: 3.0.7-r1
+
+  CVE-2022-4203:
+    - timestamp: 2023-02-07T11:50:00.020081-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2022-4304:
+    - timestamp: 2023-02-07T11:49:50.211721-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2022-4450:
+    - timestamp: 2023-02-07T11:50:17.798241-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2023-0215:
+    - timestamp: 2023-02-07T11:50:08.401769-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2023-0216:
+    - timestamp: 2023-02-07T11:50:29.806824-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2023-0217:
+    - timestamp: 2023-02-07T11:50:39.207629-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2023-0286:
+    - timestamp: 2023-02-07T11:49:30.049397-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2023-0401:
+    - timestamp: 2023-02-07T11:50:53.191261-05:00
+      status: fixed
+      fixed-version: 3.0.8-r0
+
+  CVE-2023-0464:
+    - timestamp: 2023-03-23T02:31:00.664255-07:00
+      status: fixed
+      fixed-version: 3.1.0-r1
+
+  CVE-2023-0465:
+    - timestamp: 2023-03-28T07:54:27.093515-07:00
+      status: fixed
+      fixed-version: 3.1.0-r2
+
+  CVE-2023-0466:
+    - timestamp: 2023-04-08T12:32:54.797413-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
+
+  CVE-2023-1255:
+    - timestamp: 2023-04-20T09:29:24.558074-07:00
+      status: fixed
+      fixed-version: 3.1.0-r5

--- a/pkg/advisory/testdata/db/security.json
+++ b/pkg/advisory/testdata/db/security.json
@@ -1,0 +1,71 @@
+{
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "x86_64"
+  ],
+  "reponame": "os",
+  "urlprefix": "https://packages.wolfi.dev",
+  "packages": [
+    {
+      "pkg": {
+        "name": "brotli",
+        "secfixes": {
+          "1.0.9-r0": [
+            "CVE-2020-8927"
+          ]
+        }
+      }
+    },
+    {
+      "pkg": {
+        "name": "ko",
+        "secfixes": {
+          "0.13.0-r3": [
+            "GHSA-33pg-m6jh-5237",
+            "GHSA-232p-vwff-86mp",
+            "GHSA-hw7c-3rfg-p46j",
+            "GHSA-2h5h-59f5-c5x9",
+            "GHSA-6wrf-mxfj-pf5p"
+          ]
+        }
+      }
+    },
+    {
+      "pkg": {
+        "name": "openssl",
+        "secfixes": {
+          "0": [
+            "CVE-2023-0466"
+          ],
+          "3.0.7-r0": [
+            "CVE-2022-3358",
+            "CVE-2022-3602",
+            "CVE-2022-3786"
+          ],
+          "3.0.7-r1": [
+            "CVE-2022-3996"
+          ],
+          "3.0.8-r0": [
+            "CVE-2023-0286",
+            "CVE-2022-4304",
+            "CVE-2022-4203",
+            "CVE-2023-0215",
+            "CVE-2022-4450",
+            "CVE-2023-0216",
+            "CVE-2023-0217",
+            "CVE-2023-0401"
+          ],
+          "3.1.0-r1": [
+            "CVE-2023-0464"
+          ],
+          "3.1.0-r2": [
+            "CVE-2023-0465"
+          ],
+          "3.1.0-r5": [
+            "CVE-2023-1255"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -33,6 +33,7 @@ func Advisory() *cobra.Command {
 	cmd.AddCommand(AdvisoryUpdate())
 	cmd.AddCommand(AdvisorySyncSecfixes())
 	cmd.AddCommand(AdvisoryDiscover())
+	cmd.AddCommand(AdvisoryDB())
 
 	return cmd
 }

--- a/pkg/cli/advisory_db.go
+++ b/pkg/cli/advisory_db.go
@@ -14,7 +14,7 @@ func AdvisoryDB() *cobra.Command {
 	p := &dbParams{}
 	cmd := &cobra.Command{
 		Use:           "db",
-		Short:         "Build a security database from advisory data",
+		Short:         "Build a security database from advisory data (NOTE: For now, this command uses secfixes data, but will soon use advisory data instead.)",
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -31,6 +31,9 @@ func AdvisoryDB() *cobra.Command {
 
 			opts := advisory.BuildDatabaseOptions{
 				AdvisoryCfgs: advisoryCfgs,
+				URLPrefix:    p.urlPrefix,
+				Archs:        p.archs,
+				Repo:         p.repo,
 			}
 
 			database, err := advisory.BuildDatabase(opts)
@@ -38,9 +41,20 @@ func AdvisoryDB() *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Fprint(os.Stdout, database)
+			var outputFile *os.File
+			if p.outputLocation == "" {
+				outputFile = os.Stdout
+			} else {
+				outputFile, err = os.Create(p.outputLocation)
+				if err != nil {
+					return fmt.Errorf("unable to open output file: %w", err)
+				}
+				defer outputFile.Close()
+			}
+
+			_, err = outputFile.Write(database)
 			if err != nil {
-				return fmt.Errorf("unable to write out database: %w", err)
+				return fmt.Errorf("unable to write the security database to specified location: %w", err)
 			}
 
 			return nil
@@ -55,10 +69,18 @@ type dbParams struct {
 	advisoriesRepoDir string
 
 	outputLocation string
+
+	urlPrefix string
+	archs     []string
+	repo      string
 }
 
 func (p *dbParams) addFlagsTo(cmd *cobra.Command) {
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 
 	cmd.Flags().StringVarP(&p.outputLocation, "output", "o", "", "output location (default: stdout)")
+
+	cmd.Flags().StringVar(&p.urlPrefix, "url-prefix", "https://packages.wolfi.dev", "URL scheme and hostname for the package repository")
+	cmd.Flags().StringSliceVar(&p.archs, "arch", []string{"x86_64"}, "the package architectures the security database is for")
+	cmd.Flags().StringVar(&p.repo, "repo", "os", "the name of the package repository")
 }

--- a/pkg/cli/advisory_db.go
+++ b/pkg/cli/advisory_db.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+)
+
+func AdvisoryDB() *cobra.Command {
+	p := &dbParams{}
+	cmd := &cobra.Command{
+		Use:           "db",
+		Short:         "Build a security database from advisory data",
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
+			if advisoriesRepoDir == "" {
+				advisoriesRepoDir = defaultAdvisoriesRepoDir
+			}
+
+			advisoryFsys := rwos.DirFS(advisoriesRepoDir)
+			advisoryCfgs, err := advisoryconfigs.NewIndex(advisoryFsys)
+			if err != nil {
+				return err
+			}
+
+			opts := advisory.BuildDatabaseOptions{
+				AdvisoryCfgs: advisoryCfgs,
+			}
+
+			database, err := advisory.BuildDatabase(opts)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprint(os.Stdout, database)
+			if err != nil {
+				return fmt.Errorf("unable to write out database: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	p.addFlagsTo(cmd)
+	return cmd
+}
+
+type dbParams struct {
+	advisoriesRepoDir string
+
+	outputLocation string
+}
+
+func (p *dbParams) addFlagsTo(cmd *cobra.Command) {
+	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
+
+	cmd.Flags().StringVarP(&p.outputLocation, "output", "o", "", "output location (default: stdout)")
+}


### PR DESCRIPTION
This implements the `wolfi-secdb generate` command from https://github.com/wolfi-dev/secdb as the new command `wolfictl advisory db`.

To ensure parity, this logic was implemented against a test fixture secdb (`security.json`) that was generated by `wolfi-secdb`.

cc: @kaniini 