### PR TITLE
wolfi update: fix issue where updates come from release monitor so th…

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -737,6 +737,10 @@ func (o *Options) getPackagesToUpdate(latestVersions map[string]NewVersionResult
 
 		// if versions match but the commit doesn't then we need to update the commit
 		// this can occur when an upstream project recreated a tag with a new commit
+		// if release monitor was used we won't have a commit sha
+		if v.Commit == "" {
+			return results, nil
+		}
 		if currentVersionSemver.Equal(latestVersionSemver) {
 			for i := range pc.Config.Pipeline {
 				pipeline := &pc.Config.Pipeline[i]

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -215,6 +215,16 @@ func TestOptions_getPackagesToUpdate(t *testing.T) {
 			want: map[string]NewVersionResults{"foo": {Version: "2.0.0", BumpEpoch: false}}, // new version
 		},
 		{
+			// simulates an update from Release Monitor
+			name: "no update and no commit sha",
+			args: args{
+				latestVersions: map[string]NewVersionResults{
+					"foo": {Version: "1.0.0", Commit: "", BumpEpoch: false}, // same version and no commit
+				},
+			},
+			want: map[string]NewVersionResults{},
+		},
+		{
 			// if versions match but the commit doesn't then we need to update the commit
 			// this can occur when an upstream project recreated a tag with a new commit
 			name: "update as we have incorrect expected commit",


### PR DESCRIPTION
…ey have no related commit sha

A recent [change](https://github.com/wolfi-dev/wolfictl/pull/300) to handle upstream projects that re-release using the same tag but different commit sha was added.  However this is causing some PRs to be created incorrectly...

https://github.com/wolfi-dev/os/pull/4042/files
https://github.com/wolfi-dev/os/pull/4039/files
https://github.com/wolfi-dev/os/pull/4043/files

This PR will fix this, if the latest upstream version came from release monitor then there will be no associated commit sha, therefore we should not add to the map of packages to update.