### PR TITLE
remove replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,6 @@ module github.com/wolfi-dev/wolfictl
 
 go 1.20
 
-replace gitlab.alpinelinux.org/alpine/go => gitlab.alpinelinux.org/jdolitsky/go v0.5.2-0.20230428222852-3db8d023b49b
-
-// See https://github.com/kubernetes/kube-openapi/issues/404
-// And https://github.com/kubernetes/client-go/issues/1084#issuecomment-1584750974
-replace k8s.io/client-go => k8s.io/client-go v0.28.0-alpha.2
-
 require (
 	chainguard.dev/apko v0.9.1-0.20230711074042-37b82f3a5bd8
 	chainguard.dev/melange v0.4.1-0.20230728095210-1a45952a5b7b
@@ -56,7 +50,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.0-alpha.4
 	k8s.io/apimachinery v0.28.0-alpha.4
-	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
+	k8s.io/client-go v0.28.0-alpha.4
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	sigs.k8s.io/release-utils v0.7.5-0.20230601212346-3866fe05b204
 )

--- a/go.sum
+++ b/go.sum
@@ -1112,6 +1112,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zealic/xignore v0.3.3 h1:EpLXUgZY/JEzFkTc+Y/VYypzXtNz+MSOMVCGW5Q4CKQ=
 github.com/zealic/xignore v0.3.3/go.mod h1:lhS8V7fuSOtJOKsvKI7WfsZE276/7AYEqokv3UiqEAU=
+gitlab.alpinelinux.org/alpine/go v0.7.1-0.20230613043312-f696350aabb4 h1:4+AOhkYK3ppV5regspb7kzQfXxE48ZeOnL6ThKmwqKc=
+gitlab.alpinelinux.org/alpine/go v0.7.1-0.20230613043312-f696350aabb4/go.mod h1:maZIvJ1++n6Tc3VI+Ta2Sys2OjEmuoXhd92aRzeIjZI=
 gitlab.alpinelinux.org/jdolitsky/go v0.5.2-0.20230428222852-3db8d023b49b h1:YhVxsRKdQWwJuqQnBDM376PoO7lHAa2CngOaYadNxuE=
 gitlab.alpinelinux.org/jdolitsky/go v0.5.2-0.20230428222852-3db8d023b49b/go.mod h1:maZIvJ1++n6Tc3VI+Ta2Sys2OjEmuoXhd92aRzeIjZI=
 go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
@@ -1823,6 +1825,8 @@ k8s.io/apimachinery v0.28.0-alpha.4 h1:feRRYv5ZCA/cdoIBtPNn4YULwDfKacuQbjX7icsMP
 k8s.io/apimachinery v0.28.0-alpha.4/go.mod h1:tAiIbF8KB8+Ri2DfUWwZGwNOThIwM0fhXLnOymriu+4=
 k8s.io/client-go v0.28.0-alpha.2 h1:Rheb29eRyFmcz7wtk17zVeaM2F7I8aO3wRbuMVydMb0=
 k8s.io/client-go v0.28.0-alpha.2/go.mod h1:1JNmAg+bItB9F82fAkt71E42k+yTaH3a+rJ0ggd9NqA=
+k8s.io/client-go v0.28.0-alpha.4 h1:JM2btRkaPT6l6xOoX+awo8Z7AJmuzJaqYTdF+PixSBY=
+k8s.io/client-go v0.28.0-alpha.4/go.mod h1:xmOjA2s2E0WrQELQFPnVP+X9rhyjCtsw68dK4F50PX0=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
 k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20230606174411-725288a7abf1 h1:+cCtos65A2ydaMUSnO+IXcIYvhn1H+VxclLQuXYp63g=


### PR DESCRIPTION
These make it needlessly difficult to `go install`

The alpine-go replace was so we could fetch apks slightly faster using `wolfictl apk` (which nearly nobody uses), and the other one is equivalent to just `require`ing that version.