### PR TITLE
cut weekly patch releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: release
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # weekly on Monday at 00:00
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Bump patch version and push tag
+        uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 # v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ See the [wolfictl command reference](https://github.com/wolfi-dev/wolfictl/blob/
 
 [Check so_name docs](./docs/check_so_name.md) - CI check for detecting ABI breaking changes in package version updates
 [Update docs](./docs/update.md) - for detecting new upstream wolfi package versions and creating a pull request to update Wolfi
+
+## Releases
+
+This repo is configured to automatically create weekly tagged patch releases, mainly so that it can be more easily packaged in Wolfi itself.
+
+Releases happen Monday at 00:00 UTC, and can be manually run as necessary.


### PR DESCRIPTION
In my repo: 
- https://github.com/imjasonh/wolfictl/actions/workflows/release.yaml
- https://github.com/imjasonh/wolfictl/tags

In my tests I couldn't manually run this until it had run one time automatically, so if we want to test this out before Monday we'll need to add another trigger and remove it after it works.