### PR TITLE
Add new 'sbom' command

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -27,6 +27,7 @@ func New() *cobra.Command {
 		Check(),
 		Lint(),
 		Ls(),
+		SBOM(),
 		Scan(),
 		Update(),
 		VEX(),

--- a/pkg/cli/sbom.go
+++ b/pkg/cli/sbom.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/formats/syftjson"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/sbom"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	sbomFormatOutline  = "outline"
+	sbomFormatSyftJSON = "syft-json"
+)
+
+func SBOM() *cobra.Command {
+	p := &sbomParams{}
+	cmd := &cobra.Command{
+		Use:           "sbom <path/to/package.apk>",
+		Short:         "Generate a software bill of materials (SBOM) for an APK file",
+		Hidden:        true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !slices.Contains([]string{sbomFormatOutline, sbomFormatSyftJSON}, p.outputFormat) {
+				return fmt.Errorf("invalid output format %q, must be one of [%s]", p.outputFormat, strings.Join([]string{sbomFormatOutline, sbomFormatSyftJSON}, ", "))
+			}
+
+			apkFilePath := args[0]
+			apkFile, err := os.Open(apkFilePath)
+			if err != nil {
+				return fmt.Errorf("failed to open apk file: %w", err)
+			}
+
+			fmt.Fprintf(os.Stderr, "Will process: %s\n", path.Base(apkFilePath))
+
+			s, err := sbom.Generate(apkFile, "wolfi") // TODO: make distro configurable
+			if err != nil {
+				return fmt.Errorf("failed to generate SBOM: %w", err)
+			}
+
+			switch p.outputFormat {
+			case sbomFormatOutline:
+				tree := newPackageTree(s.Artifacts.Packages.Sorted())
+				fmt.Println(tree.render())
+
+			case sbomFormatSyftJSON:
+				model := syftjson.ToFormatModel(*s)
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetEscapeHTML(false)
+				err = enc.Encode(model)
+				if err != nil {
+					return fmt.Errorf("failed to encode SBOM: %w", err)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	p.addFlagsTo(cmd)
+	return cmd
+}
+
+type sbomParams struct {
+	outputFormat string
+}
+
+func (p *sbomParams) addFlagsTo(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", sbomFormatOutline, "output format (outline, syft-json)")
+}
+
+type packageTree struct {
+	packagesByLocation map[string][]pkg.Package
+}
+
+func newPackageTree(packages []pkg.Package) *packageTree {
+	packagesByLocation := map[string][]pkg.Package{}
+	for i := range packages {
+		p := packages[i]
+		locs := lo.Map(p.Locations.ToSlice(), func(l file.Location, _ int) string {
+			return "/" + l.RealPath
+		})
+
+		location := strings.Join(locs, ", ")
+		packagesByLocation[location] = append(packagesByLocation[location], p)
+	}
+	return &packageTree{
+		packagesByLocation: packagesByLocation,
+	}
+}
+
+func (t *packageTree) render() string {
+	locations := lo.Keys(t.packagesByLocation)
+	sort.Strings(locations)
+
+	var lines []string
+	for i, location := range locations {
+		var treeStem, verticalLine string
+		if i == len(locations)-1 {
+			treeStem = "└── "
+			verticalLine = " "
+		} else {
+			treeStem = "├── "
+			verticalLine = "│"
+		}
+
+		line := treeStem + fmt.Sprintf("📄 %s", location)
+		lines = append(lines, line)
+
+		packages := t.packagesByLocation[location]
+
+		sort.SliceStable(packages, func(i, j int) bool {
+			return packages[i].Name < packages[j].Name
+		})
+
+		for i := range packages {
+			p := packages[i]
+			line := fmt.Sprintf(
+				"%s       📦 %s %s %s",
+				verticalLine,
+				p.Name,
+				p.Version,
+				styleSubtle.Render("("+string(p.Type)+")"),
+			)
+			lines = append(lines, line)
+		}
+
+		lines = append(lines, verticalLine)
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -1,0 +1,77 @@
+package sbom
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/linux"
+	"github.com/anchore/syft/syft/pkg/cataloger"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+	"github.com/wolfi-dev/wolfictl/pkg/tar"
+)
+
+var syftCatalogersEnabled = []string{
+	"apkdb",
+	"binary",
+	"dotnet-deps",
+	"go-module-binary",
+	"graalvm-native-image",
+	"java",
+	"javascript-package",
+	"php-composer-installed",
+	"portage",
+	"python-package",
+	"r-package-cataloger",
+	"ruby-gemspec",
+}
+
+// Generate creates an SBOM for the given APK file.
+func Generate(f io.Reader, distroID string) (*sbom.SBOM, error) {
+	// Create a temp directory to house the unpacked APK file
+	tempDir, err := os.MkdirTemp("", "wolfictl-sbom-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Unpack apk to temp directory
+	err = tar.Untar(f, tempDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack apk file: %w", err)
+	}
+
+	src, err := source.NewFromDirectory(
+		source.DirectoryConfig{
+			Path: tempDir,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create source from directory: %w", err)
+	}
+
+	cfg := cataloger.DefaultConfig()
+	cfg.Catalogers = syftCatalogersEnabled
+
+	packageCollection, _, _, err := syft.CatalogPackages(src, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to catalog packages: %w", err)
+	}
+
+	s := sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages: packageCollection,
+			LinuxDistribution: &linux.Release{
+				ID: distroID,
+			},
+		},
+		Source: src.Describe(),
+		Descriptor: sbom.Descriptor{
+			Name: "wolfictl",
+		},
+	}
+
+	return &s, nil
+}


### PR DESCRIPTION
Similar to the `wolfictl scan` command, this command lets you target a local APK file and inspect it for packages, using Syft. The default view is a summary outline. But you can also get an SBOM in Syft format using `-o syft-json`. The motivation for supporting this output format is to feed it into a soon-to-come revision of the `scan` command.

Preview:

<img width="926" alt="image" src="https://github.com/wolfi-dev/wolfictl/assets/5199289/83275dfa-1210-470b-aca0-659a9ad90829">


And w/ `-o syft-json`:

<img width="1079" alt="image" src="https://github.com/wolfi-dev/wolfictl/assets/5199289/45f5416a-b425-4460-9833-fe19c6089fc4">
