### PR TITLE
Revert "Use --canned-acl=publicRead"

### DIFF
--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -280,10 +280,10 @@ done
 
 set -x
 
-# Don't cache the APKINDEX, and make sure it's publicly readable.
+# Don't cache the APKINDEX, and leave it public if it already is.
 gcloud --quiet storage cp \
 	--cache-control=no-store \
-        --canned-acl=publicRead \
+	--preserve-acl \
 	"./packages/{{.arch}}/APKINDEX.tar.gz" gs://{{.bucket}}{{.arch}}/ || true
 
 # apks will be cached in CDN for an hour by default.


### PR DESCRIPTION
Reverts wolfi-dev/wolfictl#305

```
2023-07-21T18:53:35.1371014Z Copying file://./packages/aarch64/APKINDEX.tar.gz to gs://wolfi-production-registry-destination/os/aarch64/APKINDEX.tar.gz
2023-07-21T18:53:35.1481180Z   
2023-07-21T18:53:35.6403211Z ERROR: HTTPError 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access
```