### PR TITLE
check upgrade: respect tag and strip-prefix for github

### DIFF
--- a/pkg/checks/testdata/git-checkout-correct-tag.yaml
+++ b/pkg/checks/testdata/git-checkout-correct-tag.yaml
@@ -1,0 +1,19 @@
+package:
+  name: git-checkout-correct-tag
+  version: 1.10.0
+  epoch: 0
+  description: scandir, a better directory iterator and faster os.walk()
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 982e6ba60e7165ef965567eacd7138149c9ce292
+      repository: https://github.com/benhoyt/scandir
+      tag: v${{package.version}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: benhoyt/scandir
+    strip-prefix: v

--- a/pkg/checks/testdata/git-checkout-wrong-just-strip.yaml
+++ b/pkg/checks/testdata/git-checkout-wrong-just-strip.yaml
@@ -1,0 +1,19 @@
+package:
+  name: git-checkout-wrong-just-strip
+  version: 1.10.0
+  epoch: 0
+  description: scandir, a better directory iterator and faster os.walk()
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 982e6ba60e7165ef965567eacd7138149c9ce292
+      repository: https://github.com/benhoyt/scandir
+      tag: ${{package.version}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: benhoyt/scandir
+    strip-prefix: v

--- a/pkg/checks/testdata/git-checkout-wrong-no-strip.yaml
+++ b/pkg/checks/testdata/git-checkout-wrong-no-strip.yaml
@@ -1,0 +1,18 @@
+package:
+  name: git-checkout-wrong-no-strip
+  version: 1.10.0
+  epoch: 0
+  description: scandir, a better directory iterator and faster os.walk()
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 982e6ba60e7165ef965567eacd7138149c9ce292
+      repository: https://github.com/benhoyt/scandir
+      tag: v${{package.version}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: benhoyt/scandir

--- a/pkg/checks/testdata/git-checkout-wrong-tag.yaml
+++ b/pkg/checks/testdata/git-checkout-wrong-tag.yaml
@@ -1,0 +1,18 @@
+package:
+  name: git-checkout-wrong-tag
+  version: 1.10.0
+  epoch: 0
+  description: scandir, a better directory iterator and faster os.walk()
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 982e6ba60e7165ef965567eacd7138149c9ce292
+      repository: https://github.com/benhoyt/scandir
+      tag: ${{package.version}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: benhoyt/scandir


### PR DESCRIPTION
This PR fixes an issue where `check upgrade` command exists successfully by only respecting `.update` even if `git-checkout.tag` is not exist on upstream repo. This makes the `lint` step is pass on CI but resulting fail on `build` stage.