### PR TITLE
wolfi check so-name: we saw an upstream project include a soname file…

### DIFF
--- a/pkg/checks/so_name_test.go
+++ b/pkg/checks/so_name_test.go
@@ -125,7 +125,11 @@ func TestSoNameOptions_checkSonamesMatch(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "complex", existingSonameFiles: []string{"libstdc++.so.6.0.30-gdb.py"}, newSonameFiles: []string{"libstdc++.so.6.0.30-gdb.py"},
+			name: "complex_chars_with_qualifier", existingSonameFiles: []string{"libstdc++.so.6.0.30-gdb.py"}, newSonameFiles: []string{"libstdc++.so.6.0.30-gdb.py"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "ignore_non_standard_version_suffix", existingSonameFiles: []string{"libgs.so.10.02.debug"}, newSonameFiles: []string{"libgs.so.10.02.debug"},
 			wantErr: assert.NoError,
 		},
 	}


### PR DESCRIPTION
… with a suffix rather than qualifier, which failed the check

This code adds a regex to extract only the version number and any qualifiers from the soname file

An example of where this is failing

PR: https://github.com/wolfi-dev/os/pull/5553
Failed build: https://github.com/wolfi-dev/os/actions/runs/6188733019/job/16808136937?pr=5553
