### PR TITLE
revert gsutil change

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -278,6 +278,8 @@ do
   sleep $interval
 done
 
+set -x
+
 # Don't cache the APKINDEX, and leave it public if it already is.
 gcloud --quiet storage cp \
 	--cache-control=no-store \

--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -278,10 +278,10 @@ do
   sleep $interval
 done
 
-# Don't cache the APKINDEX, and always make it public.
-gsutil cp \
-	-h "Cache-Control:no-store" \
-	-a public-read \
+# Don't cache the APKINDEX, and leave it public if it already is.
+gcloud --quiet storage cp \
+	--cache-control=no-store \
+	--preserve-acl \
 	"./packages/{{.arch}}/APKINDEX.tar.gz" gs://{{.bucket}}{{.arch}}/ || true
 
 # apks will be cached in CDN for an hour by default.


### PR DESCRIPTION
Undoes https://github.com/wolfi-dev/wolfictl/commit/77f5b2900be23bb0172137e549c9f2cef3da6d00 which seems to cause errors uploading APKINDEX for arm64 builds

```
2023-06-13T00:24:35.2542771Z CommandException: Incorrect option(s) specified. Usage:
2023-06-13T00:24:35.2543058Z 
2023-06-13T00:24:35.2543221Z   gsutil cp [OPTION]... src_url dst_url
2023-06-13T00:24:35.2543610Z   gsutil cp [OPTION]... src_url... dst_url
2023-06-13T00:24:35.2544255Z   gsutil cp [OPTION]... -I dst_url
2023-06-13T00:24:35.2544437Z 
2023-06-13T00:24:35.2544569Z For additional help run:
2023-06-13T00:24:35.2544859Z   gsutil help cp
```

Also improve logging.