### PR TITLE
Fix: segfault when `relatedMetadata` is nil

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -175,6 +175,9 @@ func mapMatchToFinding(m match.Match, datastore *store.Store) (*Finding, error) 
 		if err != nil {
 			return nil, fmt.Errorf("unable to get metadata for related vulnerability %s: %w", relatedRef.ID, err)
 		}
+		if relatedMetadata == nil {
+			continue
+		}
 		relatedMetadatas = append(relatedMetadatas, relatedMetadata)
 	}
 


### PR DESCRIPTION
This bug repros with this: `wolfictl scan =(curl -sL https://packages.wolfi.dev/os/x86_64/nodejs-20-20.4.0-r0.apk)`