### PR TITLE
SBOM-related optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 
 `wolfictl` is a command line tool for working with Wolfi
 
+## Installation
+
+You can install  `wolfictl` straight from its source code. To do this, clone the git repository and then run `go install`:
+
+```bash
+# Clone the repo
+
+git clone git@github.com:wolfi-dev/wolfictl.git wolfictl && cd $_
+
+# Install the `wolfictl` command
+
+go install
+```
 
 ## Commands
 

--- a/pkg/cli/sbom.go
+++ b/pkg/cli/sbom.go
@@ -45,9 +45,9 @@ func SBOM() *cobra.Command {
 
 			var s *sbomSyft.SBOM
 			if p.disableSBOMCache {
-				s, err = sbom.Generate(apkFilePath, apkFile, "wolfi") // TODO: make distro configurable
+				s, err = sbom.Generate(apkFilePath, apkFile, p.distro)
 			} else {
-				s, err = sbom.CachedGenerate(apkFilePath, apkFile, "wolfi") // TODO: make distro configurable
+				s, err = sbom.CachedGenerate(apkFilePath, apkFile, p.distro)
 			}
 			if err != nil {
 				return fmt.Errorf("failed to generate SBOM: %w", err)
@@ -80,11 +80,13 @@ func SBOM() *cobra.Command {
 
 type sbomParams struct {
 	outputFormat     string
+	distro           string
 	disableSBOMCache bool
 }
 
 func (p *sbomParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", sbomFormatOutline, "output format (outline, syft-json)")
+	cmd.Flags().StringVar(&p.distro, "distro", "wolfi", "distro to report in SBOM")
 	cmd.Flags().BoolVar(&p.disableSBOMCache, "disable-sbom-cache", false, "don't use the SBOM cache")
 }
 

--- a/pkg/cli/sbom.go
+++ b/pkg/cli/sbom.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
+	sbomSyft "github.com/anchore/syft/syft/sbom"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/sbom"
@@ -42,7 +43,12 @@ func SBOM() *cobra.Command {
 
 			fmt.Fprintf(os.Stderr, "Will process: %s\n", path.Base(apkFilePath))
 
-			s, err := sbom.Generate(apkFile, "wolfi") // TODO: make distro configurable
+			var s *sbomSyft.SBOM
+			if p.disableSBOMCache {
+				s, err = sbom.Generate(apkFilePath, apkFile, "wolfi") // TODO: make distro configurable
+			} else {
+				s, err = sbom.CachedGenerate(apkFilePath, apkFile, "wolfi") // TODO: make distro configurable
+			}
 			if err != nil {
 				return fmt.Errorf("failed to generate SBOM: %w", err)
 			}
@@ -73,11 +79,13 @@ func SBOM() *cobra.Command {
 }
 
 type sbomParams struct {
-	outputFormat string
+	outputFormat     string
+	disableSBOMCache bool
 }
 
 func (p *sbomParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", sbomFormatOutline, "output format (outline, syft-json)")
+	cmd.Flags().BoolVar(&p.disableSBOMCache, "disable-sbom-cache", false, "don't use the SBOM cache")
 }
 
 type packageTree struct {

--- a/pkg/sbom/cache.go
+++ b/pkg/sbom/cache.go
@@ -1,0 +1,98 @@
+package sbom
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/adrg/xdg"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+var sbomCacheDirectory = path.Join(xdg.CacheHome, "wolfictl", "sbom", "apk")
+
+func cachedSBOMPath(inputFilePath string, f io.Reader) (string, error) {
+	h := sha256.New()
+	_, err := io.Copy(h, f)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash input file: %w", err)
+	}
+
+	digest := h.Sum(nil)
+	apkFilename := path.Base(inputFilePath)
+	apkFilename = apkFilename[:len(apkFilename)-len(path.Ext(apkFilename))]
+
+	return path.Join(sbomCacheDirectory, fmt.Sprintf("%s-sha256-%x.syft.json", apkFilename, digest)), nil
+}
+
+// CachedGenerate behaves similarly to Generate, but it caches the result of the
+// SBOM generation using the user's local XDG cache home directory. Furthermore,
+// if a generated SBOM is already available in the cache for the given APK,
+// CachedGenerate will return the cached SBOM immediately instead of generating
+// a new SBOM.
+func CachedGenerate(inputFilePath string, f io.ReadSeeker, distroID string) (*sbom.SBOM, error) {
+	// Check cache first
+
+	cachedPath, err := cachedSBOMPath(inputFilePath, f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute cached SBOM path: %w", err)
+	}
+
+	cached, err := os.Open(cachedPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to open cached SBOM for %q: %w", inputFilePath, err)
+		}
+
+		// Cache miss. Generate the SBOM.
+
+		_, err := f.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, fmt.Errorf("failed to seek to start of input file: %w", err)
+		}
+
+		s, err := Generate(inputFilePath, f, distroID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate SBOM: %w", err)
+		}
+
+		// Cache the new SBOM for retrieval later.
+
+		err = os.MkdirAll(path.Dir(cachedPath), 0o755)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cache directory: %w", err)
+		}
+
+		cached, err := os.Create(cachedPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cached SBOM file: %w", err)
+		}
+		defer cached.Close()
+
+		jsonReader, err := ToSyftJSON(s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert SBOM to Syft JSON: %w", err)
+		}
+
+		_, err = io.Copy(cached, jsonReader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to write SBOM to cache: %w", err)
+		}
+
+		// Finally, return the SBOM.
+
+		return s, nil
+	}
+
+	// Cache hit!
+
+	defer cached.Close()
+	s, err := FromSyftJSON(cached)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cached SBOM (%s): %w", cachedPath, err)
+	}
+
+	return s, nil
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -35,7 +35,7 @@ var syftCatalogersEnabled = []string{
 }
 
 // Generate creates an SBOM for the given APK file.
-func Generate(f io.Reader, distroID string) (*sbom.SBOM, error) {
+func Generate(inputFilePath string, f io.Reader, distroID string) (*sbom.SBOM, error) {
 	// Create a temp directory to house the unpacked APK file
 	tempDir, err := os.MkdirTemp("", "wolfictl-sbom-*")
 	if err != nil {
@@ -86,7 +86,7 @@ func Generate(f io.Reader, distroID string) (*sbom.SBOM, error) {
 				ID: distroID,
 			},
 		},
-		Source: getDeterministicSourceDescription(src),
+		Source: getDeterministicSourceDescription(src, inputFilePath),
 		Descriptor: sbom.Descriptor{
 			Name: "wolfictl",
 		},
@@ -95,13 +95,13 @@ func Generate(f io.Reader, distroID string) (*sbom.SBOM, error) {
 	return &s, nil
 }
 
-func getDeterministicSourceDescription(src *source.DirectorySource) source.Description {
+func getDeterministicSourceDescription(src *source.DirectorySource, inputFilePath string) source.Description {
 	description := src.Describe()
 
 	description.ID = "(redacted for determinism)"
-	description.Name = "(tmpdir: redacted for determinism)"
+	description.Name = inputFilePath
 	metadata := source.DirectorySourceMetadata{
-		Path: "(tmpdir: redacted for determinism)",
+		Path: inputFilePath,
 	}
 	description.Metadata = metadata
 

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -86,13 +86,26 @@ func Generate(f io.Reader, distroID string) (*sbom.SBOM, error) {
 				ID: distroID,
 			},
 		},
-		Source: src.Describe(),
+		Source: getDeterministicSourceDescription(src),
 		Descriptor: sbom.Descriptor{
 			Name: "wolfictl",
 		},
 	}
 
 	return &s, nil
+}
+
+func getDeterministicSourceDescription(src *source.DirectorySource) source.Description {
+	description := src.Describe()
+
+	description.ID = "(redacted for determinism)"
+	description.Name = "(tmpdir: redacted for determinism)"
+	metadata := source.DirectorySourceMetadata{
+		Path: "(tmpdir: redacted for determinism)",
+	}
+	description.Metadata = metadata
+
+	return description
 }
 
 func newAPKPackage(r io.Reader) (*pkg.Package, error) {


### PR DESCRIPTION
A few useful improvements to the SBOM generation capability that's used in both `wolfictl sbom` and `wolfictl scan`:

1. JSON output is now **deterministic**.
2. SBOM data is now **cached** by default, so subsequent `sbom` and `scan` commands on a given APK file are _NOTICEABLY_ faster. This cache can be disabled with `--disable-sbom-cache`.
3. The distro ID value can now be set explicitly with `--distro` (it defaults to "wolfi").

---

Also, adds installation instructions to the README. 😁 