### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wolfi-dev/wolfictl
 
-go 1.21.1
+go 1.21
 
 require (
 	chainguard.dev/apko v0.10.1-0.20230827210213-0f242ef6963e


### PR DESCRIPTION
Fixes error:
❯ go install
go: errors parsing go.mod:
/home/josborne/code/wolfictl/go.mod:3: invalid go version '1.21.1': must match format 1.23