### PR TITLE
Minor advisory prompt improvements

### DIFF
--- a/pkg/cli/components/advisory/field/text_field.go
+++ b/pkg/cli/components/advisory/field/text_field.go
@@ -72,7 +72,6 @@ type TextValidationRule func(string) error
 func NewTextField(cfg TextFieldConfiguration) TextField {
 	t := textinput.New()
 	t.Cursor.Style = styles.Default()
-	t.CharLimit = 32
 
 	t.Prompt = cfg.Prompt
 

--- a/pkg/cli/components/advisory/prompt/model.go
+++ b/pkg/cli/components/advisory/prompt/model.go
@@ -100,6 +100,21 @@ func (m Model) newActionFieldConfig() field.TextFieldConfiguration {
 	}
 }
 
+func (m Model) newImpactFieldConfig() field.TextFieldConfiguration {
+	return field.TextFieldConfiguration{
+		Prompt: "Impact: ",
+		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
+			req.Impact = value
+			return req
+		},
+		ValidationRules: []field.TextValidationRule{
+			func(_ string) error {
+				return nil
+			},
+		},
+	}
+}
+
 func (m Model) newJustificationFieldConfig() field.ListFieldConfiguration {
 	return field.ListFieldConfiguration{
 		Prompt:  "Justification: ",
@@ -197,7 +212,11 @@ func (m Model) addMissingFields() (Model, bool) {
 			return m, true
 		}
 
-		// TODO: Prompt for Impact if folks want to enter it. (There's a gotcha if adding it if left blank.)
+		if m.Request.Impact == "" {
+			f := field.NewTextField(m.newImpactFieldConfig())
+			m.fields = append(m.fields, f)
+			return m, true
+		}
 	}
 
 	return m, false


### PR DESCRIPTION
Two improvements:

- Remove character limit for text fields (it had been `32`)
- Prompt for `impact` field when status is `not_affected`