### PR TITLE
fix: minor issues with advisory prompts

### DIFF
--- a/pkg/cli/components/advisory/field/field.go
+++ b/pkg/cli/components/advisory/field/field.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Field interface {
+	ID() string
 	View() string
 	IsDone() bool
 	Value() string

--- a/pkg/cli/components/advisory/field/list_field.go
+++ b/pkg/cli/components/advisory/field/list_field.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ListField struct {
+	id             string
 	prompt         string
 	input          list.Model
 	done           bool
@@ -18,6 +19,9 @@ type ListField struct {
 }
 
 type ListFieldConfiguration struct {
+	// ID is a unique identifier for the field.
+	ID string
+
 	Prompt         string
 	Options        []string
 	RequestUpdater func(value string, req advisory.Request) advisory.Request
@@ -29,10 +33,15 @@ func NewListField(cfg ListFieldConfiguration) ListField {
 	l.UnselectedStyle = styles.Secondary()
 
 	return ListField{
+		id:             cfg.ID,
 		prompt:         cfg.Prompt,
 		input:          l,
 		requestUpdater: cfg.RequestUpdater,
 	}
+}
+
+func (f ListField) ID() string {
+	return f.id
 }
 
 func (f ListField) UpdateRequest(req advisory.Request) advisory.Request {

--- a/pkg/cli/components/advisory/field/text_field.go
+++ b/pkg/cli/components/advisory/field/text_field.go
@@ -22,6 +22,7 @@ const maxSuggestionsDisplayed = 4
 var ErrValueNotInAllowedSet = errors.New("value not in allowed set")
 
 type TextField struct {
+	id             string
 	allowedValues  []string
 	requestUpdater func(value string, req advisory.Request) advisory.Request
 
@@ -39,6 +40,9 @@ type TextField struct {
 }
 
 type TextFieldConfiguration struct {
+	// ID is a unique identifier for the field.
+	ID string
+
 	// Prompt is the text shown before the input field. (E.g. "Name: ")
 	Prompt string
 
@@ -76,6 +80,7 @@ func NewTextField(cfg TextFieldConfiguration) TextField {
 	t.Prompt = cfg.Prompt
 
 	return TextField{
+		id:                cfg.ID,
 		input:             t,
 		requestUpdater:    cfg.RequestUpdater,
 		allowedValues:     cfg.AllowedValues,
@@ -92,6 +97,10 @@ func NotEmpty(value string) error {
 	}
 
 	return nil
+}
+
+func (f TextField) ID() string {
+	return f.id
 }
 
 func (f TextField) runAllValidationRules(value string) error {

--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -123,7 +123,8 @@ func (adv Advisory) validateEvents() error {
 		errors.Join(lo.Map(adv.Events, func(event Event, i int) error {
 			err := event.Validate()
 			if err != nil {
-				return labelError(fmt.Sprintf("event %d", i), err)
+				// show the event index as 1-based, not 0-based, just for ease of understanding
+				return labelError(fmt.Sprintf("event %d", i+1), err)
 			}
 			return nil
 		})...),


### PR DESCRIPTION
- should prompt for "note" value for new event types: fix-not-planned, analysis-not-planned
- prompt should allow empty "note" response for true positives, since the field is optional
- prompt should require a non-empty "note" response for false positives
- non-empty response values were followed by the prompt askig for the same field again
- change event index from 0-based to 1-based in advisory validation messages