### PR TITLE
Add ls command for listing and querying package configs

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -26,6 +26,7 @@ func New() *cobra.Command {
 		cmdMake(),
 		Check(),
 		Lint(),
+		Ls(),
 		Update(),
 		VEX(),
 		version.Version(),

--- a/pkg/cli/ls.go
+++ b/pkg/cli/ls.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"chainguard.dev/melange/pkg/build"
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	buildconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/build"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+	"github.com/wolfi-dev/wolfictl/pkg/distro"
+	"github.com/wolfi-dev/wolfictl/pkg/ls"
+)
+
+func Ls() *cobra.Command {
+	p := &lsParams{}
+	cmd := &cobra.Command{
+		Use:           "ls [packages]",
+		Short:         "List distro packages (experimental)",
+		SilenceErrors: true,
+		Hidden:        true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(p.distroRepoDirs) == 0 {
+				if p.doNotDetectDistro {
+					return fmt.Errorf("no distro repo dir specified")
+				}
+
+				d, err := distro.Detect()
+				if err != nil {
+					return fmt.Errorf("no distro repo dir specified, and distro auto-detection failed: %w", err)
+				}
+
+				p.distroRepoDirs = append(p.distroRepoDirs, d.DistroRepoDir)
+				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
+			}
+
+			indices := make([]*configs.Index[build.Configuration], 0, len(p.distroRepoDirs))
+			for _, dir := range p.distroRepoDirs {
+				distroFsys := rwos.DirFS(dir)
+				index, err := buildconfigs.NewIndex(distroFsys)
+				if err != nil {
+					return fmt.Errorf("unable to index build configs for directory %q: %w", dir, err)
+				}
+
+				indices = append(indices, index)
+			}
+
+			requestedPkgs := args
+
+			opts := ls.ListOptions{
+				BuildCfgIndices:    indices,
+				IncludeSubpackages: p.includeSubpackages,
+				RequestedPackages:  requestedPkgs,
+				Template:           p.format,
+			}
+
+			results, err := ls.List(opts)
+			if err != nil {
+				return fmt.Errorf("unable to list packages: %w", err)
+			}
+
+			fmt.Println(strings.Join(results, "\n"))
+
+			return nil
+		},
+	}
+
+	p.addFlagsTo(cmd)
+	return cmd
+}
+
+type lsParams struct {
+	doNotDetectDistro bool
+	distroRepoDirs    []string
+
+	includeSubpackages bool
+	format             string
+}
+
+func (p *lsParams) addFlagsTo(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&p.doNotDetectDistro, "do-not-detect-distro", false, "Do not auto-detect distro")
+	cmd.Flags().StringSliceVarP(&p.distroRepoDirs, "distro-repo-dir", "d", nil, "Path to distro repo dir")
+
+	cmd.Flags().BoolVarP(&p.includeSubpackages, "subpackages", "s", false, "Include subpackages")
+	cmd.Flags().StringVarP(&p.format, "format", "f", "", "Output format (in the form of a literal Go template applied to each result item)")
+}

