### PR TITLE
add -k and -r to graph-using commands

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -25,6 +25,8 @@ func Build() *cobra.Command {
 	var dir, pipelineDir string
 	var jobs int
 	var dryrun bool
+	var extraKeys, extraRepos []string
+
 	// TODO: buildworld bool (build deps vs get them from package repo)
 	// TODO: builddownstream bool (build things that depend on listed packages)
 	cmd := &cobra.Command{
@@ -59,7 +61,9 @@ func Build() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			g, err := dag.NewGraph(pkgs)
+			g, err := dag.NewGraph(pkgs,
+				dag.WithKeys(extraKeys...),
+				dag.WithRepos(extraRepos...))
 			if err != nil {
 				return err
 			}
@@ -133,6 +137,8 @@ func Build() *cobra.Command {
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "number of jobs to run concurrently (default is GOMAXPROCS)")
 	cmd.Flags().StringSliceVar(&archs, "arch", []string{"x86_64", "aarch64"}, "arch of package to build")
 	cmd.Flags().BoolVar(&dryrun, "dry-run", false, "print commands instead of executing them")
+	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
+	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	return cmd
 }
 

--- a/pkg/cli/dot.go
+++ b/pkg/cli/dot.go
@@ -16,6 +16,7 @@ import (
 func cmdSVG() *cobra.Command {
 	var dir, pipelineDir string
 	var showDependents, buildtimeReposForRuntime bool
+	var extraKeys, extraRepos []string
 	d := &cobra.Command{
 		Use:   "dot",
 		Short: "Generate graphviz .dot output",
@@ -37,7 +38,11 @@ Generate .dot output and pipe it to dot to generate a PNG
 			if err != nil {
 				return err
 			}
-			g, err := dag.NewGraph(pkgs, dag.WithBuildtimeReposRuntime(buildtimeReposForRuntime))
+			g, err := dag.NewGraph(pkgs,
+				dag.WithBuildtimeReposRuntime(buildtimeReposForRuntime),
+				dag.WithKeys(extraKeys...),
+				dag.WithRepos(extraRepos...),
+			)
 			if err != nil {
 				return err
 			}
@@ -81,6 +86,8 @@ Generate .dot output and pipe it to dot to generate a PNG
 	d.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	d.Flags().BoolVarP(&showDependents, "show-dependents", "D", false, "show packages that depend on these packages, instead of these packages' dependencies")
 	d.Flags().BoolVar(&buildtimeReposForRuntime, "buildtime-repos-for-runtime", false, "use buildtime environment repositories to resolve runtime graph as well")
+	d.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
+	d.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	return d
 }
 

--- a/pkg/cli/pod.go
+++ b/pkg/cli/pod.go
@@ -51,6 +51,8 @@ func cmdPod() *cobra.Command {
 	var create, watch, secretKey, buildtimeReposForRuntime bool
 	var pendingTimeout time.Duration
 
+	var extraKeys, extraRepos []string
+
 	pod := &cobra.Command{
 		Use:   "pod",
 		Short: "Generate a kubernetes pod to run the build",
@@ -82,7 +84,10 @@ func cmdPod() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				g, err := dag.NewGraph(pkgs, dag.WithBuildtimeReposRuntime(buildtimeReposForRuntime))
+				g, err := dag.NewGraph(pkgs,
+					dag.WithBuildtimeReposRuntime(buildtimeReposForRuntime),
+					dag.WithKeys(extraKeys...),
+					dag.WithRepos(extraRepos...))
 				if err != nil {
 					return err
 				}
@@ -389,6 +394,8 @@ gcloud --quiet storage cp \
 	pod.Flags().StringVar(&melangeBuildOpts, "melange-build-options", "", "additional options to pass to the melange build")
 	pod.Flags().StringVar(&gcloudImage, "gcloud-image", "gcr.io/google.com/cloudsdktool/google-cloud-cli:slim", "image to use for gcloud stuff")
 	pod.Flags().BoolVar(&buildtimeReposForRuntime, "buildtime-repos-for-runtime", false, "use buildtime environment repositories to resolve runtime graph as well")
+	pod.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
+	pod.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 
 	_ = pod.MarkFlagRequired("repo") //nolint:errcheck
 	return pod

--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -17,6 +17,7 @@ import (
 func cmdText() *cobra.Command {
 	var dir, pipelineDir, arch, t string
 	var showDependents, buildtimeReposForRuntime bool
+	var extraKeys, extraRepos []string
 	text := &cobra.Command{
 		Use:   "text",
 		Short: "Print a sorted list of downstream dependent packages",
@@ -31,7 +32,10 @@ func cmdText() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			g, err := dag.NewGraph(pkgs, dag.WithBuildtimeReposRuntime(buildtimeReposForRuntime))
+			g, err := dag.NewGraph(pkgs,
+				dag.WithBuildtimeReposRuntime(buildtimeReposForRuntime),
+				dag.WithKeys(extraKeys...),
+				dag.WithRepos(extraRepos...))
 			if err != nil {
 				return err
 			}
@@ -76,6 +80,8 @@ func cmdText() *cobra.Command {
 	text.Flags().BoolVarP(&showDependents, "show-dependents", "D", false, "show packages that depend on these packages, instead of these packages' dependencies")
 	text.Flags().StringVarP(&t, "type", "t", string(typeTarget), fmt.Sprintf("What type of text to emit; values can be one of: %v", textTypes))
 	text.Flags().BoolVar(&buildtimeReposForRuntime, "buildtime-repos-for-runtime", false, "use buildtime environment repositories to resolve runtime graph as well")
+	text.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
+	text.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	return text
 }
 


### PR DESCRIPTION
This is a dependency of https://github.com/wolfi-dev/os/pull/5257 but is probably a good idea regardless.

This adds `--keyring-append` and `--repository-append` to commands in `wolfictl` that deal with the dep graph. This makes it possible to switch on/off bootstrap-awareness as compatible with https://github.com/wolfi-dev/os/pull/5257 for dep graph construction.