### PR TITLE
scan: support https URLs and stdin

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -140,17 +140,17 @@ func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
 		if err := t.Close(); err != nil {
 			return nil, err
 		}
-		fmt.Fprintln(os.Stderr, "Will process apk from stdin")
+		fmt.Fprintln(os.Stderr, "Will process from stdin")
 		inputFilePath = t.Name()
 	} else if strings.HasPrefix(inputFilePath, "https://") {
 		// Fetch the remote apk into a temp file.
 		t, err := os.CreateTemp("", "wolfictl-scan-")
 		if err != nil {
-			return nil, fmt.Errorf("failed to create temp file for remote apk: %w", err)
+			return nil, fmt.Errorf("failed to create temp file for remote: %w", err)
 		}
 		resp, err := http.Get(inputFilePath) //nolint:gosec
 		if err != nil {
-			return nil, fmt.Errorf("failed to download remote apk: %w", err)
+			return nil, fmt.Errorf("failed to download from remote: %w", err)
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
@@ -158,7 +158,7 @@ func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
 			if err != nil {
 				return nil, err
 			}
-			return nil, fmt.Errorf("failed to download remote apk (%d): %s", resp.StatusCode, string(all))
+			return nil, fmt.Errorf("failed to download from remote (%d): %s", resp.StatusCode, string(all))
 		}
 		if _, err := io.Copy(t, resp.Body); err != nil {
 			return nil, err

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"sort"
@@ -127,13 +128,54 @@ func Scan() *cobra.Command {
 }
 
 func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
+	if inputFilePath == "-" {
+		// Read stdin into a temp file.
+		t, err := os.CreateTemp("", "wolfictl-scan-")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp file for stdin: %w", err)
+		}
+		if _, err := io.Copy(t, os.Stdin); err != nil {
+			return nil, err
+		}
+		if err := t.Close(); err != nil {
+			return nil, err
+		}
+		fmt.Fprintln(os.Stderr, "Will process apk from stdin")
+		inputFilePath = t.Name()
+	} else if strings.HasPrefix(inputFilePath, "https://") {
+		// Fetch the remote apk into a temp file.
+		t, err := os.CreateTemp("", "wolfictl-scan-")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp file for remote apk: %w", err)
+		}
+		resp, err := http.Get(inputFilePath) //nolint:gosec
+		if err != nil {
+			return nil, fmt.Errorf("failed to download remote apk: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			all, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("failed to download remote apk (%d): %s", resp.StatusCode, string(all))
+		}
+		if _, err := io.Copy(t, resp.Body); err != nil {
+			return nil, err
+		}
+		if err := t.Close(); err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(os.Stderr, "Will process: %s\n", inputFilePath)
+		inputFilePath = t.Name()
+	} else {
+		fmt.Fprintf(os.Stderr, "Will process: %s\n", path.Base(inputFilePath))
+	}
 	inputFile, err := os.Open(inputFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open input file: %w", err)
 	}
 	defer inputFile.Close()
-
-	fmt.Fprintf(os.Stderr, "Will process: %s\n", path.Base(inputFilePath))
 
 	// Get SBOM of the APK
 

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -143,7 +143,7 @@ func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
 		fmt.Fprintln(os.Stderr, "Will process from stdin")
 		inputFilePath = t.Name()
 	} else if strings.HasPrefix(inputFilePath, "https://") {
-		// Fetch the remote apk into a temp file.
+		// Fetch the remote URL into a temp file.
 		t, err := os.CreateTemp("", "wolfictl-scan-")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp file for remote: %w", err)


### PR DESCRIPTION
```sh
$ curl -s https://packages.wolfi.dev/os/aarch64/crossplane-provider-aws-0.39.0-r0.apk | go run ./ scan -
Will process apk from stdin
✅ No vulnerabilities found
$ go run ./ scan https://packages.wolfi.dev/os/aarch64/crossplane-provider-aws-0.39.0-r0.apk            
Will process: https://packages.wolfi.dev/os/aarch64/crossplane-provider-aws-0.39.0-r0.apk
✅ No vulnerabilities found
```