### PR TITLE
wolfictl lint: allow flag to override what severity of lint rules to …

### DIFF
--- a/pkg/cli/lint.go
+++ b/pkg/cli/lint.go
@@ -12,6 +12,7 @@ type lintOptions struct {
 	verbose   bool
 	list      bool
 	skipRules []string
+	severity  string
 }
 
 func cmdLint() *cobra.Command {
@@ -32,6 +33,7 @@ func cmdLint() *cobra.Command {
 	cmd.Flags().BoolVarP(&o.verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVarP(&o.list, "list", "l", false, "prints the all of available rules and exits")
 	cmd.Flags().StringArrayVarP(&o.skipRules, "skip-rule", "", []string{}, "list of rules to skip")
+	cmd.Flags().StringVarP(&o.severity, "severity", "", string(lint.SeverityError), "list of rules to skip")
 
 	cmd.AddCommand(cmdLintYam())
 
@@ -69,5 +71,6 @@ func (o lintOptions) makeLintOptions() []lint.Option {
 		lint.WithPath(o.args[0]),
 		lint.WithVerbose(o.verbose),
 		lint.WithSkipRules(o.skipRules),
+		lint.WithSeverity(o.severity),
 	}
 }

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -57,6 +57,11 @@ func (l *Linter) Lint() (Result, error) {
 	for name := range filesToLint {
 		failedRules := make(EvalRuleErrors, 0)
 		for _, rule := range rules {
+			// Check if the rule should be evaluated.
+			if string(rule.Severity) != l.options.Severity {
+				continue
+			}
+
 			// Check if we should skip this rule.
 			shouldEvaluate := true
 			if len(rule.ConditionFuncs) > 0 {

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -12,7 +12,7 @@ func newTestLinterWithDir(path string) *Linter {
 }
 
 func newTestLinterWithFile(path string) *Linter {
-	return New(WithPath(filepath.Join("testdata/files/", path)))
+	return New(WithPath(filepath.Join("testdata/files/", path)), WithSeverity("ERROR"))
 }
 
 func TestLinter_Dir(t *testing.T) {

--- a/pkg/lint/options.go
+++ b/pkg/lint/options.go
@@ -10,6 +10,9 @@ type Options struct {
 
 	// Skip rules removes the given slice of rules to be checked
 	SkipRules []string
+
+	// Severity sets the severity of the rules to be checked
+	Severity string
 }
 
 // Option represents a linter option.
@@ -33,5 +36,12 @@ func WithVerbose(verbose bool) Option {
 func WithSkipRules(skipRules []string) Option {
 	return func(o *Options) {
 		o.SkipRules = skipRules
+	}
+}
+
+// WithSeverity sets the severity rules option.
+func WithSeverity(severity string) Option {
+	return func(o *Options) {
+		o.Severity = severity
 	}
 }

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -89,7 +89,7 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 		{
 			Name:        "valid-copyright-header",
 			Description: "every package should have a valid copyright header",
-			Severity:    SeverityInfo,
+			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				if len(config.Package.Copyright) == 0 {
 					return fmt.Errorf("copyright header is missing")

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -24,9 +24,9 @@ func TestLinter_Rules(t *testing.T) {
 					{
 						Rule: Rule{
 							Name:     "valid-copyright-header",
-							Severity: SeverityInfo,
+							Severity: SeverityError,
 						},
-						Error: fmt.Errorf("[valid-copyright-header]: copyright header is missing (INFO)"),
+						Error: fmt.Errorf("[valid-copyright-header]: copyright header is missing (ERROR)"),
 					},
 				},
 			},
@@ -215,9 +215,9 @@ func TestLinter_Rules(t *testing.T) {
 					{
 						Rule: Rule{
 							Name:     "valid-copyright-header",
-							Severity: SeverityInfo,
+							Severity: SeverityError,
 						},
-						Error: fmt.Errorf("[valid-copyright-header]: copyright header is missing (INFO)"),
+						Error: fmt.Errorf("[valid-copyright-header]: copyright header is missing (ERROR)"),
 					},
 				},
 			},


### PR DESCRIPTION
…evaluate

This can be useful if a user wants to create CI jobs with different required checks for different severity levels

This also makes the copywrite rule an error as this should be mandatory