### PR TITLE
fix: use correct yam config for non-cwd advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/anchore/syft v0.86.1
 	github.com/chainguard-dev/go-apk v0.0.0-20230710230135-7fc46e8b3c4d
 	github.com/chainguard-dev/kontext v0.1.0
-	github.com/chainguard-dev/yam v0.0.0-20230612072630-1e2fc91b1eb4
+	github.com/chainguard-dev/yam v0.0.0-20230807153807-4de7c531f3e1
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/charmbracelet/lipgloss v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/chainguard-dev/go-apk v0.0.0-20230710230135-7fc46e8b3c4d h1:FiATZeiXc
 github.com/chainguard-dev/go-apk v0.0.0-20230710230135-7fc46e8b3c4d/go.mod h1:woT/bFOpXAUI8PgmogdS4IPPwdNdfhg8XnNQeA+R7j8=
 github.com/chainguard-dev/kontext v0.1.0 h1:GFnDRZiqa+anUi7tzZMECXr0nwt4Eo/zMzTQPLRXUIs=
 github.com/chainguard-dev/kontext v0.1.0/go.mod h1:hdyG5Sia0niCW8HN8MDXcDh/nL0sgcWQYSjPRFZOX/w=
-github.com/chainguard-dev/yam v0.0.0-20230612072630-1e2fc91b1eb4 h1:8fusC0j3DfEPwGr7DkG60G6YVkUb1hLHa8wNJV7r6E8=
-github.com/chainguard-dev/yam v0.0.0-20230612072630-1e2fc91b1eb4/go.mod h1:okUhPc01MlA/ss50BH6m4pYGs13ErgelZYP1a0LEHTk=
+github.com/chainguard-dev/yam v0.0.0-20230807153807-4de7c531f3e1 h1:DognYXAUXsGd53ieS7GMCayC98zGvl0TBAomnwBWO0Q=
+github.com/chainguard-dev/yam v0.0.0-20230807153807-4de7c531f3e1/go.mod h1:okUhPc01MlA/ss50BH6m4pYGs13ErgelZYP1a0LEHTk=
 github.com/charmbracelet/bubbles v0.16.1 h1:6uzpAAaT9ZqKssntbvZMlksWHruQLNxg49H5WdeuYSY=
 github.com/charmbracelet/bubbles v0.16.1/go.mod h1:2QCp9LFlEsBQMvIYERr7Ww2H2bA7xen1idUDIzm/+Xc=
 github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06RaW2cx/SY=

--- a/pkg/configs/index.go
+++ b/pkg/configs/index.go
@@ -166,14 +166,14 @@ func (i *Index[T]) format(filepath string) error {
 	yamConfig, err := i.fsys.Open(path.Join(path.Dir(filepath), yamutil.ConfigFileName))
 	if err != nil {
 		// This formatting was "best effort", so just return without formatting in this case.
-		return err
+		return nil
 	}
 	defer yamConfig.Close()
 
 	encodeOptions, err := formatted.ReadConfigFrom(yamConfig)
 	if err != nil {
 		// This formatting was "best effort", so just return without formatting in this case.
-		return err
+		return nil
 	}
 
 	err = yam.Format(yamFsysAdapter{i.fsys}, []string{filepath}, yam.FormatOptions{EncodeOptions: *encodeOptions})


### PR DESCRIPTION
Previously, the use of `.AutomaticConfig()` was reading the yam config from the current working directory, even if `wolfictl` was interacting with advisory data in a _different_ directory, and the net result was that the correct formatting wasn't used for the advisories directory.

cc: @ajayk @kaniini 