### PR TITLE
wolfictl update: fix updates from release monitor + optionally use au…

### DIFF
--- a/pkg/update/releaseMonitor.go
+++ b/pkg/update/releaseMonitor.go
@@ -34,6 +34,18 @@ const (
 	releaseMonitorURL = "https://release-monitoring.org/api/v2/versions/?project_id=%d"
 )
 
+type CustomTransport struct {
+	Transport http.RoundTripper
+	Token     string
+}
+
+func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Token %s", t.Token))
+	}
+	return t.Transport.RoundTrip(req)
+}
+
 func (m MonitorService) getLatestReleaseMonitorVersions(melangePackages map[string]*melange.Packages) (packagesToUpdate map[string]NewVersionResults, errorMessages map[string]string) {
 	packagesToUpdate = make(map[string]NewVersionResults)
 	errorMessages = make(map[string]string)

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -186,6 +186,22 @@ func TestOptions_getPackagesToUpdate(t *testing.T) {
 				},
 			},
 		},
+		"bar": {
+			Config: config.Configuration{
+				Package: config.Package{
+					Name:    "foo",
+					Version: "1.0.0",
+				},
+				Pipeline: []config.Pipeline{
+					{
+						Uses: "git-checkout",
+						With: map[string]string{
+							"expected-commit": "1234567890",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	type args struct {
@@ -234,6 +250,18 @@ func TestOptions_getPackagesToUpdate(t *testing.T) {
 				},
 			},
 			want: map[string]NewVersionResults{"foo": {Version: "1.0.0", Commit: "4444444444", BumpEpoch: true}}, // new commit
+		},
+		{
+			// simulates an update from Release Monitor
+			name: "test bug when one package has no commit sha but another requires an update",
+			args: args{
+				latestVersions: map[string]NewVersionResults{
+
+					"foo": {Version: "1.0.0", Commit: "", BumpEpoch: false},
+					"bar": {Version: "2.0.0", Commit: "", BumpEpoch: false},
+				},
+			},
+			want: map[string]NewVersionResults{"foo": {Version: "2.0.0", BumpEpoch: false}}, // new version
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
…th token

I introduced a [bug](https://github.com/wolfi-dev/wolfictl/commit/1a4970bbb4ee368a7b642aa62661d4c2a24ede10) 3 weeks ago which causes code to break out of a loop containing package updates from release monitor rather than continuing.

I've added a test case and also optionally include auth for release monitor which means we can use a lower rate limit when configured.