### PR TITLE
scan: filter out results using advisory data

### DIFF
--- a/pkg/advisory/advisory.go
+++ b/pkg/advisory/advisory.go
@@ -3,7 +3,9 @@ package advisory
 import (
 	"sort"
 
+	"github.com/openvex/go-vex/pkg/vex"
 	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	"github.com/wolfi-dev/wolfictl/pkg/versions"
 )
 
 // Latest returns the latest entry among the given set of entries for an
@@ -23,4 +25,39 @@ func Latest(entries []advisoryconfigs.Entry) *advisoryconfigs.Entry {
 
 	latestEntry := items[len(items)-1]
 	return &latestEntry
+}
+
+// IsResolved returns true if the latest entry for an advisory indicates that
+// the vulnerability is resolved for the given package. If the currentAPKVersion
+// parameter is provided, this function checks to see if the advisory can be
+// considered resolved for the given package version.
+func IsResolved(advisory []advisoryconfigs.Entry, currentAPKVersion string) bool {
+	latestEntry := Latest(advisory)
+
+	if latestEntry == nil {
+		return false
+	}
+
+	if latestEntry.Status == vex.StatusNotAffected {
+		return true
+	}
+
+	if currentAPKVersion == "" {
+		return false
+	}
+
+	fixedVersion, err := versions.NewVersion(latestEntry.FixedVersion)
+	if err != nil {
+		return false
+	}
+	currentVersion, err := versions.NewVersion(currentAPKVersion)
+	if err != nil {
+		return false
+	}
+
+	if currentVersion.GreaterThanOrEqual(fixedVersion) {
+		return true
+	}
+
+	return false
 }

--- a/pkg/cli/sbom.go
+++ b/pkg/cli/sbom.go
@@ -1,15 +1,14 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"sort"
 	"strings"
 
 	"github.com/anchore/syft/syft/file"
-	"github.com/anchore/syft/syft/formats/syftjson"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -54,12 +53,14 @@ func SBOM() *cobra.Command {
 				fmt.Println(tree.render())
 
 			case sbomFormatSyftJSON:
-				model := syftjson.ToFormatModel(*s)
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetEscapeHTML(false)
-				err = enc.Encode(model)
+				jsonReader, err := sbom.ToSyftJSON(s)
 				if err != nil {
 					return fmt.Errorf("failed to encode SBOM: %w", err)
+				}
+
+				_, err = io.Copy(os.Stdout, jsonReader)
+				if err != nil {
+					return fmt.Errorf("failed to write SBOM: %w", err)
 				}
 			}
 

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,19 +14,13 @@ import (
 	"github.com/samber/lo"
 	"github.com/savioxavier/termlink"
 	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 	"github.com/wolfi-dev/wolfictl/pkg/sbom"
 	"github.com/wolfi-dev/wolfictl/pkg/scan"
+	"golang.org/x/exp/slices"
 )
