### PR TITLE
advisory commands: add distro auto-detection, and add flags to disable this detection and interactive prompts

### DIFF
--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/openvex/go-vex/pkg/vex"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory/sync"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	"github.com/wolfi-dev/wolfictl/pkg/distro"
 )
 
 const (
@@ -56,6 +58,12 @@ func resolveAdvisoriesDir(cliFlagValue string) string {
 	}
 
 	return ""
+}
+
+var distroMutedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#888"))
+
+func renderDetectedDistro(d distro.DetectedDistro) string {
+	return distroMutedStyle.Render("Auto-detected distro: ") + d.Name + "\n\n"
 }
 
 func resolveTimestamp(ts string) (time.Time, error) {
@@ -145,4 +153,12 @@ func addDistroDirFlag(val *string, cmd *cobra.Command) {
 
 func addAdvisoriesDirFlag(val *string, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(val, "advisories-repo-dir", "a", "", fmt.Sprintf("directory containing the advisories repository (can also be set with environment variable `%s`)", envVarNameForAdvisoriesDir))
+}
+
+func addNoPromptFlag(val *bool, cmd *cobra.Command) {
+	cmd.Flags().BoolVar(val, "no-prompt", false, "do not prompt the user for input")
+}
+
+func addNoDistroDetectionFlag(val *bool, cmd *cobra.Command) {
+	cmd.Flags().BoolVar(val, "no-distro-detection", false, "do not attempt to auto-detect the distro")
 }

--- a/pkg/cli/advisory_create.go
+++ b/pkg/cli/advisory_create.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -10,6 +11,7 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/advisory/createprompt"
 	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+	"github.com/wolfi-dev/wolfictl/pkg/distro"
 )
 
 func AdvisoryCreate() *cobra.Command {
@@ -22,7 +24,17 @@ func AdvisoryCreate() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
 			if advisoriesRepoDir == "" {
-				advisoriesRepoDir = defaultAdvisoriesRepoDir
+				if p.doNotDetectDistro {
+					return fmt.Errorf("no advisories repo dir specified")
+				}
+
+				d, err := distro.Detect()
+				if err != nil {
+					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
+				}
+
+				advisoriesRepoDir = d.AdvisoriesRepoDir
+				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 
 			advisoryFsys := rwos.DirFS(advisoriesRepoDir)
@@ -37,6 +49,10 @@ func AdvisoryCreate() *cobra.Command {
 			}
 
 			if err := req.Validate(); err != nil {
+				if p.doNotPrompt {
+					return fmt.Errorf("not enough information to create advisory: %w", err)
+				}
+
 				// prompt for missing fields
 
 				m := createprompt.New(req)
@@ -86,11 +102,17 @@ func AdvisoryCreate() *cobra.Command {
 }
 
 type createParams struct {
+	doNotDetectDistro bool
+	doNotPrompt       bool
+
 	requestParams     advisoryRequestParams
 	advisoriesRepoDir string
 }
 
 func (p *createParams) addFlagsTo(cmd *cobra.Command) {
+	addNoDistroDetectionFlag(&p.doNotDetectDistro, cmd)
+	addNoPromptFlag(&p.doNotPrompt, cmd)
+
 	p.requestParams.addFlags(cmd)
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 }

--- a/pkg/cli/advisory_list.go
+++ b/pkg/cli/advisory_list.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/openvex/go-vex/pkg/vex"
@@ -9,6 +10,7 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+	"github.com/wolfi-dev/wolfictl/pkg/distro"
 )
 
 func AdvisoryList() *cobra.Command {
@@ -21,7 +23,17 @@ func AdvisoryList() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
 			if advisoriesRepoDir == "" {
-				advisoriesRepoDir = defaultAdvisoriesRepoDir
+				if p.doNotDetectDistro {
+					return fmt.Errorf("no advisories repo dir specified")
+				}
+
+				d, err := distro.Detect()
+				if err != nil {
+					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
+				}
+
+				advisoriesRepoDir = d.AdvisoriesRepoDir
+				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 
 			advisoriesFsys := rwos.DirFS(advisoriesRepoDir)
@@ -87,6 +99,8 @@ func AdvisoryList() *cobra.Command {
 }
 
 type listParams struct {
+	doNotDetectDistro bool
+
 	advisoriesRepoDir string
 
 	packageName string
@@ -96,6 +110,8 @@ type listParams struct {
 }
 
 func (p *listParams) addFlagsTo(cmd *cobra.Command) {
+	addNoDistroDetectionFlag(&p.doNotDetectDistro, cmd)
+
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 
 	addPackageFlag(&p.packageName, cmd)

--- a/pkg/distro/detect.go
+++ b/pkg/distro/detect.go
@@ -1,0 +1,186 @@
+package distro
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"golang.org/x/exp/slices"
+)
+
+// Detect tries to automatically detect which distro the user wants to
+// operate on, and the corresponding directory paths for the distro and
+// advisories repos.
+func Detect() (DetectedDistro, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return DetectedDistro{}, err
+	}
+
+	distro, err := detectDistroInRepo(cwd)
+	if err != nil {
+		return DetectedDistro{}, err
+	}
+
+	d, err := getDistroByName(distro.Name)
+	if err != nil {
+		return DetectedDistro{}, err
+	}
+
+	// We assume that the parent directory of the initially found repo directory is
+	// a directory that contains all the relevant repo directories.
+	dirOfRepos := filepath.Dir(cwd)
+
+	switch {
+	case distro.DistroRepoDir == "":
+		distroDir, err := findDistroDir(d, dirOfRepos)
+		if err != nil {
+			return DetectedDistro{}, err
+		}
+		distro.DistroRepoDir = distroDir
+		return distro, nil
+
+	case distro.AdvisoriesRepoDir == "":
+		advisoryDir, err := findAdvisoriesDir(d, dirOfRepos)
+		if err != nil {
+			return DetectedDistro{}, err
+		}
+		distro.AdvisoriesRepoDir = advisoryDir
+		return distro, nil
+	}
+
+	return DetectedDistro{}, fmt.Errorf("unable to detect distro")
+}
+
+var errNotDistroRepo = fmt.Errorf("current directory is not a distro or advisories repository")
+
+func detectDistroInRepo(dir string) (DetectedDistro, error) {
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		return DetectedDistro{}, fmt.Errorf("unable to identify distro: couldn't open git repo: %w", err)
+	}
+
+	config, err := repo.Config()
+	if err != nil {
+		return DetectedDistro{}, err
+	}
+
+	for _, remoteConfig := range config.Remotes {
+		urls := remoteConfig.URLs
+		if len(urls) == 0 {
+			continue
+		}
+
+		url := urls[0]
+
+		for _, d := range []identifiableDistro{wolfiDistro, chainguardDistro} {
+			if slices.Contains(d.distroRemoteURLs, url) {
+				return DetectedDistro{
+					Name:          d.name,
+					DistroRepoDir: dir,
+				}, nil
+			}
+
+			if slices.Contains(d.advisoriesRemoteURLs, url) {
+				return DetectedDistro{
+					Name:              d.name,
+					AdvisoriesRepoDir: dir,
+				}, nil
+			}
+		}
+	}
+
+	return DetectedDistro{}, errNotDistroRepo
+}
+
+func getDistroByName(name string) (identifiableDistro, error) {
+	for _, d := range []identifiableDistro{wolfiDistro, chainguardDistro} {
+		if d.name == name {
+			return d, nil
+		}
+	}
+
+	return identifiableDistro{}, fmt.Errorf("unknown distro: %s", name)
+}
+
+func findDistroDir(targetDistro identifiableDistro, dirOfRepos string) (string, error) {
+	return findRepoDir(targetDistro, dirOfRepos, func(d DetectedDistro) string {
+		return d.DistroRepoDir
+	})
+}
+
+func findAdvisoriesDir(targetDistro identifiableDistro, dirOfRepos string) (string, error) {
+	return findRepoDir(targetDistro, dirOfRepos, func(d DetectedDistro) string {
+		return d.AdvisoriesRepoDir
+	})
+}
+
+func findRepoDir(targetDistro identifiableDistro, dirOfRepos string, getRepoDir func(DetectedDistro) string) (string, error) {
+	files, err := os.ReadDir(dirOfRepos)
+	if err != nil {
+		return "", err
+	}
+
+	for _, f := range files {
+		if !f.IsDir() {
+			continue
+		}
+
+		d, err := detectDistroInRepo(filepath.Join(dirOfRepos, f.Name()))
+		if err != nil {
+			// no usable distro or advisories repo here
+			continue
+		}
+
+		if d.Name != targetDistro.name {
+			continue
+		}
+
+		dir := getRepoDir(d)
+		if dir == "" {
+			continue
+		}
+
+		return dir, nil
+	}
+
+	return "", fmt.Errorf("unable to find repo dir")
+}
+
+type identifiableDistro struct {
+	name                                   string
+	distroRemoteURLs, advisoriesRemoteURLs []string
+}
+
+var (
+	wolfiDistro = identifiableDistro{
+		name: "Wolfi",
+		distroRemoteURLs: []string{
+			"git@github.com:wolfi-dev/os.git",
+			"https://github.com/wolfi-dev/os.git",
+		},
+		advisoriesRemoteURLs: []string{
+			"git@github.com:wolfi-dev/advisories.git",
+			"https://github.com/wolfi-dev/advisories.git",
+		},
+	}
+
+	chainguardDistro = identifiableDistro{
+		name: "Chainguard",
+		distroRemoteURLs: []string{
+			"git@github.com:chainguard-dev/enterprise-packages.git",
+			"https://github.com/chainguard-dev/enterprise-packages.git",
+		},
+		advisoriesRemoteURLs: []string{
+			"git@github.com:chainguard-dev/enterprise-advisories.git",
+			"https://github.com/chainguard-dev/enterprise-advisories.git",
+		},
+	}
+)
+
+type DetectedDistro struct {
+	Name              string
+	DistroRepoDir     string
+	AdvisoriesRepoDir string
+}

--- a/pkg/distro/detect_test.go
+++ b/pkg/distro/detect_test.go
@@ -1,0 +1,97 @@
+package distro
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetect(t *testing.T) {
+	// Create a test directory with a few git repos, some of which are distro-related
+
+	tempDir, err := os.MkdirTemp("", "test-distro-detect-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.RemoveAll(tempDir)
+		require.NoError(t, err)
+	})
+
+	repos := []struct {
+		name       string
+		remoteURLs []string
+	}{
+		{
+			name: "my-wolfi",
+			remoteURLs: []string{
+				"https://github.com/wolfi-dev/os.git",
+				"https://foo.git",
+			},
+		},
+		{
+			name: "some-other-repo",
+			remoteURLs: []string{
+				"https://some-other-repo.git",
+			},
+		},
+		{
+			name: "my-advisories",
+			remoteURLs: []string{
+				"git@github.com:wolfi-dev/advisories.git",
+			},
+		},
+	}
+
+	repoAbsolutePath := func(repoName string) string {
+		return filepath.Join(tempDir, repoName)
+	}
+
+	for _, r := range repos {
+		repoDir := repoAbsolutePath(r.name)
+		err := os.Mkdir(repoDir, 0o755)
+		require.NoError(t, err)
+
+		_, err = git.PlainInit(repoDir, false)
+		require.NoError(t, err)
+
+		repo, err := git.PlainOpen(repoDir)
+		require.NoError(t, err)
+
+		_, err = repo.CreateRemote(&config.RemoteConfig{
+			Name: "origin",
+			URLs: r.remoteURLs,
+		})
+		require.NoError(t, err)
+	}
+
+	originalWorkDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWorkDir) //nolint:errCheck
+	})
+
+	newWorkDir := repoAbsolutePath(repos[0].name)
+	err = os.Chdir(newWorkDir)
+	require.NoError(t, err)
+
+	// Run the function under test
+
+	d, err := Detect()
+	require.NoError(t, err)
+
+	// Check the results
+
+	// (We need to resolve the symlinks because this test uses temp dirs, which are symlinked on some operating systems.)
+	expectedDistroRepoDir, err := filepath.EvalSymlinks(repoAbsolutePath(repos[0].name))
+	require.NoError(t, err)
+	expectedAdvisoriesRepoDir, err := filepath.EvalSymlinks(repoAbsolutePath(repos[2].name))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Wolfi", d.Name)
+	assert.Equal(t, expectedDistroRepoDir, d.DistroRepoDir)
+	assert.Equal(t, expectedAdvisoriesRepoDir, d.AdvisoriesRepoDir)
+}


