### PR TITLE
always use buildtime repos for runtime resolution

### DIFF
--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -31,6 +31,7 @@ func cmdText() *cobra.Command {
 				return err
 			}
 			g, err := dag.NewGraph(pkgs,
+				dag.WithBuildtimeReposRuntime(true),
 				dag.WithKeys(extraKeys...),
 				dag.WithRepos(extraRepos...))
 			if err != nil {


### PR DESCRIPTION
This was previously a flag in `wolfictl text`, but I think it should just always be true.

If this lands well I will remove the option to set it to false and always have it be true.