### PR TITLE
ci: check that `wolfictl text` runs on wolfi-dev/os

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,4 +39,4 @@ jobs:
         with:
           repository: 'wolfi-dev/os'
           path: 'wolfi-os'
-      - run: wolfictl text -d wolfi-os --type=name --pipeline-dir=wolfi-os/pipelines/
+      - run: ./wolfictl text -d wolfi-os --type=name --pipeline-dir=wolfi-os/pipelines/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,3 +22,21 @@ jobs:
       - uses: chainguard-dev/actions/goimports@main
       - run: make wolfictl
       - run: make test
+
+  wolfictl-text:
+    name: wolfictl text on wolfi-dev/os
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version: '1.20'
+          check-latest: true
+
+      - run: make wolfictl
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          repository: 'wolfi-dev/os'
+          path: 'wolfi-os'
+      - run: wolfictl text -d wolfi-os --type=name --pipeline-dir=wolfi-os/pipelines/


### PR DESCRIPTION
This should hopefully help us guard against DAG regressions that affect wolfi-dev/os's usage before we find out about them when we start using them in that repo.