### PR TITLE
support --pipeline-dir anywhere we can

### DIFF
--- a/pkg/cli/dot.go
+++ b/pkg/cli/dot.go
@@ -12,7 +12,7 @@ import (
 )
 
 func cmdSVG() *cobra.Command {
-	var dir string
+	var dir, pipelineDir string
 	var showDependents bool
 	d := &cobra.Command{
 		Use:   "dot",
@@ -27,7 +27,7 @@ Generate .dot output and pipe it to dot to generate a PNG
   wolfictl dot | dot -Tpng > graph.png
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pkgs, err := dag.NewPackages(os.DirFS(dir), dir)
+			pkgs, err := dag.NewPackages(os.DirFS(dir), dir, pipelineDir)
 			if err != nil {
 				return err
 			}
@@ -72,6 +72,7 @@ Generate .dot output and pipe it to dot to generate a PNG
 		},
 	}
 	d.Flags().StringVarP(&dir, "dir", "d", ".", "directory to search for melange configs")
+	d.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	d.Flags().BoolVarP(&showDependents, "show-dependents", "D", false, "show packages that depend on these packages, instead of these packages' dependencies")
 	return d
 }

--- a/pkg/cli/make.go
+++ b/pkg/cli/make.go
@@ -11,7 +11,7 @@ import (
 )
 
 func cmdMake() *cobra.Command {
-	var dir, arch string
+	var dir, pipelineDir, arch string
 	var dryrun bool
 	text := &cobra.Command{
 		Use:   "make",
@@ -19,7 +19,7 @@ func cmdMake() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			arch := types.ParseArchitecture(arch).ToAPK()
 
-			pkgs, err := dag.NewPackages(os.DirFS(dir), dir)
+			pkgs, err := dag.NewPackages(os.DirFS(dir), dir, pipelineDir)
 			if err != nil {
 				return err
 			}
@@ -59,6 +59,7 @@ func cmdMake() *cobra.Command {
 		},
 	}
 	text.Flags().StringVarP(&dir, "dir", "d", ".", "directory to search for melange configs")
+	text.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	text.Flags().StringVarP(&arch, "arch", "a", "x86_64", "architecture to build for")
 	text.Flags().BoolVar(&dryrun, "dryrun", false, "if true, only print `make` commands")
 	return text

--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -45,7 +45,7 @@ func gcloudProjectID(ctx context.Context) (string, error) {
 }
 
 func cmdPod() *cobra.Command {
-	var dir, arch, project, bundleRepo, ns, cpu, ram, sa, sdkimg, gcloudImage, cachedig, bucket, srcBucket, publicKeyBucket, signingKeyName, melangeBuildOpts string
+	var dir, pipelineDir, arch, project, bundleRepo, ns, cpu, ram, sa, sdkimg, gcloudImage, cachedig, bucket, srcBucket, publicKeyBucket, signingKeyName, melangeBuildOpts string
 
 	var create, watch, secretKey bool
 	var pendingTimeout time.Duration
@@ -74,7 +74,7 @@ func cmdPod() *cobra.Command {
 
 			targets := []string{"all"}
 			if len(args) > 0 {
-				pkgs, err := dag.NewPackages(os.DirFS(dir), dir)
+				pkgs, err := dag.NewPackages(os.DirFS(dir), dir, pipelineDir)
 				if err != nil {
 					return err
 				}
@@ -355,6 +355,7 @@ gcloud --quiet storage cp \
 		},
 	}
 	pod.Flags().StringVarP(&dir, "dir", "d", ".", "directory to search for melange configs")
+	pod.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	pod.Flags().StringVarP(&arch, "arch", "a", "x86_64", "architecture to build for")
 	pod.Flags().StringVar(&bundleRepo, "bundle-repo", "", "OCI repository to push the bundle to; if unset, gcr.io/$PROJECT/dag")
 	pod.Flags().StringVar(&project, "project", "", "GCP project; if unset, detects project configured by gcloud")

--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -14,7 +14,7 @@ import (
 )
 
 func cmdText() *cobra.Command {
-	var dir, arch, t string
+	var dir, pipelineDir, arch, t string
 	var showDependents bool
 	text := &cobra.Command{
 		Use:   "text",
@@ -22,7 +22,7 @@ func cmdText() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			arch := types.ParseArchitecture(arch).ToAPK()
 
-			pkgs, err := dag.NewPackages(os.DirFS(dir), dir)
+			pkgs, err := dag.NewPackages(os.DirFS(dir), dir, pipelineDir)
 			if err != nil {
 				return err
 			}
@@ -66,6 +66,7 @@ func cmdText() *cobra.Command {
 		},
 	}
 	text.Flags().StringVarP(&dir, "dir", "d", ".", "directory to search for melange configs")
+	text.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	text.Flags().StringVarP(&arch, "arch", "a", "x86_64", "architecture to build for")
 	text.Flags().BoolVarP(&showDependents, "show-dependents", "D", false, "show packages that depend on these packages, instead of these packages' dependencies")
 	text.Flags().StringVarP(&t, "type", "t", string(typeTarget), fmt.Sprintf("What type of text to emit; values can be one of: %v", textTypes))

--- a/pkg/dag/graph_test.go
+++ b/pkg/dag/graph_test.go
@@ -20,7 +20,7 @@ func TestNewGraph(t *testing.T) {
 			testDir = "testdata/basic"
 		)
 		t.Run("allowed dangling", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir)
+			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
 			graph, err := NewGraph(pkgs, WithAllowUnresolved())
 			require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestNewGraph(t *testing.T) {
 			}
 		})
 		t.Run("has expected tree", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir)
+			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
 			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
@@ -89,13 +89,13 @@ func TestNewGraph(t *testing.T) {
 	t.Run("complex", func(t *testing.T) {
 		var testDir = "testdata/complex"
 		t.Run("allowed dangling", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir)
+			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
 			_, err = NewGraph(pkgs, WithAllowUnresolved())
 			require.NoError(t, err)
 		})
 		t.Run("external dependencies only", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir)
+			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
 			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestNewGraph(t *testing.T) {
 			}
 		})
 		t.Run("internal and external dependencies", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir)
