### PR TITLE
fix release monitor bot on wolfi

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -592,6 +592,7 @@ func (o *Options) createErrorMessageIssue(repo *git.Repository, packageName, mes
 		PackageName: packageName,
 		Comment:     message,
 		Title:       gh.GetErrorIssueTitle(bot, packageName),
+		Labels:      o.IssueLabels,
 	}
 	existingIssue, err := gitOpts.CheckExistingIssue(context.Background(), i)
 	if err != nil {


### PR DESCRIPTION
release monitor jobs have been failing since a packge update contained a bad URL which means the bort worklflow creates an issue rather than a PR.

Lables were added a couple of weeks ago to help with project board management.

This will fix the error we are seeing:

```
Error: creating updates: POST https://api.github.com/repos/wolfi-dev/os/issues: 422 Invalid request.

For 'properties/labels', nil is not an array. []
time="2023-06-06T16:59:35Z" level=fatal msg="error during command execution: creating updates: POST https://api.github.com/repos/wolfi-dev/os/issues: 422 Invalid request.\n\nFor 'properties/labels', nil is not an array. []"
```

https://github.com/wolfi-dev/os/actions/runs/5191079332/jobs/9358423759