--- a/pkg/ls/ls.go
+++ b/pkg/ls/ls.go
@@ -1,0 +1,126 @@
+package ls
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+
+	"chainguard.dev/melange/pkg/build"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+)
+
+type ListOptions struct {
+	BuildCfgIndices []*configs.Index[build.Configuration]
+
+	// IncludeSubpackages indicates whether subpackages should be included in the results.
+	IncludeSubpackages bool
+
+	// RequestedPackages is a list of package names to list. If empty, all packages are listed.
+	RequestedPackages []string
+
+	// Template is the Go template string to use when printing results.
+	Template string
+}
+
+// List lists packages.
+func List(opts ListOptions) ([]string, error) {
+	var results []string
+
+	var tmpl *template.Template
+	if opts.Template != "" {
+		var err error
+		tmpl, err = template.New("result").Parse(opts.Template)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse template: %w", err)
+		}
+	}
+
+	if len(opts.RequestedPackages) == 0 {
+		for _, index := range opts.BuildCfgIndices {
+			cfgs := index.Select().Configurations()
+
+			packageNames, err := listPackageNames(cfgs, opts.IncludeSubpackages, tmpl)
+			if err != nil {
+				return nil, fmt.Errorf("unable to list package names: %w", err)
+			}
+			results = append(results, packageNames...)
+		}
+
+		return results, nil
+	}
+
+	for _, requestedPkg := range opts.RequestedPackages {
+		var cfgsForRequestedPkg []build.Configuration
+
+		for _, index := range opts.BuildCfgIndices {
+			cfgs := index.Select().WhereName(requestedPkg).Configurations()
+			cfgsForRequestedPkg = append(cfgsForRequestedPkg, cfgs...)
+		}
+
+		if len(cfgsForRequestedPkg) == 0 {
+			// If a package was requested that doesn't exist, surface that as an error.
+			return nil, fmt.Errorf("no package found for %q", requestedPkg)
+		}
+
+		packageNames, err := listPackageNames(cfgsForRequestedPkg, opts.IncludeSubpackages, tmpl)
+		if err != nil {
+			return nil, fmt.Errorf("unable to list package names: %w", err)
+		}
+		results = append(results, packageNames...)
+	}
+
+	return results, nil
+}
+
+// renderResultItem renders a result item using the provided template. If tmpl
+// is nil, the package name is returned. The item parameter's type should be
+// build.Configuration or build.Subpackage.
+func renderResultItem(item any, tmpl *template.Template) (string, error) {
+	if tmpl == nil {
+		switch item := item.(type) {
+		case build.Configuration:
+			return item.Package.Name, nil
+		case build.Subpackage:
+			return item.Name, nil
+		default:
+			return "", fmt.Errorf("unexpected type %T", item)
+		}
+	}
+
+	var b strings.Builder
+	err := tmpl.Execute(&b, item)
+	if err != nil {
+		return "", fmt.Errorf("unable to render template: %w", err)
+	}
+
+	return b.String(), nil
+}
+
+func listPackageNames(cfgs []build.Configuration, includeSubpackages bool, tmpl *template.Template) ([]string, error) {
+	var results []string
+
+	for i := range cfgs {
+		cfg := cfgs[i]
+
+		rendered, err := renderResultItem(cfg, tmpl)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, rendered)
+
+		if includeSubpackages {
+			for i := range cfg.Subpackages {
+				subpkg := cfg.Subpackages[i]
+				rendered, err := renderResultItem(subpkg, tmpl)
+				if err != nil {
+					return nil, err
+				}
+
+				results = append(results, rendered)
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/pkg/ls/ls_test.go
+++ b/pkg/ls/ls_test.go
@@ -1,0 +1,122 @@
+package ls
+
+import (
+	"testing"
+
+	"chainguard.dev/melange/pkg/build"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	buildconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/build"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+)
+
+func TestList(t *testing.T) {
+	cases := []struct {
+		name               string
+		distroDirs         []string
+		includeSubpackages bool
+		requestedPackages  []string
+		template           string
+		expectedResults    []string
+		errorAssertion     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "package names",
+			distroDirs: []string{
+				"./testdata/buildconfigs",
+			},
+			expectedResults: []string{
+				"acl",
+				"aom",
+				"apko",
+			},
+			errorAssertion: assert.NoError,
+		},
+		{
+			name: "package and subpackage names",
+			distroDirs: []string{
+				"./testdata/buildconfigs",
+			},
+			includeSubpackages: true,
+			expectedResults: []string{
+				"acl",
+				"acl-dev",
+				"libacl1",
+				"aom",
+				"aom-dev",
+				"aom-libs",
+				"apko",
+			},
+			errorAssertion: assert.NoError,
+		},
+		{
+			name: "specific package's subpackages",
+			distroDirs: []string{
+				"./testdata/buildconfigs",
+			},
+			includeSubpackages: true,
+			requestedPackages:  []string{"aom"},
+			expectedResults: []string{
+				"aom",
+				"aom-dev",
+				"aom-libs",
+			},
+			errorAssertion: assert.NoError,
+		},
+		{
+			name: "nonexistent package",
+			distroDirs: []string{
+				"./testdata/buildconfigs",
+			},
+			includeSubpackages: true,
+			requestedPackages:  []string{"nonexistent"},
+			errorAssertion:     assert.Error,
+		},
+		{
+			name: "template (e.g. show pipeline's first step)",
+			distroDirs: []string{
+				"./testdata/buildconfigs",
+			},
+			expectedResults: []string{
+				"fetch",
+				"git-checkout",
+				"git-checkout",
+			},
+			template:       "{{(index (.Pipeline) 0).Uses}}",
+			errorAssertion: assert.NoError,
+		},
+		{
+			name: "bad template",
+			distroDirs: []string{
+				"./testdata/buildconfigs",
+			},
+			template:       "{{.lsdjflksjfljslefjlsdkjflsdjfljdlfk}}",
+			errorAssertion: assert.Error,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			indices := make([]*configs.Index[build.Configuration], 0, len(tt.distroDirs))
+			for _, dir := range tt.distroDirs {
+				distroFsys := rwos.DirFS(dir)
+				buildCfgs, err := buildconfigs.NewIndex(distroFsys)
+				require.NoError(t, err)
+				indices = append(indices, buildCfgs)
+			}
+
+			opts := ListOptions{
+				BuildCfgIndices:    indices,
+				IncludeSubpackages: tt.includeSubpackages,
+				RequestedPackages:  tt.requestedPackages,
+				Template:           tt.template,
+			}
+
+			results, err := List(opts)
+			tt.errorAssertion(t, err)
+
+			assert.Equal(t, tt.expectedResults, results)
+		})
+	}
+}

--- a/pkg/ls/testdata/buildconfigs/acl.yaml
+++ b/pkg/ls/testdata/buildconfigs/acl.yaml
@@ -1,0 +1,59 @@
+package:
+  name: acl
+  version: 2.3.1
+  epoch: 4
+  description: "access control list utilities"
+  copyright:
+    - license: LGPL-2.1-or-later AND GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - attr-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://download.savannah.nongnu.org/releases/acl/acl-${{package.version}}.tar.gz
+      expected-sha256: 760c61c68901b37fdd5eefeeaf4c0c7a26bdfdd8ac747a1edff1ce0e243c11af
+
+  - runs: |
+      ./configure \
+         --prefix=/usr \
+         --libdir=/lib \
+         --libexecdir=/usr/libexec
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/lib
+      mv "${{targets.destdir}}"/lib/pkgconfig "${{targets.destdir}}"/usr/lib/
+
+  - uses: strip
+
+subpackages:
+  - name: "acl-dev"
+    description: "headers for libacl"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - acl
+
+  - name: "libacl1"
+    description: "library for managing access control lists"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/lib
+          mv "${{targets.destdir}}"/lib/libacl.so.* "${{targets.subpkgdir}}"/lib/
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 16

--- a/pkg/ls/testdata/buildconfigs/aom.yaml
+++ b/pkg/ls/testdata/buildconfigs/aom.yaml
@@ -1,0 +1,66 @@
+package:
+  name: aom
+  version: 3.6.1
+  epoch: 0
+  description: Alliance for Open Media (AOM) AV1 codec SDK
+  copyright:
+    - license: BSD-2-Clause AND custom
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - cmake
+      - perl
+      - python3
+      - yasm
+      - samurai
+      - tree
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://aomedia.googlesource.com/aom
+      tag: v${{package.version}}
+      expected-commit: 7ade96172b95adc91a5d85bf80c90989cd543ee8
+      destination: aom
+
+  - runs: |
+      cd aom
+      cmake -B build -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DBUILD_SHARED_LIBS=True \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DENABLE_TESTS="OFF"
+      ninja -C build
+      DESTDIR=${{targets.destdir}} ninja -C build install
+
+  - uses: strip
+
+  - runs: tree ${{targets.destdir}}
+
+subpackages:
+  - name: aom-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - aom
+    description: aom dev
+
+  - name: aom-libs
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libaom.so.* ${{targets.subpkgdir}}/usr/lib/
+    description: aom libs
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 17628

--- a/pkg/ls/testdata/buildconfigs/apko.yaml
+++ b/pkg/ls/testdata/buildconfigs/apko.yaml
@@ -1,0 +1,38 @@
+package:
+  name: apko
+  # When bumping the version check if the CVE/GHSA mitigations below can be removed.
+  version: 0.9.0
+  epoch: 0
+  description: Build OCI images using APK directly without Dockerfile
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/apko
+      tag: v${{package.version}}
+      expected-commit: 1e5f9dbfd40406c0219c30ffa9ee34007814a438
+      destination: apko
+
+  - runs: |
+      cd apko
+      make apko
+      install -m755 -D ./apko "${{targets.destdir}}"/usr/bin/apko
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/apko
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Adds new root command `wolfictl ls`. This command lists packages that are defined in the given directory.

(This command uses "advisory-command-style" auto-detection or specified via `-d <path/to/distro/directory>`.)

## Usage

```console
$ wolfictl ls
7zip
acl
acme.sh
aerospike
alpine-keys
alsa-lib
...
```

### Subpackages

Specify `-s`/`--subpackages` to include subpackages.

```console
$ wolfictl ls -s
7zip
7zip-doc
acl
acl-dev
libacl1
```

### Specific packages

Pass package names as args to select a specific package. This is operating on _parsed_ configurations, **so factors like `range` data are already considered.**

```console
$ wolfictl ls -s glibc
glibc
ld-linux
glibc-dev
...
glibc-locale-af
glibc-locale-agr
glibc-locale-ak
glibc-locale-am
glibc-locale-an
glibc-locale-anp
glibc-locale-ar
glibc-locale-as
glibc-locale-ast
glibc-locale-ayc
glibc-locale-az
glibc-locale-be
glibc-locale-bem
...
```

The command exits 1 if any specified package can't be found, so this can be used in scripting to check for the existence of a package.

```console
$ wolfictl ls some-new-package 2>/dev/null; echo $?
1
```

### Querying via templates

You can also use the `-f`/`--format` flag to pass in a literal [Go template](https://pkg.go.dev/text/template) as means of rendering data in a particular way, or querying for specific fields in the Melange configuration on a per-package basis.

E.g.: see what licenses are used:

```console
$ wolfictl ls -f '{{(index (.Package.Copyright) 0).License}}'
LGPL-2.0-only
LGPL-2.1-or-later AND GPL-2.0-or-later
GPL-3.0-only
AGPL-3.0-only
MIT
...
```

E.g. see how we're grabbing source code:

```console
$ wolfictl ls -f '{{(index (.Pipeline) 0).Uses}}'
fetch
fetch
git-checkout
git-checkout
fetch
fetch
...
```