+			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
 			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestNewGraph(t *testing.T) {
 		})
 
 		t.Run("internal dependencies numbered", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir)
+			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
 			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestNewGraph(t *testing.T) {
 				"d": {"a:1.3.5-r1@local"},
 			}
 		)
-		pkgs, err := NewPackages(os.DirFS(testDir), testDir)
+		pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
 		require.NoError(t, err)
 		graph, err := NewGraph(pkgs, WithRepos(cyclePackageRepo), WithKeys(cycleKey))
 		require.NoError(t, err)

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -126,7 +126,7 @@ func (p *Packages) addProvides(c *Configuration, provides []string) error {
 //
 // The repetition of the path is necessary because of how the upstream parser in melange
 // requires the full path to the directory to be passed in.
-func NewPackages(fsys fs.FS, dirPath string) (*Packages, error) {
+func NewPackages(fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
 	pkgs := &Packages{
 		configs:  make(map[string][]*Configuration),
 		packages: make(map[string][]*Configuration),
@@ -195,6 +195,7 @@ func NewPackages(fsys fs.FS, dirPath string) (*Packages, error) {
 			// .environment.contents.packages so the next block can include those as build deps.
 			pctx := &build.PipelineContext{
 				Context: &build.Context{
+					PipelineDir:   pipelineDir,
 					Configuration: *c.Configuration,
 				},
 				Package: &c.Package,

--- a/pkg/dag/packages_test.go
+++ b/pkg/dag/packages_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewPackages(t *testing.T) {
 	// for now, just a simple test that the loaded info is correct
 	testdir := "testdata/complex"
-	pkgs, err := NewPackages(os.DirFS(testdir), testdir)
+	pkgs, err := NewPackages(os.DirFS(testdir), testdir, "")
 	require.NoError(t, err)
 
 	// should have named packages that match what is in the files and *not* the filenames


### PR DESCRIPTION
This enables us to define custom pipeline directories to use outside of the ones built-in to melange.

https://github.com/wolfi-dev/os/pull/3579 added such a pipeline for Wolfi, `go-fips/build`, which was `go/build` but using `go-fips` instead of `go`. It probably doesn't make sense to have this defined in Melange itself.

With this change, `wolfictl text` considers the `--pipeline-dir` passed to it when determining the build graph, instead of failing to find the pipeline.