### PR TITLE
Set apkindex URL prefix based on detected distro

### DIFF
--- a/pkg/advisory/discover.go
+++ b/pkg/advisory/discover.go
@@ -45,9 +45,14 @@ type DiscoverOptions struct {
 func Discover(opts DiscoverOptions) error {
 	ctx := context.Background()
 
+	packageRepositoryURL := opts.PackageRepositoryURL
+	if packageRepositoryURL == "" {
+		return fmt.Errorf("package repository URL must be specified")
+	}
+
 	var apkindexes []*repository.ApkIndex
 	for _, arch := range opts.Arches {
-		apkindex, err := index.Index(arch, opts.PackageRepositoryURL)
+		apkindex, err := index.Index(arch, packageRepositoryURL)
 		if err != nil {
 			return fmt.Errorf("unable to get APKINDEX for arch %q: %w", arch, err)
 		}

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -19,7 +19,6 @@ import (
 const (
 	envVarNameForDistroDir     = "WOLFICTL_DISTRO_REPO_DIR"
 	envVarNameForAdvisoriesDir = "WOLFICTL_ADVISORIES_REPO_DIR"
-	defaultAdvisoriesRepoDir   = "."
 )
 
 func Advisory() *cobra.Command {
@@ -62,7 +61,7 @@ func resolveAdvisoriesDir(cliFlagValue string) string {
 
 var distroMutedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#888"))
 
-func renderDetectedDistro(d distro.DetectedDistro) string {
+func renderDetectedDistro(d distro.Distro) string {
 	return distroMutedStyle.Render("Auto-detected distro: ") + d.Name + "\n\n"
 }
 

--- a/pkg/cli/advisory_discover.go
+++ b/pkg/cli/advisory_discover.go
@@ -31,6 +31,8 @@ func AdvisoryDiscover() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			start := time.Now()
 
+			packageRepositoryURL := p.packageRepositoryURL
+
 			distroRepoDir := resolveDistroDir(p.distroRepoDir)
 			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
 			if distroRepoDir == "" || advisoriesRepoDir == "" {
@@ -45,6 +47,11 @@ func AdvisoryDiscover() *cobra.Command {
 
 				distroRepoDir = d.DistroRepoDir
 				advisoriesRepoDir = d.AdvisoriesRepoDir
+
+				if packageRepositoryURL == "" {
+					packageRepositoryURL = d.APKRepositoryURL
+				}
+
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 
@@ -68,7 +75,7 @@ func AdvisoryDiscover() *cobra.Command {
 				SelectedPackages:      selectedPackages,
 				BuildCfgs:             buildCfgs,
 				AdvisoryCfgs:          advisoryCfgs,
-				PackageRepositoryURL:  p.packageRepositoryURL,
+				PackageRepositoryURL:  packageRepositoryURL,
 				Arches:                []string{"x86_64", "aarch64"},
 				VulnerabilityDetector: nvdapi.NewDetector(http.DefaultClient, nvdapi.DefaultHost, apiKey),
 			})
@@ -107,7 +114,7 @@ func (p *discoverParams) addFlagsTo(cmd *cobra.Command) {
 	addDistroDirFlag(&p.distroRepoDir, cmd)
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 
-	cmd.Flags().StringVarP(&p.packageRepositoryURL, "package-repo-url", "r", "https://packages.wolfi.dev/os", "URL of the APK package repository")
+	cmd.Flags().StringVarP(&p.packageRepositoryURL, "package-repo-url", "r", "", "URL of the APK package repository")
 
 	cmd.Flags().StringVar(&p.nvdAPIKey, "nvd-api-key", "", fmt.Sprintf("NVD API key (Can also be set via the environment variable '%s'. Using an API key significantly increases the rate limit for API requests. If you need an NVD API key, go to https://nvd.nist.gov/developers/request-an-api-key .)", envVarNameForNVDAPIKey))
 }

--- a/pkg/distro/detect_test.go
+++ b/pkg/distro/detect_test.go
@@ -94,4 +94,5 @@ func TestDetect(t *testing.T) {
 	assert.Equal(t, "Wolfi", d.Name)
 	assert.Equal(t, expectedDistroRepoDir, d.DistroRepoDir)
 	assert.Equal(t, expectedAdvisoriesRepoDir, d.AdvisoriesRepoDir)
+	assert.Equal(t, "https://packages.wolfi.dev/os", d.APKRepositoryURL)
 }


### PR DESCRIPTION
This updates the `wolfictl adv discover` command by letting the package repository URL (used as the prefix to the APKINDEX) to be determined dynamically via distro detection. This reduces the need for users to use the `--package-repo-url` during discovery.

Going forward, as more commands become "APKINDEX-aware", this pattern can carry forward to similarly auto-resolve the URL on users' behalf.