### PR TITLE
pod: don't upload apks if they already exist

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -287,7 +287,9 @@ gcloud --quiet storage cp \
 	"./packages/{{.arch}}/APKINDEX.tar.gz" gs://{{.bucket}}{{.arch}}/ || true
 
 # apks will be cached in CDN for an hour by default.
+# Don't upload the object if it already exists.
 gcloud --quiet storage cp \
+	--no-clobber \
 	"./packages/{{.arch}}/*.apk" gs://{{.bucket}}{{.arch}}/ || true
 `, map[string]string{"bucket": bucket, "arch": arch}),
 					},


### PR DESCRIPTION
this replicates the change made to x86 builds on wolfi, details and further explanation found in this PR from @imjasonh  https://github.com/wolfi-dev/os/pull/2969