### PR TITLE
advisory: autosuggest and validation

### DIFF
--- a/pkg/cli/advisory_create.go
+++ b/pkg/cli/advisory_create.go
@@ -1,17 +1,21 @@
-//nolint:dupl // We expect create and update to diverge.
 package cli
 
 import (
 	"fmt"
 	"os"
 
+	"chainguard.dev/melange/pkg/build"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
-	"github.com/wolfi-dev/wolfictl/pkg/cli/components/advisory/createprompt"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/advisory/prompt"
 	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	buildconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/build"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
+	"github.com/wolfi-dev/wolfictl/pkg/index"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
 func AdvisoryCreate() *cobra.Command {
@@ -22,17 +26,29 @@ func AdvisoryCreate() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			archs := p.archs
+			packageRepositoryURL := p.packageRepositoryURL
+			distroRepoDir := resolveDistroDir(p.distroRepoDir)
 			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
-			if advisoriesRepoDir == "" {
+			if distroRepoDir == "" || advisoriesRepoDir == "" {
 				if p.doNotDetectDistro {
-					return fmt.Errorf("no advisories repo dir specified")
+					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified")
 				}
 
 				d, err := distro.Detect()
 				if err != nil {
-					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
+					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified, and distro auto-detection failed: %w", err)
 				}
 
+				if len(archs) == 0 {
+					archs = d.SupportedArchitectures
+				}
+
+				if packageRepositoryURL == "" {
+					packageRepositoryURL = d.APKRepositoryURL
+				}
+
+				distroRepoDir = d.DistroRepoDir
 				advisoriesRepoDir = d.AdvisoriesRepoDir
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
@@ -43,9 +59,24 @@ func AdvisoryCreate() *cobra.Command {
 				return err
 			}
 
+			fsys := rwos.DirFS(distroRepoDir)
+			buildCfgs, err := buildconfigs.NewIndex(fsys)
+			if err != nil {
+				return fmt.Errorf("unable to select packages: %w", err)
+			}
+
 			req, err := p.requestParams.advisoryRequest()
 			if err != nil {
 				return err
+			}
+
+			var apkindexes []*repository.ApkIndex
+			for _, arch := range archs {
+				idx, err := index.Index(arch, packageRepositoryURL)
+				if err != nil {
+					return fmt.Errorf("unable to load APKINDEX for %s: %w", arch, err)
+				}
+				apkindexes = append(apkindexes, idx)
 			}
 
 			if err := req.Validate(); err != nil {
@@ -55,7 +86,24 @@ func AdvisoryCreate() *cobra.Command {
 
 				// prompt for missing fields
 
-				m := createprompt.New(req)
+				allowedPackages := func() []string {
+					return lo.Map(buildCfgs.Select().Configurations(), func(cfg build.Configuration, _ int) string {
+						return cfg.Package.Name
+					})
+				}
+
+				allowedVulnerabilities := func(packageName string) []string {
+					return nil
+				}
+
+				allowedFixedVersions := newAllowedFixedVersionsFunc(apkindexes, buildCfgs)
+
+				m := prompt.New(prompt.Configuration{
+					Request:                    req,
+					AllowedPackagesFunc:        allowedPackages,
+					AllowedVulnerabilitiesFunc: allowedVulnerabilities,
+					AllowedFixedVersionsFunc:   allowedFixedVersions,
+				})
 				var returnedModel tea.Model
 				program := tea.NewProgram(m)
 
@@ -66,7 +114,7 @@ func AdvisoryCreate() *cobra.Command {
 					return err
 				}
 
-				if m, ok := returnedModel.(createprompt.Model); ok {
+				if m, ok := returnedModel.(prompt.Model); ok {
 					if m.EarlyExit {
 						return nil
 					}
@@ -105,8 +153,10 @@ type createParams struct {
 	doNotDetectDistro bool
 	doNotPrompt       bool
 
-	requestParams     advisoryRequestParams
-	advisoriesRepoDir string
+	requestParams                    advisoryRequestParams
+	distroRepoDir, advisoriesRepoDir string
+	archs                            []string
+	packageRepositoryURL             string
 }
 
 func (p *createParams) addFlagsTo(cmd *cobra.Command) {
@@ -114,5 +164,8 @@ func (p *createParams) addFlagsTo(cmd *cobra.Command) {
 	addNoPromptFlag(&p.doNotPrompt, cmd)
 
 	p.requestParams.addFlags(cmd)
+	addDistroDirFlag(&p.distroRepoDir, cmd)
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
+	cmd.Flags().StringSliceVar(&p.archs, "arch", []string{"x86_64", "aarch64"}, "package architectures to find published versions for")
+	cmd.Flags().StringVarP(&p.packageRepositoryURL, "package-repo-url", "r", "", "URL of the APK package repository")
 }

--- a/pkg/cli/advisory_update.go
+++ b/pkg/cli/advisory_update.go
@@ -1,17 +1,21 @@
-//nolint:dupl // We expect create and update to diverge.
 package cli
 
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
-	"github.com/wolfi-dev/wolfictl/pkg/cli/components/advisory/createprompt"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/advisory/prompt"
 	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	buildconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/build"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
+	"github.com/wolfi-dev/wolfictl/pkg/index"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
 func AdvisoryUpdate() *cobra.Command {
@@ -22,17 +26,29 @@ func AdvisoryUpdate() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			archs := p.archs
+			packageRepositoryURL := p.packageRepositoryURL
+			distroRepoDir := resolveDistroDir(p.distroRepoDir)
 			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
-			if advisoriesRepoDir == "" {
+			if distroRepoDir == "" || advisoriesRepoDir == "" {
 				if p.doNotDetectDistro {
-					return fmt.Errorf("no advisories repo dir specified")
+					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified")
 				}
 
 				d, err := distro.Detect()
 				if err != nil {
-					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
+					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified, and distro auto-detection failed: %w", err)
 				}
 
+				if len(archs) == 0 {
+					archs = d.SupportedArchitectures
+				}
+
+				if packageRepositoryURL == "" {
+					packageRepositoryURL = d.APKRepositoryURL
+				}
+
+				distroRepoDir = d.DistroRepoDir
 				advisoriesRepoDir = d.AdvisoriesRepoDir
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
@@ -43,9 +59,24 @@ func AdvisoryUpdate() *cobra.Command {
 				return err
 			}
 
+			fsys := rwos.DirFS(distroRepoDir)
+			buildCfgs, err := buildconfigs.NewIndex(fsys)
+			if err != nil {
+				return fmt.Errorf("unable to select packages: %w", err)
+			}
+
 			req, err := p.requestParams.advisoryRequest()
 			if err != nil {
 				return err
+			}
+
+			var apkindexes []*repository.ApkIndex
+			for _, arch := range archs {
+				idx, err := index.Index(arch, packageRepositoryURL)
+				if err != nil {
+					return fmt.Errorf("unable to load APKINDEX for %s: %w", arch, err)
+				}
+				apkindexes = append(apkindexes, idx)
 			}
 
 			if err := req.Validate(); err != nil {
@@ -55,7 +86,30 @@ func AdvisoryUpdate() *cobra.Command {
 
 				// prompt for missing fields
 
-				m := createprompt.New(req)
+				allowedPackages := func() []string {
+					return lo.Map(advisoryCfgs.Select().Configurations(), func(cfg advisoryconfigs.Document, _ int) string {
+						return cfg.Package.Name
+					})
+				}
+
+				allowedVulnerabilities := func(packageName string) []string {
+					var vulnerabilities []string
+					for _, cfg := range advisoryCfgs.Select().WhereName(packageName).Configurations() {
+						vulns := lo.Keys(cfg.Advisories)
+						sort.Strings(vulns)
+						vulnerabilities = append(vulnerabilities, vulns...)
+					}
+					return vulnerabilities
+				}
+
+				allowedFixedVersions := newAllowedFixedVersionsFunc(apkindexes, buildCfgs)
+
+				m := prompt.New(prompt.Configuration{
+					Request:                    req,
+					AllowedPackagesFunc:        allowedPackages,
+					AllowedVulnerabilitiesFunc: allowedVulnerabilities,
+					AllowedFixedVersionsFunc:   allowedFixedVersions,
+				})
 				var returnedModel tea.Model
 				program := tea.NewProgram(m)
 
@@ -66,7 +120,7 @@ func AdvisoryUpdate() *cobra.Command {
 					return err
 				}
 
-				if m, ok := returnedModel.(createprompt.Model); ok {
+				if m, ok := returnedModel.(prompt.Model); ok {
 					if m.EarlyExit {
 						return nil
 					}
@@ -105,8 +159,10 @@ type updateParams struct {
 	doNotDetectDistro bool
 	doNotPrompt       bool
 
-	requestParams     advisoryRequestParams
-	advisoriesRepoDir string
+	requestParams                    advisoryRequestParams
+	distroRepoDir, advisoriesRepoDir string
+	archs                            []string
+	packageRepositoryURL             string
 }
 
 func (p *updateParams) addFlagsTo(cmd *cobra.Command) {
@@ -114,5 +170,8 @@ func (p *updateParams) addFlagsTo(cmd *cobra.Command) {
 	addNoPromptFlag(&p.doNotPrompt, cmd)
 
 	p.requestParams.addFlags(cmd)
+	addDistroDirFlag(&p.distroRepoDir, cmd)
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
+	cmd.Flags().StringSliceVar(&p.archs, "arch", []string{"x86_64", "aarch64"}, "package architectures to find published versions for")
+	cmd.Flags().StringVarP(&p.packageRepositoryURL, "package-repo-url", "r", "", "URL of the APK package repository")
 }

--- a/pkg/cli/components/advisory/field/field.go
+++ b/pkg/cli/components/advisory/field/field.go
@@ -1,8 +1,9 @@
 package field
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 )
 
@@ -11,18 +12,18 @@ type Field interface {
 	IsDone() bool
 	Value() string
 
-	SetDone() Field
 	SetBlur() Field
 	SetFocus() (Field, tea.Cmd)
 	Update(tea.Msg) (Field, tea.Cmd)
-	UpdateRequest(value string, request advisory.Request) advisory.Request
+	UpdateRequest(request advisory.Request) advisory.Request
+	SubmitValue() (Field, error)
 }
 
-var (
-	focusedStyle        = lipgloss.NewStyle()
-	blurredStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	cursorStyle         = focusedStyle.Copy()
-	noStyle             = lipgloss.NewStyle()
-	helpStyle           = blurredStyle.Copy()
-	cursorModeHelpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
-)
+type ErrValueNotAccepted struct {
+	Value  string
+	Reason error
+}
+
+func (e ErrValueNotAccepted) Error() string {
+	return fmt.Sprintf("entered value %q is not accepted: %s", e.Value, e.Reason.Error())
+}

--- a/pkg/cli/components/advisory/field/list_field.go
+++ b/pkg/cli/components/advisory/field/list_field.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/list"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
 )
 
 type ListField struct {
@@ -24,8 +25,8 @@ type ListFieldConfiguration struct {
 
 func NewListField(cfg ListFieldConfiguration) ListField {
 	l := list.New(cfg.Prompt, cfg.Options)
-	l.SelectedStyle = focusedStyle
-	l.UnselectedStyle = blurredStyle
+	l.SelectedStyle = styles.Accented()
+	l.UnselectedStyle = styles.Secondary()
 
 	return ListField{
 		prompt:         cfg.Prompt,
@@ -34,21 +35,27 @@ func NewListField(cfg ListFieldConfiguration) ListField {
 	}
 }
 
-func (f ListField) UpdateRequest(value string, req advisory.Request) advisory.Request {
+func (f ListField) UpdateRequest(req advisory.Request) advisory.Request {
+	value := f.Value()
 	return f.requestUpdater(value, req)
 }
 
-func (f ListField) Update(msg tea.Msg) (Field, tea.Cmd) {
-	var cmd tea.Cmd
+func (f ListField) SubmitValue() (Field, error) {
+	return f.setDone(), nil
+}
 
-	if f.input.Focused() {
-		f.input, cmd = f.input.Update(msg)
+func (f ListField) Update(msg tea.Msg) (Field, tea.Cmd) {
+	if f.done {
+		return f, nil
 	}
+
+	var cmd tea.Cmd
+	f.input, cmd = f.input.Update(msg)
 
 	return f, cmd
 }
 
-func (f ListField) SetDone() Field {
+func (f ListField) setDone() ListField {
 	f.done = true
 	return f
 }
@@ -78,10 +85,10 @@ func (f ListField) View() string {
 		lines = append(lines, f.input.View())
 		helpText := fmt.Sprintf(
 			"%s %s %s %s",
-			cursorModeHelpStyle.Render("Enter"),
-			helpStyle.Render("to confirm value."),
-			cursorModeHelpStyle.Render("Ctrl+C"),
-			helpStyle.Render("to quit."),
+			helpKeyStyle.Render("Enter"),
+			helpExplanationStyle.Render("to confirm."),
+			helpKeyStyle.Render("Ctrl+C"),
+			helpExplanationStyle.Render("to quit."),
 		)
 
 		lines = append(lines, helpText)

--- a/pkg/cli/components/advisory/field/text_field.go
+++ b/pkg/cli/components/advisory/field/text_field.go
@@ -1,49 +1,238 @@
 package field
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
 )
 
+var (
+	selectedSuggestionStyle = styles.Accented().Copy().Underline(true)
+	helpKeyStyle            = styles.FaintAccent().Copy()
+	helpExplanationStyle    = styles.Faint().Copy()
+)
+
+const maxSuggestionsDisplayed = 4
+
+var ErrValueNotInAllowedSet = errors.New("value not in allowed set")
+
 type TextField struct {
-	input          textinput.Model
-	done           bool
+	allowedValues  []string
 	requestUpdater func(value string, req advisory.Request) advisory.Request
+
+	input                 textinput.Model
+	done                  bool
+	currentSuggestions    []string
+	selectedSuggestion    int
+	suggestionWindowStart int
+	defaultSuggestion     string
+	validationRules       []TextValidationRule
+	currentValidationErr  error
+
+	emptyValueHelpMsg string
+	noMatchHelpMsg    string
 }
 
 type TextFieldConfiguration struct {
-	Prompt         string
+	// Prompt is the text shown before the input field. (E.g. "Name: ")
+	Prompt string
+
+	// RequestUpdater is a function that updates the advisory request with the
+	// current field value.
 	RequestUpdater func(value string, req advisory.Request) advisory.Request
+
+	// AllowedValues is a list of values that are allowed to be entered and are used
+	// as suggestions when the user starts typing.
+	AllowedValues []string
+
+	// DefaultSuggestion is the value that is shown as a suggestion when the user
+	// hasn't entered anything.
+	DefaultSuggestion string
+
+	// EmptyValueHelpMsg is the help message shown when the user hasn't entered
+	// anything and there are no suggestions.
+	EmptyValueHelpMsg string
+
+	// NoMatchHelpMsg is the help message shown when the user has entered something
+	// but there are no matching suggestions.
+	NoMatchHelpMsg string
+
+	// ValidationRules is a list of validation rules that are run when the user
+	// submits the field. All rules must pass for the field to be valid.
+	ValidationRules []TextValidationRule
 }
+
+type TextValidationRule func(string) error
 
 func NewTextField(cfg TextFieldConfiguration) TextField {
 	t := textinput.New()
-	t.CursorStyle = cursorStyle
+	t.CursorStyle = styles.Default()
 	t.CharLimit = 32
 
 	t.Prompt = cfg.Prompt
 
 	return TextField{
-		input:          t,
-		requestUpdater: cfg.RequestUpdater,
+		input:             t,
+		requestUpdater:    cfg.RequestUpdater,
+		allowedValues:     cfg.AllowedValues,
+		emptyValueHelpMsg: cfg.EmptyValueHelpMsg,
+		noMatchHelpMsg:    cfg.NoMatchHelpMsg,
+		validationRules:   cfg.ValidationRules,
+		defaultSuggestion: cfg.DefaultSuggestion,
 	}
 }
 
-func (f TextField) UpdateRequest(value string, req advisory.Request) advisory.Request {
+func NotEmpty(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return errors.New("cannot be empty")
+	}
+
+	return nil
+}
+
+func (f TextField) runAllValidationRules(value string) error {
+	for _, rule := range f.validationRules {
+		err := rule(value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (f TextField) UpdateRequest(req advisory.Request) advisory.Request {
+	value := f.Value()
 	return f.requestUpdater(value, req)
 }
 
+func (f TextField) SubmitValue() (Field, error) {
+	if f.usingSuggestions() && f.noSuggestions() {
+		return nil, ErrValueNotAccepted{
+			Value:  f.input.Value(),
+			Reason: ErrValueNotInAllowedSet,
+		}
+	}
+
+	value := f.Value()
+
+	err := f.runAllValidationRules(value)
+	if err != nil {
+		return nil, ErrValueNotAccepted{
+			Value:  value,
+			Reason: err,
+		}
+	}
+
+	f = f.setDone()
+
+	return f, nil
+}
+
 func (f TextField) Update(msg tea.Msg) (Field, tea.Cmd) {
+	if f.done {
+		return f, nil
+	}
+
 	m, cmd := f.input.Update(msg)
 	f.input = m
+
+	f.currentValidationErr = f.runAllValidationRules(f.input.Value())
+
+	if !f.usingSuggestions() {
+		return f, cmd
+	}
+
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		switch msg.String() {
+		case "tab":
+			f = f.nextSuggestion()
+
+		case "shift+tab":
+			f = f.previousSuggestion()
+
+		default:
+			f = f.updateSuggestions()
+		}
+	}
+
 	return f, cmd
 }
 
-func (f TextField) SetDone() Field {
+func (f TextField) usingSuggestions() bool {
+	return f.allowedValues != nil
+}
+
+func (f TextField) updateSuggestions() TextField {
+	f.currentSuggestions = f.computeSuggestions()
+	f.selectedSuggestion = 0
+	f.suggestionWindowStart = 0
+
+	return f
+}
+
+func (f TextField) nextSuggestion() TextField {
+	if f.selectedSuggestion == len(f.currentSuggestions)-1 {
+		return f
+	}
+
+	if f.selectedSuggestion == f.suggestionWindowEnd()-1 {
+		f.suggestionWindowStart++
+	}
+
+	f.selectedSuggestion++
+	return f
+}
+
+func (f TextField) previousSuggestion() TextField {
+	if f.selectedSuggestion == 0 {
+		return f
+	}
+
+	if f.selectedSuggestion == f.suggestionWindowStart {
+		f.suggestionWindowStart--
+	}
+
+	f.selectedSuggestion--
+	return f
+}
+
+func (f TextField) computeSuggestions() []string {
+	v := f.input.Value()
+
+	if v == "" {
+		if f.defaultSuggestion != "" {
+			return []string{f.defaultSuggestion}
+		}
+
+		return nil
+	}
+
+	var suggestions []string
+
+	for _, allowedValue := range f.allowedValues {
+		if strings.HasPrefix(allowedValue, v) {
+			suggestions = append(suggestions, allowedValue)
+		}
+	}
+
+	return suggestions
+}
+
+func (f TextField) suggestionWindowEnd() int {
+	if len(f.currentSuggestions) <= maxSuggestionsDisplayed {
+		return len(f.currentSuggestions)
+	}
+
+	return f.suggestionWindowStart + maxSuggestionsDisplayed
+}
+
+func (f TextField) setDone() TextField {
 	f.done = true
 	return f
 }
@@ -51,8 +240,8 @@ func (f TextField) SetDone() Field {
 func (f TextField) SetBlur() Field {
 	f.input.Blur()
 
-	f.input.PromptStyle = noStyle
-	f.input.TextStyle = noStyle
+	f.input.PromptStyle = styles.Default()
+	f.input.TextStyle = styles.Default()
 
 	return f
 }
@@ -60,8 +249,9 @@ func (f TextField) SetBlur() Field {
 func (f TextField) SetFocus() (Field, tea.Cmd) {
 	cmd := f.input.Focus()
 
-	f.input.PromptStyle = focusedStyle
-	f.input.TextStyle = focusedStyle
+	f = f.updateSuggestions()
+	f.input.PromptStyle = styles.Default()
+	f.input.TextStyle = styles.Default()
 
 	return f, cmd
 }
@@ -71,25 +261,145 @@ func (f TextField) IsDone() bool {
 }
 
 func (f TextField) Value() string {
-	return f.input.Value()
+	if !f.usingSuggestions() {
+		return f.input.Value()
+	}
+
+	selectedValue := f.currentSuggestions[f.selectedSuggestion]
+	return selectedValue
 }
 
 func (f TextField) View() string {
 	var lines []string
 
-	lines = append(lines, f.input.View())
+	if f.done && f.usingSuggestions() {
+		f.input.SetValue(f.Value())
+	}
+
+	inputLine := f.input.View()
+
+	if !f.done && f.usingSuggestions() {
+		inputLine = fmt.Sprintf("%s   %s", inputLine, f.renderSuggestions())
+	}
+
+	lines = append(lines, inputLine)
 
 	if !f.done {
-		helpText := fmt.Sprintf(
-			"%s %s %s %s",
-			cursorModeHelpStyle.Render("Enter"),
-			helpStyle.Render("to confirm value."),
-			cursorModeHelpStyle.Render("Ctrl+C"),
-			helpStyle.Render("to quit."),
-		)
-
+		helpText := f.renderHelp()
 		lines = append(lines, helpText)
 	}
 
 	return strings.Join(lines, "\n")
 }
+
+func (f TextField) noSuggestions() bool {
+	return len(f.currentSuggestions) == 0
+}
+
+func (f TextField) onlyOneSuggestion() bool {
+	return len(f.currentSuggestions) == 1
+}
+
+func (f TextField) multipleSuggestions() bool {
+	return len(f.currentSuggestions) > 1
+}
+
+func (f TextField) userHasEnteredText() bool {
+	return f.input.Value() != ""
+}
+
+func (f TextField) enteredTextIsSoleSuggestion() bool {
+	return f.input.Value() == f.currentSuggestions[0]
+}
+
+func (f TextField) enteredValueIsValid() bool {
+	return f.currentValidationErr == nil
+}
+
+func (f TextField) renderSuggestions() string {
+	if !f.userHasEnteredText() && f.defaultSuggestion != "" {
+		return selectedSuggestionStyle.Render(f.defaultSuggestion)
+	}
+
+	if f.noSuggestions() || (f.onlyOneSuggestion() && f.enteredTextIsSoleSuggestion()) {
+		return ""
+	}
+
+	renderedSuggestions := make([]string, 0, maxSuggestionsDisplayed)
+
+	for i := f.suggestionWindowStart; i < f.suggestionWindowEnd(); i++ {
+		suggestion := f.currentSuggestions[i]
+		if i == f.selectedSuggestion {
+			suggestion = selectedSuggestionStyle.Render(suggestion)
+		} else {
+			suggestion = styles.Secondary().Render(suggestion)
+		}
+		renderedSuggestions = append(renderedSuggestions, suggestion)
+	}
+
+	ellipses := styles.Secondary().Render("…")
+
+	if f.suggestionWindowStart > 0 {
+		renderedSuggestions = append([]string{ellipses}, renderedSuggestions...)
+	}
+
+	if f.suggestionWindowEnd() < len(f.currentSuggestions) {
+		renderedSuggestions = append(renderedSuggestions, ellipses)
+	}
+
+	return strings.Join(renderedSuggestions, " ")
+}
+
+func (f TextField) renderHelp() string {
+	var helpMsgs []string
+
+	if msg := f.renderHelpMsgEmptyValue(); !f.userHasEnteredText() && msg != "" {
+		helpMsgs = append(helpMsgs, msg)
+	} else if !f.enteredValueIsValid() {
+		msg := styles.Faint().Render(
+			fmt.Sprintf("Invalid value: %s.", f.currentValidationErr),
+		)
+		helpMsgs = append(helpMsgs, msg)
+	}
+
+	if f.usingSuggestions() {
+		switch {
+		case f.noSuggestions() && f.userHasEnteredText():
+			helpMsgs = append(helpMsgs, f.renderHelpMsgNoMatch())
+
+		case f.onlyOneSuggestion() && f.enteredTextIsSoleSuggestion():
+			helpMsgs = append(helpMsgs, helpMsgEnterOnInput)
+
+		case f.onlyOneSuggestion() && !f.enteredTextIsSoleSuggestion():
+			helpMsgs = append(helpMsgs, helpMsgEnterOnSuggestion)
+
+		case f.multipleSuggestions():
+			helpMsgs = append(helpMsgs, helpMsgEnterOnSuggestion, helpMsgTab)
+		}
+	} else if f.userHasEnteredText() && f.enteredValueIsValid() {
+		helpMsgs = append(helpMsgs, helpMsgEnterOnInput)
+	}
+
+	helpMsgs = append(helpMsgs, helpMsgQuit)
+	return strings.Join(helpMsgs, " ")
+}
+
+func (f TextField) renderHelpMsgEmptyValue() string {
+	msg := f.emptyValueHelpMsg
+	if msg == "" {
+		return ""
+	}
+
+	return styles.Faint().Render(msg)
+}
+
+func (f TextField) renderHelpMsgNoMatch() string {
+	return styles.Faint().Render(f.noMatchHelpMsg)
+}
+
+var (
+	helpMsgEnterOnInput      = helpKeyStyle.Render("Enter") + " " + helpExplanationStyle.Render("to confirm.")
+	helpMsgEnterOnSuggestion = helpKeyStyle.Render("Enter") + " " + helpExplanationStyle.Render("to accept suggestion.")
+	helpMsgTab               = helpKeyStyle.Render("Tab") + " " + helpExplanationStyle.Render("for next suggestion.")
+	helpMsgQuit              = helpKeyStyle.Render("Ctrl+C") + " " + helpExplanationStyle.Render("to quit.")
+)

--- a/pkg/cli/styles/styles.go
+++ b/pkg/cli/styles/styles.go
@@ -1,0 +1,50 @@
+package styles
+
+import "github.com/charmbracelet/lipgloss"
+
+var darkMode = lipgloss.HasDarkBackground()
+
+var (
+	defaultStyle = lipgloss.NewStyle()
+	accented     = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffffff"))
+	secondary    = lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
+	faint        = lipgloss.NewStyle().Foreground(lipgloss.Color("#606060"))
+	faintAccent  = lipgloss.NewStyle().Foreground(lipgloss.Color("#777777"))
+
+	accentedLight    = lipgloss.NewStyle().Foreground(lipgloss.Color("#000000"))
+	secondaryLight   = lipgloss.NewStyle().Foreground(lipgloss.Color("#444444"))
+	faintLight       = lipgloss.NewStyle().Foreground(lipgloss.Color("#AAAAAA"))
+	faintAccentLight = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
+)
+
+func Default() lipgloss.Style {
+	return defaultStyle
+}
+
+func Accented() lipgloss.Style {
+	if !darkMode {
+		return accentedLight
+	}
+	return accented
+}
+
+func Secondary() lipgloss.Style {
+	if !darkMode {
+		return secondaryLight
+	}
+	return secondary
+}
+
+func Faint() lipgloss.Style {
+	if !darkMode {
+		return faintLight
+	}
+	return faint
+}
+
+func FaintAccent() lipgloss.Style {
+	if !darkMode {
+		return faintAccentLight
+	}
+	return faintAccent
+}

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -1,0 +1,66 @@
+package distro
+
+// Distro represents a wolfictl-compatible distro, along with important
+// properties discovered about how the user interacts with the distro.
+type Distro struct {
+	// Name of the distro.
+	Name string
+
+	// DistroRepoDir is the path to the directory containing the user's clone of the
+	// distro repo, i.e. the repo containing the distro's build configurations.
+	DistroRepoDir string
+
+	// AdvisoriesRepoDir is the path to the directory containing the user's clone of
+	// the advisories repo, i.e. the repo containing the distro's advisory data.
+	AdvisoriesRepoDir string
+
+	// APKRepositoryURL is the URL to the distro's package repository (e.g.
+	// "https://packages.wolfi.dev/os").
+	APKRepositoryURL string
+
+	// SupportedArchitectures is a list of architectures supported by the distro.
+	SupportedArchitectures []string
+}
+
+type knownDistro struct {
+	name                                   string
+	distroRemoteURLs, advisoriesRemoteURLs []string
+	apkRepositoryURL                       string
+	supportedArchitectures                 []string
+}
+
+var (
+	wolfiDistro = knownDistro{
+		name: "Wolfi",
+		distroRemoteURLs: []string{
+			"git@github.com:wolfi-dev/os.git",
+			"https://github.com/wolfi-dev/os.git",
+		},
+		advisoriesRemoteURLs: []string{
+			"git@github.com:wolfi-dev/advisories.git",
+			"https://github.com/wolfi-dev/advisories.git",
+		},
+		apkRepositoryURL: "https://packages.wolfi.dev/os",
+		supportedArchitectures: []string{
+			"x86_64",
+			"aarch64",
+		},
+	}
+
+	chainguardDistro = knownDistro{
+		name: "Chainguard",
+		distroRemoteURLs: []string{
+			"git@github.com:chainguard-dev/enterprise-packages.git",
+			"https://github.com/chainguard-dev/enterprise-packages.git",
+		},
+		advisoriesRemoteURLs: []string{
+			"git@github.com:chainguard-dev/enterprise-advisories.git",
+			"https://github.com/chainguard-dev/enterprise-advisories.git",
+		},
+		apkRepositoryURL: "https://packages.cgr.dev/os",
+		supportedArchitectures: []string{
+			"x86_64",
+			"aarch64",
+		},
+	}
+)

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -57,3 +57,33 @@ func NewVersion(v string) (*version.Version, error) {
 	v = strings.ReplaceAll(v, "_", "")
 	return version.NewVersion(v)
 }
+
+// ByLatestStrings is like ByLatest but lets the user pass in strings instead of Version objects.
+type ByLatestStrings []string
+
+func (by ByLatestStrings) Len() int {
+	return len(by)
+}
+
+func (by ByLatestStrings) Less(i, j int) bool {
+	vi, err := NewVersion(by[i])
+	if err != nil {
+		return false
+	}
+	vj, err := NewVersion(by[j])
+	if err != nil {
+		return false
+	}
+	if equal(vi.Segments(), vj.Segments()) {
+		if vj.Metadata() != "" {
+			if vj.Metadata() > vi.Metadata() {
+				return false
+			}
+		}
+	}
+	return vi.GreaterThan(vj)
+}
+
+func (by ByLatestStrings) Swap(i, j int) {
+	by[i], by[j] = by[j], by[i]
+}

--- a/pkg/versions/versions_test.go
+++ b/pkg/versions/versions_test.go
@@ -2,6 +2,7 @@ package versions
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -78,6 +79,29 @@ func TestGitHubReleases_SortVersions(t *testing.T) {
 			sort.Sort(ByLatest(versions))
 
 			assert.Equal(t, test.expectedLatestVersion, versions[len(versions)-1].Original())
+		})
+	}
+}
+
+func TestSort_ByLatestStrings(t *testing.T) {
+	cases := []struct {
+		input    []string
+		expected []string
+	}{
+		{
+			input:    []string{"1.2.3", "1.1.1", "2.3.4", "0.1.3"},
+			expected: []string{"2.3.4", "1.2.3", "1.1.1", "0.1.3"},
+		},
+		{
+			input:    []string{"0.1.0-r5", "0.1.0-r4", "0.2.0-r0"},
+			expected: []string{"0.2.0-r0", "0.1.0-r5", "0.1.0-r4"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(strings.Join(tt.input, ","), func(t *testing.T) {
+			sort.Sort(ByLatestStrings(tt.input))
+			assert.Equal(t, tt.expected, tt.input)
 		})
 	}
 }


### PR DESCRIPTION
This PR builds on the distro auto-detection added in #208 and the interactive TUI (terminal UI) added in #204 by adding validation and automatic suggestions to the TUI based on user input.

This improves the experience of running the `wolfictl adv create` and `wolfictl adv update` commands:

1. The `Package:` field uses package names found in the distro repo (for `create`) or advisories repo (for `update`).
2. The `Vulnerability:` field validates that the input is a valid CVE ID, and for `update` ensures that the CVE ID corresponds to an existing advisory.
3. The `Fixed Version:` field uses package versions from the APKINDEX and the current build configuration, providing a default value of the current package version.

The theory is that these UX improvements will make it even more appealing to use the prompts instead of CLI flags. Soon we plan to update the underlying advisory data model in several fundamental ways, and it will be easier for users to follow along via interactive prompting than from breaking CLI flag changes.

This PR also adds support for detecting light/dark backgrounds in the terminal and updating the TUI styles accordingly.