### PR TITLE
use :latest secrets-store-csi images

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -26,7 +26,7 @@ kubectl apply \
 # If this image is not available, comment this out to use the upstream directly.
 kubectl set image ds/csi-secrets-store \
   -n kube-system \
-  secrets-store=cgr.dev/chainguard/secrets-store-csi-driver:${CSI_DRIVER_VERSION}
+  secrets-store=cgr.dev/chainguard/secrets-store-csi-driver:latest
 
 # Install the GCP provider for the secrets store CSI driver.
 GCP_PLUGIN_VERSION=1.2.0
@@ -36,7 +36,7 @@ kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/secrets-
 # If this image is not available, comment this out to use the upstream directly.
 kubectl set image daemonset/csi-secrets-store-provider-gcp \
   -n kube-system \
-  provider=cgr.dev/chainguard/secrets-store-csi-driver-provider-gcp:${GCP_PLUGIN_VERSION}
+  provider=cgr.dev/chainguard/secrets-store-csi-driver-provider-gcp:latest
 
 # Patch the secrets store CSI driver and GCP provider to tolerate Arm nodes.
 kubectl patch daemonset csi-secrets-store-provider-gcp \


### PR DESCRIPTION
As we see in #224, pinning to a specific version means we have to remember to update the version to pick up any fixes.

This PR has us depend on `:latest` for secrets-store-csi-driver{-provider-gcp}.

If we're worried about this being disruptive, we can put a digestabot in place so that upgrades are discrete and acknowledged, but automated.