### PR TITLE
Use --canned-acl=publicRead

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -280,10 +280,10 @@ done
 
 set -x
 
-# Don't cache the APKINDEX, and leave it public if it already is.
+# Don't cache the APKINDEX, and make sure it's publicly readable.
 gcloud --quiet storage cp \
 	--cache-control=no-store \
-	--preserve-acl \
+        --canned-acl=publicRead \
 	"./packages/{{.arch}}/APKINDEX.tar.gz" gs://{{.bucket}}{{.arch}}/ || true
 
 # apks will be cached in CDN for an hour by default.


### PR DESCRIPTION
This is an attempt to get our private packages' APKINDEXes to stop getting reset to private when we update them.

- https://cloud.google.com/sdk/gcloud/reference/storage/cp#--canned-acl
- https://cloud.google.com/storage/docs/access-control/lists#predefined-acl


This was attempted before in https://github.com/wolfi-dev/wolfictl/pull/259/files (reverted in https://github.com/wolfi-dev/wolfictl/pull/264) using `gsutil cp -a`. I'm not sure why we didn't use `gcloud storage cp --canned-acl` at that time, it may not have been supported then, but is now:

> This isn't supported by the gcloud surface[...]