### PR TITLE
fix secrets-store-csi-driver by using latest version

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -14,7 +14,7 @@ kubectl annotate serviceaccount default --overwrite \
   "iam.gke.io/gcp-service-account=${SA}@${PROJECT}.iam.gserviceaccount.com"
 
 # Install the secrets store CSI driver.
-CSI_DRIVER_VERSION=1.3.2
+CSI_DRIVER_VERSION=1.3.3
 kubectl apply \
   -f "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v${CSI_DRIVER_VERSION}/deploy/rbac-secretproviderclass.yaml" \
   -f "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v${CSI_DRIVER_VERSION}/deploy/csidriver.yaml" \


### PR DESCRIPTION
The fix applied in https://github.com/chainguard-images/images/pull/557 to include `mount` only made that change to `:1.3.3`, so pinning to `:1.3.2` didn't pick it up.

Ideally we should just be on `:latest` but that can be a separate PR.

Annoyingly, the missing-`mount` failure only happens when the secret is actually used, and doesn't manifest just in seeing the DaemonSet come up.