### PR TITLE
cache repos in graph; use go-apk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	chainguard.dev/apko v0.7.4-0.20230427160853-4082ea6e082e
 	chainguard.dev/melange v0.3.1-0.20230502151024-40098bfea030
 	cloud.google.com/go/storage v1.30.1
+	github.com/chainguard-dev/go-apk v0.0.0-20230529173142-c78bd5ba3cae
 	github.com/chainguard-dev/kontext v0.1.0
 	github.com/chainguard-dev/yam v0.0.0-20230515182324-679f6de74032
 	github.com/charmbracelet/bubbles v0.15.0
@@ -114,7 +115,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/buildkite/agent/v3 v3.45.0 // indirect
-	github.com/chainguard-dev/go-apk v0.0.0-20230501082831-d4a4a3b48750 // indirect
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20221129204813-6a4d6ed5d396 // indirect
 	github.com/clbanning/mxj/v2 v2.5.7 // indirect
 	github.com/cloudflare/circl v1.3.1 // indirect
@@ -266,7 +266,7 @@ require (
 	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/tools v0.8.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
-github.com/chainguard-dev/go-apk v0.0.0-20230501082831-d4a4a3b48750 h1:l0s4EA2eGjn1VFK4k7yxZywPCr7yGXkRtxS3jwMWlO4=
-github.com/chainguard-dev/go-apk v0.0.0-20230501082831-d4a4a3b48750/go.mod h1:AAWHP+cZSBRe1AjQbfio64C66XxlOXAS08orCjF0zj8=
+github.com/chainguard-dev/go-apk v0.0.0-20230529173142-c78bd5ba3cae h1:H8VtmUKMcRtM2ZUwfO+odDDsuOtWPw5cpQhSJkWaFXw=
+github.com/chainguard-dev/go-apk v0.0.0-20230529173142-c78bd5ba3cae/go.mod h1:BM0gO+KLpyVLuJSFiYYZP52DS+S4GjQoPaEljWo6uWw=
 github.com/chainguard-dev/kontext v0.1.0 h1:GFnDRZiqa+anUi7tzZMECXr0nwt4Eo/zMzTQPLRXUIs=
 github.com/chainguard-dev/kontext v0.1.0/go.mod h1:hdyG5Sia0niCW8HN8MDXcDh/nL0sgcWQYSjPRFZOX/w=
 github.com/chainguard-dev/yam v0.0.0-20230515182324-679f6de74032 h1:z0RPQIcYgpJAU7jQf2stcXh8NDBjd9vkR20maYYwgMM=
@@ -1367,8 +1367,8 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
-golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	apko "chainguard.dev/apko/pkg/apk/impl"
 	"chainguard.dev/melange/pkg/build"
+	apk "github.com/chainguard-dev/go-apk/pkg/apk"
 	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
@@ -334,7 +334,7 @@ func (p Packages) Sub(names ...string) (*Packages, error) {
 
 // Repository provide the Packages as a repository.RepositoryWithIndex. To be used in other places that require
 // using alpine/go structs instead of ours.
-func (p Packages) Repository(arch string) apko.NamedIndex {
+func (p Packages) Repository(arch string) apk.NamedIndex {
 	repo := repository.NewRepositoryFromComponents(Local, "latest", "", arch)
 	packages := make([]*repository.Package, 0)
 	for _, byVersion := range p.packages {
@@ -373,7 +373,7 @@ func (p Packages) Repository(arch string) apko.NamedIndex {
 		Packages:    packages,
 	}
 
-	return apko.NewNamedRepositoryWithIndex("", repo.WithIndex(index))
+	return apk.NewNamedRepositoryWithIndex("", repo.WithIndex(index))
 }
 
 func packageNameFromProvides(prov string) (name, version string) {


### PR DESCRIPTION
This only gets it down to about 245s for the graph, so another 10-15s, but it helps. I believe the last bump will have to come from inside the graph algorithm.