### PR TITLE
Mark the workspace as a safe directory for git operations.

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -204,6 +204,10 @@ else
   ls {{.signingKeyName}}.rsa
 fi
 
+# In order to run "git log" on the packaged .git metadata we need to
+# make sure that we don't hit "dubious permission" errors.
+git config --global --add safe.directory /workspace
+
 set +e # Always touch start-gcloud-cp to start uploading buitl packages, even if the build fails.
 find ./packages -print -exec touch \{} \;
 MELANGE=/usr/bin/melange MELANGE_DIR=/usr/share/melange KEY=${KEY} ARCH={{.arch}} REPO=./packages MELANGE_EXTRA_OPTS="{{.melangeBuildOpts}}" make {{.targets}}


### PR DESCRIPTION
I realized this as I want to revert my other change that we would hit the "dubious permission" issue and need this command to accept the workspace as a safe directory.  🤞 

See also: https://github.com/chainguard-dev/kontext/blob/347f191bd8d465631acc627f8a8309e01016fce0/.github/workflows/e2e-test.yaml#LL64C21-L64C72