### PR TITLE
Guard against using dirs with no security data, and add support for multiple advisory repo dirs

### DIFF
--- a/pkg/advisory/db_test.go
+++ b/pkg/advisory/db_test.go
@@ -5,30 +5,78 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 )
 
 func TestBuildDatabase(t *testing.T) {
-	advisoryFsys := rwos.DirFS("./testdata/db/advisories")
-	advisoryCfgs, err := advisoryconfigs.NewIndex(advisoryFsys)
-	require.NoError(t, err)
-
-	opts := BuildDatabaseOptions{
-		AdvisoryCfgs: advisoryCfgs,
-		URLPrefix:    "https://packages.wolfi.dev",
-		Archs:        []string{"x86_64"},
-		Repo:         "os",
+	cases := []struct {
+		name                   string
+		advisoryDirs           []string
+		pathToExpectedDatabase string
+		errorAssertion         assert.ErrorAssertionFunc
+	}{
+		{
+			name: "single advisories dir",
+			advisoryDirs: []string{
+				"./testdata/db/advisories",
+			},
+			pathToExpectedDatabase: "./testdata/db/security.json",
+			errorAssertion:         assert.NoError,
+		},
+		{
+			name: "multiple advisories dirs",
+			advisoryDirs: []string{
+				"./testdata/db/advisories",
+				"./testdata/db/other-advisories",
+			},
+			pathToExpectedDatabase: "./testdata/db/security-multiple.json",
+			errorAssertion:         assert.NoError,
+		},
+		{
+			name: "use a dir with no adv data",
+			advisoryDirs: []string{
+				"./testdata/db/advisories",
+				"./testdata/db/advisories-empty",
+			},
+			pathToExpectedDatabase: "",
+			errorAssertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrNoPackageSecurityData)
+			},
+		},
 	}
 
-	database, err := BuildDatabase(opts)
-	require.NoError(t, err)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			indices := make([]*configs.Index[advisoryconfigs.Document], 0, len(tt.advisoryDirs))
+			for _, dir := range tt.advisoryDirs {
+				advisoryFsys := rwos.DirFS(dir)
+				advisoryCfgs, err := advisoryconfigs.NewIndex(advisoryFsys)
+				require.NoError(t, err)
+				indices = append(indices, advisoryCfgs)
+			}
 
-	expectedDatabase, err := os.ReadFile("./testdata/db/security.json")
-	require.NoError(t, err)
+			opts := BuildDatabaseOptions{
+				AdvisoryCfgIndices: indices,
+				URLPrefix:          "https://packages.wolfi.dev",
+				Archs:              []string{"x86_64"},
+				Repo:               "os",
+			}
 
-	if diff := cmp.Diff(expectedDatabase, database); diff != "" {
-		t.Errorf("BuildDatabase() produced an unexpected database (-want +got):\n%s", diff)
+			database, err := BuildDatabase(opts)
+			tt.errorAssertion(t, err)
+
+			if p := tt.pathToExpectedDatabase; p != "" {
+				expectedDatabase, err := os.ReadFile(p)
+				require.NoError(t, err)
+
+				if diff := cmp.Diff(expectedDatabase, database); diff != "" {
+					t.Errorf("BuildDatabase() produced an unexpected database (-want +got):\n%s", diff)
+				}
+			}
+		})
 	}
 }

--- a/pkg/advisory/testdata/db/other-advisories/cups.advisories.yaml
+++ b/pkg/advisory/testdata/db/other-advisories/cups.advisories.yaml
@@ -1,0 +1,12 @@
+package:
+  name: cups
+
+secfixes:
+  2.4.2-r0:
+    - CVE-2022-26691
+
+advisories:
+  CVE-2022-26691:
+    - timestamp: 2022-10-25T13:38:24-04:00
+      status: fixed
+      fixed-version: 2.4.2-r0

--- a/pkg/advisory/testdata/db/security-multiple.json
+++ b/pkg/advisory/testdata/db/security-multiple.json
@@ -1,0 +1,81 @@
+{
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "x86_64"
+  ],
+  "reponame": "os",
+  "urlprefix": "https://packages.wolfi.dev",
+  "packages": [
+    {
+      "pkg": {
+        "name": "brotli",
+        "secfixes": {
+          "1.0.9-r0": [
+            "CVE-2020-8927"
+          ]
+        }
+      }
+    },
+    {
+      "pkg": {
+        "name": "ko",
+        "secfixes": {
+          "0.13.0-r3": [
+            "GHSA-33pg-m6jh-5237",
+            "GHSA-232p-vwff-86mp",
+            "GHSA-hw7c-3rfg-p46j",
+            "GHSA-2h5h-59f5-c5x9",
+            "GHSA-6wrf-mxfj-pf5p"
+          ]
+        }
+      }
+    },
+    {
+      "pkg": {
+        "name": "openssl",
+        "secfixes": {
+          "0": [
+            "CVE-2023-0466"
+          ],
+          "3.0.7-r0": [
+            "CVE-2022-3358",
+            "CVE-2022-3602",
+            "CVE-2022-3786"
+          ],
+          "3.0.7-r1": [
+            "CVE-2022-3996"
+          ],
+          "3.0.8-r0": [
+            "CVE-2023-0286",
+            "CVE-2022-4304",
+            "CVE-2022-4203",
+            "CVE-2023-0215",
+            "CVE-2022-4450",
+            "CVE-2023-0216",
+            "CVE-2023-0217",
+            "CVE-2023-0401"
+          ],
+          "3.1.0-r1": [
+            "CVE-2023-0464"
+          ],
+          "3.1.0-r2": [
+            "CVE-2023-0465"
+          ],
+          "3.1.0-r5": [
+            "CVE-2023-1255"
+          ]
+        }
+      }
+    },
+    {
+      "pkg": {
+        "name": "cups",
+        "secfixes": {
+          "2.4.2-r0": [
+            "CVE-2022-26691"
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
New behavior:

<img width="1840" alt="image" src="https://github.com/wolfi-dev/wolfictl/assets/5199289/44d576fb-a725-4609-9df2-b43aa2ccf5c4">