### PR TITLE
Add option to export in YAML

### DIFF
--- a/pkg/advisory/export.go
+++ b/pkg/advisory/export.go
@@ -10,7 +10,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	"github.com/wolfi-dev/wolfictl/pkg/configs/advisory"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type ExportOptions struct {

--- a/pkg/advisory/export_test.go
+++ b/pkg/advisory/export_test.go
@@ -13,7 +13,7 @@ import (
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 )
 
-func TestExport(t *testing.T) {
+func TestExportCSV(t *testing.T) {
 	cases := []struct {
 		name               string
 		advisoryDirs       []string
@@ -44,7 +44,7 @@ func TestExport(t *testing.T) {
 				AdvisoryCfgIndices: indices,
 			}
 
-			exported, err := Export(opts)
+			exported, err := ExportCSV(opts)
 			tt.errorAssertion(t, err)
 
 			exportedBytes, err := io.ReadAll(exported)
@@ -55,7 +55,7 @@ func TestExport(t *testing.T) {
 				require.NoError(t, err)
 
 				if diff := cmp.Diff(string(expectedBytes), string(exportedBytes)); diff != "" {
-					t.Errorf("Export() produced unexpected data (-want +got):\n%s", diff)
+					t.Errorf("ExportCSV() produced unexpected data (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/pkg/cli/advisory_export.go
+++ b/pkg/cli/advisory_export.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
@@ -56,10 +57,10 @@ func AdvisoryExport() *cobra.Command {
 			switch p.format {
 			case OutputYAML:
 				export, err = advisory.ExportYAML(opts)
-			case OutputCSV, OutputDefault:
+			case OutputCSV:
 				export, err = advisory.ExportCSV(opts)
 			default:
-				return fmt.Errorf("unrecognized format: %q. Valid formats are: [%q, %q, %q]", p.format, OutputDefault, OutputYAML, OutputCSV)
+				return fmt.Errorf("unrecognized format: %q. Valid formats are: [%s]", p.format, strings.Join([]string{OutputYAML, OutputCSV}, ", "))
 			}
 
 			if err != nil {
@@ -77,7 +78,6 @@ func AdvisoryExport() *cobra.Command {
 				defer outputFile.Close()
 			}
 
-			fmt.Println(export)
 			_, err = io.Copy(outputFile, export)
 			if err != nil {
 				return fmt.Errorf("unable to export data to specified location: %w", err)
@@ -103,9 +103,7 @@ type exportParams struct {
 }
 
 const (
-	// OutputDefault default output.
-	OutputDefault = ""
-	// OutputJSON JSON output.
+	// OutputYAML YAML output.
 	OutputYAML = "yaml"
 	// OutputCSV CSV output.
 	OutputCSV = "csv"
@@ -118,6 +116,5 @@ func (p *exportParams) addFlagsTo(cmd *cobra.Command) {
 
 	cmd.Flags().StringVarP(&p.outputLocation, "output", "o", "", "output location (default: stdout)")
 
-	cmd.Flags().StringVarP(&p.format, "format", "f", "",
-		fmt.Sprintf("Output format. One of: [%q, %q, %q]", OutputDefault, OutputYAML, OutputCSV))
+	cmd.Flags().StringVarP(&p.format, "format", "f", OutputCSV, fmt.Sprintf("Output format. One of: [%s]", strings.Join([]string{OutputYAML, OutputCSV}, ", ")))
 }


### PR DESCRIPTION
This change adds the option to export all advisories in a single YAML output:

```
wolfictl adv export --format yaml
```

I haven't added a test for this yet. The output order of the map of events isn't predictable yet, and it causes some instability. The format for advisories V2 will allow to test this a lot easier!