-
-const (
-	outputFormatOutline = "outline"
-	outputFormatJSON    = "json"
-)
-
-// const (
-// 	advisoryFilterResolved = "resolved"
-// 	advisoryFilterAll      = "all"
-// )
 
 func Scan() *cobra.Command {
 	p := &scanParams{}
@@ -39,71 +34,68 @@ func Scan() *cobra.Command {
 				p.outputFormat = outputFormatOutline
 			}
 
-			if p.outputFormat != outputFormatJSON && p.outputFormat != outputFormatOutline {
-				return fmt.Errorf("invalid output format %q, must be one of [%s]", p.outputFormat, strings.Join([]string{outputFormatOutline, outputFormatJSON}, ", "))
+			// Validate inputs
+
+			var advisoryCfgs *configs.Index[advisoryconfigs.Document]
+
+			if !slices.Contains(validOutputFormats, p.outputFormat) {
+				return fmt.Errorf(
+					"invalid output format %q, must be one of [%s]",
+					p.outputFormat,
+					strings.Join(validOutputFormats, ", "),
+				)
 			}
 
-			var results []Result
-
-			for _, arg := range args {
-				inputFilePath := arg
-				inputFile, err := os.Open(inputFilePath)
-				if err != nil {
-					return fmt.Errorf("failed to open input file: %w", err)
+			if p.advisoryFilterSet != "" {
+				if !slices.Contains(scan.ValidAdvisoriesSets, p.advisoryFilterSet) {
+					return fmt.Errorf(
+						"invalid advisory filter set %q, must be one of [%s]",
+						p.advisoryFilterSet,
+						strings.Join(scan.ValidAdvisoriesSets, ", "),
+					)
 				}
-				defer inputFile.Close()
 
-				fmt.Fprintf(os.Stderr, "Will process: %s\n", path.Base(inputFilePath))
+				if p.advisoriesRepoDir == "" {
+					return errors.New("advisory-based filtering requested, but no advisories repo dir was provided")
+				}
 
-				// Get SBOM of the APK
+				advisoriesFsys := rwos.DirFS(p.advisoriesRepoDir)
+				var err error
+				advisoryCfgs, err = advisoryconfigs.NewIndex(advisoriesFsys)
+				if err != nil {
+					return fmt.Errorf("failed to load advisory documents: %w", err)
+				}
+			}
 
-				var apkSBOM io.Reader
-				if p.sbomInput {
-					apkSBOM = inputFile
-				} else {
-					// TODO: consider using a cache for generated SBOMs to save time for the user
+			// Do a scan for each arg
 
-					s, err := sbom.Generate(inputFile, "wolfi") // TODO: make this configurable
+			var scans []inputScan
+
+			for _, input := range args {
+				scannedInput, err := scanInput(input, p)
+				if err != nil {
+					return err
+				}
+
+				// If requested, filter scan results using advisories
+
+				if set := p.advisoryFilterSet; set != "" {
+					findings, err := scan.FilterWithAdvisories(scannedInput.Result, advisoryCfgs, set)
 					if err != nil {
-						return fmt.Errorf("failed to generate SBOM: %w", err)
+						return fmt.Errorf("failed to filter scan results with advisories during scan of %q: %w", input, err)
 					}
 
-					reader, err := sbom.ToSyftJSON(s)
-					if err != nil {
-						return fmt.Errorf("failed to convert SBOM to Syft JSON: %w", err)
-					}
-					apkSBOM = reader
+					scannedInput.Result.Findings = findings
 				}
 
-				// Do vulnerability scan
+				scans = append(scans, *scannedInput)
 
-				findings, err := scan.APKSBOM(apkSBOM, p.localDBFilePath)
-				if err != nil {
-					return fmt.Errorf("failed to scan APK: %w", err)
-				}
+				// Handle CLI options
 
-				// Apply advisory filter to scan results if requested
-
-				// switch p.advisoryFilter {
-				// case advisoryFilterResolved:
-				// 	findings = filterResolved(findings)
-				// case advisoryFilterAll:
-				// 	// Do nothing
-				// default:
-				// 	// Leave all results untouched!
-				// }
-
-				// Prepare final output
-
-				results = append(results, Result{
-					Target: Target{
-						File:     path.Base(inputFilePath),
-						FullPath: inputFilePath,
-					},
-					Findings: findings,
-				})
-
+				findings := scannedInput.Result.Findings
 				if p.outputFormat == outputFormatOutline {
+					// Print output immediately
+
 					if len(findings) == 0 {
 						fmt.Println("✅ No vulnerabilities found")
 					} else {
@@ -111,17 +103,17 @@ func Scan() *cobra.Command {
 						fmt.Println(tree.render())
 					}
 				}
-
 				if p.requireZeroFindings && len(findings) > 0 {
+					// Exit with error immediately if any vulnerabilities are found
 					return fmt.Errorf("more than 0 vulnerabilities found")
 				}
 			}
 
 			if p.outputFormat == outputFormatJSON {
 				enc := json.NewEncoder(os.Stdout)
-				err := enc.Encode(results)
+				err := enc.Encode(scans)
 				if err != nil {
-					return fmt.Errorf("failed to marshal results to JSON: %w", err)
+					return fmt.Errorf("failed to marshal scans to JSON: %w", err)
 				}
 			}
 
@@ -133,30 +125,78 @@ func Scan() *cobra.Command {
 	return cmd
 }
 
+func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
+	inputFile, err := os.Open(inputFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open input file: %w", err)
+	}
+	defer inputFile.Close()
+
+	fmt.Fprintf(os.Stderr, "Will process: %s\n", path.Base(inputFilePath))
+
+	// Get SBOM of the APK
+
+	var apkSBOM io.Reader
+	if p.sbomInput {
+		apkSBOM = inputFile
+	} else {
+		s, err := sbom.Generate(inputFile, p.distro)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate SBOM: %w", err)
+		}
+
+		reader, err := sbom.ToSyftJSON(s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert SBOM to Syft JSON: %w", err)
+		}
+		apkSBOM = reader
+	}
+
+	// Do vulnerability scan!
+
+	result, err := scan.APKSBOM(apkSBOM, p.localDBFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan APK using %q: %w", inputFilePath, err)
+	}
+
+	is := &inputScan{
+		InputFile: inputFilePath,
+		Result:    result,
+	}
+
+	return is, nil
+}
+
 type scanParams struct {
 	requireZeroFindings bool
 	localDBFilePath     string
 	outputFormat        string
 	sbomInput           bool
-	advisoryFilter      string
+	distro              string
+	advisoryFilterSet   string
+	advisoriesRepoDir   string
 }
 
 func (p *scanParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&p.requireZeroFindings, "require-zero", false, "exit 1 if any vulnerabilities are found")
 	cmd.Flags().StringVar(&p.localDBFilePath, "local-file-grype-db", "", "import a local grype db file")
-	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", "", fmt.Sprintf("output format (%s), defaults to %s", strings.Join([]string{outputFormatOutline, outputFormatJSON}, "|"), outputFormatOutline))
+	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", "", fmt.Sprintf("output format (%s), defaults to %s", strings.Join(validOutputFormats, "|"), outputFormatOutline))
 	cmd.Flags().BoolVarP(&p.sbomInput, "sbom", "s", false, "treat input(s) as SBOM(s) of APK(s) instead of as actual APK(s)")
-	cmd.Flags().StringVarP(&p.advisoryFilter, "advisory-filter", "A", "", fmt.Sprintf("exclude vulnerability matches that are addressed by the specified set of advisories (%s)", strings.Join([]string{advisoryFilterResolved, advisoryFilterAll}, "|")))
+	cmd.Flags().StringVar(&p.distro, "distro", "wolfi", "distro to use during vulnerability matching")
+	cmd.Flags().StringVarP(&p.advisoryFilterSet, "advisory-filter", "f", "", fmt.Sprintf("exclude vulnerability matches that are referenced from the specified set of advisories (%s)", strings.Join(scan.ValidAdvisoriesSets, "|")))
+	cmd.Flags().StringVarP(&p.advisoriesRepoDir, "advisories-repo-dir", "a", "", "local directory for advisory data")
 }
 
-type Result struct {
-	Target   Target
-	Findings []*scan.Finding
-}
+const (
+	outputFormatOutline = "outline"
+	outputFormatJSON    = "json"
+)
 
-type Target struct {
-	File     string
-	FullPath string
+var validOutputFormats = []string{outputFormatOutline, outputFormatJSON}
+
+type inputScan struct {
+	InputFile string
+	Result    *scan.Result
 }
 
 type findingsTree struct {

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -1,6 +1,8 @@
 package sbom
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/formats/syftjson"
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger"
@@ -126,4 +129,19 @@ func newAPKPackage(r io.Reader) (*pkg.Package, error) {
 	p.SetID()
 
 	return &p, nil
+}
+
+// ToSyftJSON returns the SBOM as a reader of the Syft JSON format.
+func ToSyftJSON(s *sbom.SBOM) (io.Reader, error) {
+	buf := new(bytes.Buffer)
+
+	model := syftjson.ToFormatModel(*s)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(model)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode SBOM: %w", err)
+	}
+
+	return buf, nil
 }

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -145,3 +145,13 @@ func ToSyftJSON(s *sbom.SBOM) (io.Reader, error) {
 
 	return buf, nil
 }
+
+// FromSyftJSON returns an SBOM from a reader of the Syft JSON format.
+func FromSyftJSON(r io.Reader) (*sbom.SBOM, error) {
+	s, err := syftjson.Format().Decode(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode Syft JSON: %w", err)
+	}
+
+	return s, nil
+}

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -1,0 +1,85 @@
+package scan
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+)
+
+const (
+	AdvisoriesSetResolved = "resolved"
+	AdvisoriesSetAll      = "all"
+)
+
+var ValidAdvisoriesSets = []string{AdvisoriesSetResolved, AdvisoriesSetAll}
+
+// FilterWithAdvisories filters the findings in the result based on the advisories for the target APK.
+func FilterWithAdvisories(result *Result, advisoryCfgs *configs.Index[advisoryconfigs.Document], advisoryFilterSet string) ([]*Finding, error) {
+	if result == nil {
+		return nil, fmt.Errorf("result cannot be nil")
+	}
+
+	if advisoryCfgs == nil {
+		return nil, fmt.Errorf("advisory configs cannot be nil")
+	}
+
+	documents := advisoryCfgs.Select().WhereName(result.TargetAPK.Name).Configurations()
+	if len(documents) == 0 {
+		// No advisory configs for this package, so we know we wouldn't be able to filter anything.
+		return result.Findings, nil
+	}
+
+	// We know there's an advisories document for this package, so we can get the advisories.
+	packageAdvisories := documents[0].Advisories
+
+	switch advisoryFilterSet {
+	case AdvisoriesSetAll:
+		resultFindings := lo.Filter(result.Findings, func(finding *Finding, _ int) bool {
+			adv := packageAdvisories[finding.Vulnerability.ID]
+
+			// If the advisory contains any entries, filter it out!
+			if len(adv) >= 1 {
+				return false
+			}
+
+			// Also check any listed aliases
+			for _, alias := range finding.Vulnerability.Aliases {
+				adv := packageAdvisories[alias]
+				if len(adv) >= 1 {
+					return false
+				}
+			}
+
+			return true
+		})
+
+		return resultFindings, nil
+
+	case AdvisoriesSetResolved:
+		resultFindings := lo.Filter(result.Findings, func(finding *Finding, _ int) bool {
+			adv := packageAdvisories[finding.Vulnerability.ID]
+
+			if advisory.IsResolved(adv, result.TargetAPK.Version) {
+				return false
+			}
+
+			// Also check any listed aliases
+			for _, alias := range finding.Vulnerability.Aliases {
+				adv := packageAdvisories[alias]
+
+				if advisory.IsResolved(adv, result.TargetAPK.Version) {
+					return false
+				}
+			}
+
+			return true
+		})
+
+		return resultFindings, nil
+	}
+
+	return nil, fmt.Errorf("unknown advisory filter set: %s", advisoryFilterSet)
+}

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -1,0 +1,250 @@
+package scan
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	advisoryconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+)
+
+func TestFilterWithAdvisories(t *testing.T) {
+	cases := []struct {
+		name                string
+		result              *Result
+		advisoryIndexGetter func(t *testing.T) *configs.Index[advisoryconfigs.Document]
+		advisoryFilterSet   string
+		expectedFindings    []*Finding
+		errAssertion        assert.ErrorAssertionFunc
+	}{
+		{
+			name:                "nil result",
+			result:              nil,
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "",
+			expectedFindings:    nil,
+			errAssertion:        assert.Error,
+		},
+		{
+			name:                "nil advisory index",
+			result:              &Result{},
+			advisoryIndexGetter: func(_ *testing.T) *configs.Index[advisoryconfigs.Document] { return nil },
+			advisoryFilterSet:   "",
+			expectedFindings:    nil,
+			errAssertion:        assert.Error,
+		},
+		{
+			name: "no filter set",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "42",
+				},
+				Findings: []*Finding{
+					{
+						Package: Package{
+							Name:    "compliancebot",
+							Version: "3000",
+						},
+						Vulnerability: Vulnerability{
+							ID: "CVE-2023-1234",
+						},
+					},
+				},
+			},
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "",
+			expectedFindings:    nil,
+			errAssertion:        assert.Error,
+		},
+		{
+			name: "filter set all",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "42",
+				},
+				Findings: []*Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-2023-1234",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-1999-11111",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-2000-22222",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+					},
+				},
+			},
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "all",
+			expectedFindings: []*Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-2023-1234",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
+		},
+		{
+			name: "filter set all, via alias",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "42",
+				},
+				Findings: []*Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID:      "GHSA-1234-1234-1234",
+							Aliases: []string{"CVE-1999-11111"},
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID:      "GHSA-abcd-abcd-abcd",
+							Aliases: []string{"CVE-2000-22222"},
+						},
+					},
+				},
+			},
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "all",
+			expectedFindings:    []*Finding{},
+			errAssertion:        assert.NoError,
+		},
+		{
+			name: "filter set resolved",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "42",
+				},
+				Findings: []*Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-2023-1234",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-1999-11111",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-2000-22222",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+					},
+				},
+			},
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
+			expectedFindings: []*Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-2023-1234",
+					},
+				},
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-1999-11111",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
+		},
+		{
+			name: "filter set resolved, via alias",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "42",
+				},
+				Findings: []*Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID:      "GHSA-abcd-abcd-abcd",
+							Aliases: []string{"CVE-2000-22222"},
+						},
+					},
+				},
+			},
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
+			expectedFindings:    []*Finding{},
+			errAssertion:        assert.NoError,
+		},
+		{
+			name: "filter set resolved, but fixed version not reached",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "0.13.0-r2",
+				},
+				Findings: []*Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+					},
+				},
+			},
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
+			expectedFindings: []*Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "GHSA-2h5h-59f5-c5x9",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			index := tt.advisoryIndexGetter(t)
+
+			var resultFindings []*Finding
+			var err error
+			assert.NotPanics(t, func() {
+				resultFindings, err = FilterWithAdvisories(tt.result, index, tt.advisoryFilterSet)
+			})
+			tt.errAssertion(t, err)
+			assert.Equal(t, tt.expectedFindings, resultFindings)
+		})
+	}
+}
+
+func getAdvisoriesIndex(t *testing.T) *configs.Index[advisoryconfigs.Document] {
+	t.Helper()
+
+	advFS := rwos.DirFS(path.Join("testdata", "advisories"))
+	index, err := advisoryconfigs.NewIndex(advFS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return index
+}

--- a/pkg/scan/testdata/advisories/ko.advisories.yaml
+++ b/pkg/scan/testdata/advisories/ko.advisories.yaml
@@ -1,0 +1,17 @@
+package:
+  name: ko
+
+advisories:
+  CVE-1999-11111:
+    - timestamp: 2023-05-04T10:34:34.169879-04:00
+      status: under-investigation
+
+  CVE-2000-22222:
+    - timestamp: 2023-05-04T10:34:34.169879-04:00
+      status: not_affected
+      justification: component_not_present
+
+  GHSA-2h5h-59f5-c5x9:
+    - timestamp: 2023-05-04T10:34:34.169879-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3


### PR DESCRIPTION
This adds a new feature to `wolfictl scan` that uses advisory data to filter out scan results that are already accounted for in the advisory data. This will help anyone working on adding new advisory data based on scan data by reducing the "noise" of what's already been covered in the advisory data.

### Usage

There are two ways to use the advisory data to do filtering:

1. Filter out "resolved" advisories, which will leave only scan results where we're still affected, or we're not sure yet whether we're affected
2. Filter out "all" advisories, which will hide **_any_** scan results where there is any kind of advisory recorded for that vulnerability

To use this feature, you need to provide:

- `--advisory-filter`/`-f`: the set of advisories to use in filtering (set this to `resolved` or `all`)
- `--advisories-repo-dir`/`-a`: the path to a local directory that has the advisory data (**NOTE**: This MUST be set when filtering. The "auto-detection" used in other `wolfictl` commands has not been added here, while we look at a potential adjustment to how distro detection works holistically.)

### Demo

Here's an initial scan of a package:

```console
$ w scan ./packages/aarch64/kyverno-1.10.2-r0.apk                                   
Will process: kyverno-1.10.2-r0.apk
└── 📄 /usr/bin/kyverno
        📦 github.com/sigstore/rekor v1.0.1 (go-module)
            High CVE-2023-30551 GHSA-2h5h-59f5-c5x9 fixed in 1.1.1
            Medium CVE-2023-33199 GHSA-frqx-jfcm-6jjr fixed in 1.2.0
```

Let's say we've determined the first finding is a false positive. So, we create the appropriate advisory entry for that vulnerability:

```yaml
package:
  name: kyverno

advisories:
  CVE-2023-30551:
    - timestamp: 2023-08-06T09:17:13.52965-04:00
      status: not_affected
      # ...
```

Now, we'll re-run the scan, but we'll ask to filter out any vuln matches addressed in resolved advisory entries:

```console
$ w scan ./packages/aarch64/kyverno-1.10.2-r0.apk -a ../wolfi-advisories -f resolved
Will process: kyverno-1.10.2-r0.apk
└── 📄 /usr/bin/kyverno
        📦 github.com/sigstore/rekor v1.0.1 (go-module)
            Medium CVE-2023-33199 GHSA-frqx-jfcm-6jjr fixed in 1.2.0
```