### PR TITLE
Add runtime deps to graph

### DIFF
--- a/pkg/dag/testdata/complex/one-dupl.yaml
+++ b/pkg/dag/testdata/complex/one-dupl.yaml
@@ -10,10 +10,6 @@ package:
         - "*"
       attestation:
       license: Apache-2.0
-  dependencies:
-    runtime:
-      - bash
-      - gcc
 environment:
   contents:
     packages:

--- a/pkg/dag/testdata/complex/one.yaml
+++ b/pkg/dag/testdata/complex/one.yaml
@@ -10,10 +10,6 @@ package:
         - "*"
       attestation:
       license: Apache-2.0
-  dependencies:
-    runtime:
-      - bash
-      - gcc
 environment:
   contents:
     packages:

--- a/pkg/dag/testdata/complex/three.yaml
+++ b/pkg/dag/testdata/complex/three.yaml
@@ -10,10 +10,6 @@ package:
         - "*"
       attestation:
       license: Apache-2.0
-  dependencies:
-    runtime:
-      - bash
-      - gcc
 environment:
   contents:
     packages:

--- a/pkg/dag/testdata/complex/two.yaml
+++ b/pkg/dag/testdata/complex/two.yaml
@@ -11,9 +11,6 @@ package:
       attestation:
       license: Apache-2.0
   dependencies:
-    runtime:
-      - bash
-      - gcc
     provides:
       - two-provides-explicit=10.11.12
       - two-provides-implicit


### PR DESCRIPTION
The DAG calculation before did not account for runtime dependencies, i.e. those listed in `package.dependencies.runtime` as correctly pointed out by @kaniini. This updates it to account for those. The `.runtime` dependencies are to be resolved solely from the local package list, i.e. no upstream.

In order to make this work, we had to rearrange the package additions to the graph. It makes it easier to understand anyways, which is a good thing. It now is:

1. Do a loop through all packages, adding each package as a graph node, adding each subpackage as a graph node, dependent on the parent
2. Do a loop through all packages, adding each runtime dependency; this only works after the previous step, as all packages and subpackages need to exist as nodes before we can add the runtime dependencies
3. Do a loop through all packages, resolving all environment (build-time) dependencies. This includes local and, if listed, other (upstream) repositories

Steps 1 & 3 already existed, although in a single loop; step 2 is the addition.

Note that this works for everything in `wolfi-dev/os` _except_ for the following errors:

```
ruby3.2-fluentd14-1.14.6-r4: unable to resolve dependency ruby3.2-webrick<1.8: could not find package ruby3.2-webrick<1.8 in indexes
ruby3.2-fluentd15-1.16.1-r1: unable to resolve dependency ruby3.2-webrick<1.8: could not find package ruby3.2-webrick<1.8 in indexes
```

I believe this to be the graph behaving correctly, and the problem is in the package definitions in `wolfi-dev/os`. However, until @kaniini confirms it, this can be approved but should not be merged in. With @kaniini 's confirmation it can be merged in, although if the response is that this algorithm is incorrect, I will fix it.