### PR TITLE
use stable sorting for graph

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.23.2
 	github.com/charmbracelet/lipgloss v0.7.1
 	github.com/cpuguy83/go-md2man v1.0.10
-	github.com/dominikbraun/graph v0.21.0
+	github.com/dominikbraun/graph v0.22.0
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
 	github.com/facebookincubator/nvdtools v0.1.5
 	github.com/fatih/color v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dominikbraun/graph v0.21.0 h1:wiaDG3jaMgGV933DxtuNWFWuvaPRCN18UEb3Ds/lbOI=
 github.com/dominikbraun/graph v0.21.0/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
+github.com/dominikbraun/graph v0.22.0 h1:2YGQsN8+g1y/c+i7HPEbMqfW3W84sTpQsuiFpBwJWzY=
+github.com/dominikbraun/graph v0.22.0/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
 github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f h1:oEt43goQgsL1DzoOyQ/UZHQw7t9TqwyJec9W0vh0wfE=
 github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f/go.mod h1:RU3x9VqPvzbOGJ3wtP0pPBtUOp4yU/yzA/8qdxgi/6Q=
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 h1:PRxIJD8XjimM5aTknUK9w6DHLDox2r2M3DI4i2pnd3w=

--- a/pkg/dag/graph.go
+++ b/pkg/dag/graph.go
@@ -318,7 +318,9 @@ func (g *Graph) addDanglingPackage(name string, parent Package) error {
 // order, meaning that packages earlier in the list depend on packages later in
 // the list.
 func (g Graph) Sorted() ([]Package, error) {
-	nodes, err := graph.TopologicalSort(g.Graph)
+	nodes, err := graph.StableTopologicalSort(g.Graph, func(i string, j string) bool {
+		return i > j
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With the v0.22.0 release of the underlying graph, we can sort it not only by ensuring antecedents come before their descendants (which it already did), but also have a consistent sorting algorithm for equal-level nodes. In our case, we do a simple lexicographical sort.