### PR DESCRIPTION
## Context

Now that there are multiple distros managed using `wolfictl`, and now that there are two repos per distro (one for the distro itself, with package configs, and one for advisory data), things are getting slightly more complicated. 😰 

Advisory-related commands need to know about the advisories repo (for reading and writing data), and some of these commands also need to know about the distro repo that corresponds to that advisories repo (for reading data). Since multiple local directories are involved, it's not always possible to assume a given operation is intended for the current working directory, because that directory can't be both _the distro repo_ and _the advisories repo_ at the same time.

As of a recent update, users can tell `wolfictl` explicitly where their local clones of the advisories repo and the distro repo are using CLI flags or environment variables. But neither flags nor env vars are always a good fit for running these commands manually. Flags mean extra typing and verbosity for the command, and env vars make it more difficult to switch between distros and easier to make a change in the wrong distro.

## What's been added

This PR attempts to make the user experience less burdensome by adding a distro "auto-detection" mechanism to the advisory commands.  🪄 

The approach here is to see if the current working directory is a distro repo or an advisories repo. If it's neither, the detection fails. Otherwise, it tries to figure out where the other corresponding repo is for the given distro (i.e., where the advisories repo is, if we're currently in the distro repo, or vice versa).

There are also two new flags for these commands:

- `--no-distro-detection`: Don't attempt auto-detection. Fail if any needed repo dir paths haven't been provided by the user (via CLI flags or env vars).
- `--no-prompt`: This doesn't relate to auto-detection per se, but follows suit with ensuring no implicit behavior occurs. This disables interactive user prompts, which is handy for running commands in automated workflows.

Here's a miniature demo of how the distro detection behaves in various scenarios:

<img width="1396" alt="image" src="https://github.com/wolfi-dev/wolfictl/assets/5199289/a24183b3-b734-40b5-8dad-38cf2a3b7cc7">
