### PR TITLE
feat: better UI for advisory discovery

### DIFF
--- a/pkg/cli/components/advisory/field/text_field.go
+++ b/pkg/cli/components/advisory/field/text_field.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	selectedSuggestionStyle = styles.Accented().Copy().Underline(true)
-	helpKeyStyle            = styles.FaintAccent().Copy()
+	helpKeyStyle            = styles.FaintAccent().Copy().Bold(true)
 	helpExplanationStyle    = styles.Faint().Copy()
 )
 

--- a/pkg/cli/components/advisory/matchwatcher/model.go
+++ b/pkg/cli/components/advisory/matchwatcher/model.go
@@ -1,0 +1,335 @@
+package matchwatcher
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/savioxavier/termlink"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
+	"github.com/wolfi-dev/wolfictl/pkg/vuln"
+)
+
+var _ tea.Model = (*Model)(nil)
+
+var (
+	helpKeyStyle         = styles.FaintAccent().Copy().Bold(true)
+	helpExplanationStyle = styles.Faint().Copy()
+
+	styleSubtle = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
+
+	styleNegligible = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
+	styleLow        = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ff00"))
+	styleMedium     = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffff00"))
+	styleHigh       = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff9900"))
+	styleCritical   = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff0000"))
+)
+
+func New(vulnEvents chan interface{}, countTotalPackages int) Model {
+	return Model{
+		vulnEvents:         vulnEvents,
+		countTotalPackages: countTotalPackages,
+		spinner: spinner.New(
+			spinner.WithSpinner(spinner.Points),
+			spinner.WithStyle(styles.Faint()),
+		),
+	}
+}
+
+type Model struct {
+	// Err is an output the Model can return if something goes wrong.
+	Err error
+
+	vulnEvents         <-chan interface{}
+	countTotalPackages int
+
+	countPassedPackages int
+	countFailedPackages int
+
+	packages        []string
+	packageStateMap map[string]packageState
+
+	showEveryVulnerability bool
+
+	exiting bool
+
+	spinner spinner.Model
+}
+
+type packageState struct {
+	name         string
+	searching    bool
+	matchesFound []vuln.Match
+}
+
+func (m Model) appendPackage(ps packageState) Model {
+	if m.packageStateMap == nil {
+		m.packageStateMap = make(map[string]packageState)
+	}
+
+	m.packages = append(m.packages, ps.name)
+	m.packageStateMap[ps.name] = ps
+	return m
+}
+
+func (m Model) updatePackage(ps packageState) Model {
+	if m.packageStateMap == nil {
+		m.packageStateMap = make(map[string]packageState)
+	}
+
+	m.packageStateMap[ps.name] = ps
+	return m
+}
+
+func (m Model) removePackage(name string) Model {
+	if m.packageStateMap == nil {
+		m.packageStateMap = make(map[string]packageState)
+	}
+
+	delete(m.packageStateMap, name)
+	for i, pkg := range m.packages {
+		if pkg == name {
+			m.packages = append(m.packages[:i], m.packages[i+1:]...)
+			break
+		}
+	}
+	return m
+}
+
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(
+		m.processNextEventCmd(),
+		m.spinner.Tick,
+	)
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			m.exiting = true
+			return m, tea.Quit
+
+		case "v":
+			if m.showEveryVulnerability {
+				m.showEveryVulnerability = false
+			} else {
+				m.showEveryVulnerability = true
+			}
+			return m, nil
+
+		default:
+			return m, nil
+		}
+
+	case packageState:
+		if msg.searching {
+			return m.appendPackage(msg), m.processNextEventCmd()
+		}
+
+		// If the scan was clean, we don't need to show the package anymore.
+		if len(msg.matchesFound) == 0 {
+			m.countPassedPackages++
+			m = m.removePackage(msg.name)
+		} else {
+			m.countFailedPackages++
+			m = m.updatePackage(msg)
+		}
+
+		return m, m.processNextEventCmd()
+
+	case errMsg:
+		m.Err = msg.err
+		return m, tea.Quit
+
+	case doneMsg:
+		m.exiting = true
+		return m, tea.Quit
+
+	default:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+}
+
+func (m Model) processNextEventCmd() tea.Cmd {
+	return func() tea.Msg {
+		// TODO: make this preempt-able
+		if m.vulnEvents == nil {
+			return nil
+		}
+
+		e := <-m.vulnEvents
+		switch e := e.(type) {
+		case vuln.EventPackageMatchingStarting:
+			return packageState{
+				name:      e.Package,
+				searching: true,
+			}
+
+		case vuln.EventPackageMatchingFinished:
+			return packageState{
+				name:         e.Package,
+				searching:    false,
+				matchesFound: e.Matches,
+			}
+
+		case vuln.EventPackageMatchingError:
+			return errMsg{
+				err: e.Err,
+			}
+
+		case vuln.EventMatchingFinished:
+			return doneMsg{}
+		}
+
+		return nil
+	}
+}
+
+// doneMsg is a message that is sent when the matching reporter is done.
+type doneMsg struct{}
+
+type errMsg struct {
+	err error
+}
+
+func (m Model) View() string {
+	// Summary
+
+	viewSummary := styles.Secondary().Render(fmt.Sprintf(
+		"%d clean, %d vulnerable, %d remaining",
+		m.countPassedPackages,
+		m.countFailedPackages,
+		m.countTotalPackages-m.countPassedPackages-m.countFailedPackages,
+	))
+
+	// Package list
+
+	var searchingPackageRows []string
+	var vulnerablePackageRows []string
+
+	for _, pkg := range m.packages {
+		state := m.packageStateMap[pkg]
+
+		if state.searching {
+			msg := fmt.Sprintf(
+				"%s %s %s",
+				m.spinner.View(),
+				styles.Secondary().Render("searching for vulnerabilities:"),
+				pkg,
+			)
+			searchingPackageRows = append(searchingPackageRows, msg)
+
+			continue
+		}
+
+		vulnCount := len(state.matchesFound)
+		if vulnCount == 0 {
+			continue
+		}
+
+		if m.showEveryVulnerability {
+			row := strings.Builder{}
+			fmt.Fprintf(&row, "%s", pkg)
+
+			for i := range state.matchesFound {
+				match := state.matchesFound[i]
+				severity := ""
+				if match.Vulnerability.Severity != "" {
+					severity = renderSeverity(match.Vulnerability.Severity) + " "
+				}
+				fmt.Fprintf(&row, "\n  %s%s", severity, styleSubtle.Render(hyperlinkCVE(match.Vulnerability.ID)))
+			}
+
+			vulnerablePackageRows = append(vulnerablePackageRows, row.String())
+			continue
+		}
+
+		vulnsWord := "vulnerability"
+		if vulnCount != 1 {
+			vulnsWord = "vulnerabilities"
+		}
+
+		row := fmt.Sprintf(
+			"%s: %s",
+			pkg,
+			styles.Accented().Render(fmt.Sprintf("%d new %s", vulnCount, vulnsWord)),
+		)
+		vulnerablePackageRows = append(vulnerablePackageRows, row)
+	}
+
+	viewSearchingPackages := strings.Join(searchingPackageRows, "\n")
+	viewVulnerablePackages := strings.Join(vulnerablePackageRows, "\n")
+
+	// Help text (only if there are vulnerabilities)
+	viewHelp := ""
+	if m.countFailedPackages > 0 {
+		action := "expand"
+		if m.showEveryVulnerability {
+			action = "collapse"
+		}
+
+		viewHelp = fmt.Sprintf("%s%s",
+			helpKeyStyle.Render("v"),
+			helpExplanationStyle.Render(" to "+action+" vulnerabilities"),
+		)
+	}
+
+	// Put it all together
+
+	if viewSearchingPackages != "" {
+		viewSearchingPackages += "\n\n"
+	}
+
+	if viewVulnerablePackages != "" {
+		viewVulnerablePackages += "\n\n"
+	}
+
+	if m.exiting {
+		return fmt.Sprintf(
+			"%s%s",
+			viewVulnerablePackages,
+			viewSummary+"\n",
+		)
+	}
+
+	return fmt.Sprintf(
+		"%s%s%s%s",
+		viewSearchingPackages,
+		viewVulnerablePackages,
+		viewSummary+"\n",
+		viewHelp+"\n",
+	)
+}
+
+var termSupportsHyperlinks = termlink.SupportsHyperlinks()
+
+func hyperlinkCVE(id string) string {
+	if !termSupportsHyperlinks {
+		return id
+	}
+
+	return termlink.Link(id, fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", id))
+}
+
+func renderSeverity(severity vuln.Severity) string {
+	s := string(severity)
+
+	switch severity {
+	case vuln.SeverityLow:
+		return styleLow.Render(s)
+	case vuln.SeverityMedium:
+		return styleMedium.Render(s)
+	case vuln.SeverityHigh:
+		return styleHigh.Render(s)
+	case vuln.SeverityCritical:
+		return styleCritical.Render(s)
+	default:
+		return styleNegligible.Render(s)
+	}
+}

--- a/pkg/cli/styles/styles.go
+++ b/pkg/cli/styles/styles.go
@@ -13,7 +13,7 @@ var (
 
 	accentedLight    = lipgloss.NewStyle().Foreground(lipgloss.Color("#000000"))
 	secondaryLight   = lipgloss.NewStyle().Foreground(lipgloss.Color("#444444"))
-	faintLight       = lipgloss.NewStyle().Foreground(lipgloss.Color("#AAAAAA"))
+	faintLight       = lipgloss.NewStyle().Foreground(lipgloss.Color("#aaaaaa"))
 	faintAccentLight = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
 )
 

--- a/pkg/vuln/detector.go
+++ b/pkg/vuln/detector.go
@@ -2,85 +2,9 @@ package vuln
 
 import (
 	"context"
-
-	version "github.com/knqyf263/go-apk-version"
 )
 
 type Detector interface {
 	VulnerabilitiesForPackages(context.Context, ...string) (map[string][]Match, error)
-}
-
-type Match struct {
-	Package       Package
-	CPESearched   CPE
-	CPEFound      CPE
-	Vulnerability Vulnerability
-}
-
-type Package struct {
-	Name string
-}
-
-type Vulnerability struct {
-	ID, URL string
-}
-
-type CPE struct {
-	URI          string
-	VersionRange VersionRange
-}
-
-// VersionRange describes a continuous range of versions.
-type VersionRange struct {
-	// SingleVersion is populated when the VersionRange describes only a single
-	// version. If this field is used, all other fields should be set to their zero
-	// value.
-	SingleVersion string
-
-	VersionRangeLower          string
-	VersionRangeLowerInclusive bool
-	VersionRangeUpper          string
-	VersionRangeUpperInclusive bool
-}
-
-// Includes returns a bool indicating whether the given version is contained
-// within the VersionRange.
-//
-//nolint:errcheck // we expect to always have valid version ranges since we control those values
-func (vr VersionRange) Includes(otherVersion string) bool {
-	if vr.SingleVersion != "" {
-		return vr.SingleVersion == otherVersion
-	}
-
-	other, _ := version.NewVersion(otherVersion)
-
-	if vr.VersionRangeLower != "" {
-		lower, _ := version.NewVersion(vr.VersionRangeLower)
-
-		if vr.VersionRangeLowerInclusive {
-			if lower.Equal(other) {
-				return true
-			}
-		}
-
-		if !lower.LessThan(other) {
-			return false
-		}
-	}
-
-	if vr.VersionRangeUpper != "" {
-		upper, _ := version.NewVersion(vr.VersionRangeUpper)
-
-		if vr.VersionRangeUpperInclusive {
-			if upper.Equal(other) {
-				return true
-			}
-		}
-
-		if !upper.GreaterThan(other) {
-			return false
-		}
-	}
-
-	return true
+	VulnerabilitiesForPackage(context.Context, string) ([]Match, error)
 }

--- a/pkg/vuln/event.go
+++ b/pkg/vuln/event.go
@@ -1,0 +1,18 @@
+package vuln
+
+type EventPackageMatchingStarting struct {
+	Package string
+}
+
+type EventPackageMatchingFinished struct {
+	Package string
+	Matches []Match
+}
+
+type EventPackageMatchingError struct {
+	Package string
+	Err     error
+}
+
+type EventMatchingFinished struct {
+}

--- a/pkg/vuln/match.go
+++ b/pkg/vuln/match.go
@@ -1,0 +1,89 @@
+package vuln
+
+import version "github.com/knqyf263/go-apk-version"
+
+type Match struct {
+	Package       Package
+	CPESearched   CPE
+	CPEFound      CPE
+	Vulnerability Vulnerability
+}
+
+type Package struct {
+	Name string
+}
+
+type Vulnerability struct {
+	ID, URL  string
+	Severity Severity
+}
+
+type CPE struct {
+	URI          string
+	VersionRange VersionRange
+}
+
+// VersionRange describes a continuous range of versions.
+type VersionRange struct {
+	// SingleVersion is populated when the VersionRange describes only a single
+	// version. If this field is used, all other fields should be set to their zero
+	// value.
+	SingleVersion string
+
+	VersionRangeLower          string
+	VersionRangeLowerInclusive bool
+	VersionRangeUpper          string
+	VersionRangeUpperInclusive bool
+}
+
+// Includes returns a bool indicating whether the given version is contained
+// within the VersionRange.
+//
+//nolint:errcheck // we expect to always have valid version ranges since we control those values
+func (vr VersionRange) Includes(otherVersion string) bool {
+	if vr.SingleVersion != "" {
+		return vr.SingleVersion == otherVersion
+	}
+
+	other, _ := version.NewVersion(otherVersion)
+
+	if vr.VersionRangeLower != "" {
+		lower, _ := version.NewVersion(vr.VersionRangeLower)
+
+		if vr.VersionRangeLowerInclusive {
+			if lower.Equal(other) {
+				return true
+			}
+		}
+
+		if !lower.LessThan(other) {
+			return false
+		}
+	}
+
+	if vr.VersionRangeUpper != "" {
+		upper, _ := version.NewVersion(vr.VersionRangeUpper)
+
+		if vr.VersionRangeUpperInclusive {
+			if upper.Equal(other) {
+				return true
+			}
+		}
+
+		if !upper.GreaterThan(other) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type Severity string
+
+const (
+	SeverityUnknown  Severity = "Unknown"
+	SeverityLow      Severity = "Low"
+	SeverityMedium   Severity = "Medium"
+	SeverityHigh     Severity = "High"
+	SeverityCritical Severity = "Critical"
+)


### PR DESCRIPTION
This is just a superficial and refactoring change to the `wolfictl adv discover` command. This PR creates a new TUI component for showing the per-package vulnerability searches. This also starts to incorporate some of the UI elements from `wolfictl scan`.

![w adv discover](https://github.com/wolfi-dev/wolfictl/assets/5199289/f3ec5fc3-a5c7-47a1-a5b2-7550f8e66683)
