### PR TITLE
Revert "wolfictl update: transform-version needs to run before versio…

### DIFF
--- a/pkg/update/githubReleases.go
+++ b/pkg/update/githubReleases.go
@@ -624,11 +624,6 @@ func (o GitHubReleaseOptions) prepareVersion(nameHash, v, id string) (string, er
 		return "", nil
 	}
 
-	v, err := transformVersion(c.Update, v)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to transform version %s", v)
-	}
-
 	return v, nil
 }
 

--- a/pkg/update/githubReleases_test.go
+++ b/pkg/update/githubReleases_test.go
@@ -304,14 +304,6 @@ func TestGitHubReleaseOptions_prepareVersion(t *testing.T) {
 				},
 			},
 		}, version: "v1.2.3", want: "v1.2.3", wantErr: assert.NoError},
-		{name: "transform-version", melangeConfig: config.Configuration{
-			Update: config.Update{
-				VersionTransform: []config.VersionTransform{
-					{Match: "_", Replace: "."},
-				},
-				GitHubMonitor: &config.GitHubMonitor{},
-			},
-		}, version: "1_2_3", want: "1.2.3", wantErr: assert.NoError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/update/releaseMonitor.go
+++ b/pkg/update/releaseMonitor.go
@@ -115,14 +115,6 @@ func (m MonitorService) getLatestReleaseMonitorVersions(melangePackages map[stri
 			latestVersion = strings.TrimSuffix(latestVersion, p.Config.Update.ReleaseMonitor.StripSuffix)
 		}
 
-		latestVersion, err = transformVersion(p.Config.Update, latestVersion)
-		if err != nil {
-			errorMessages[p.Config.Package.Name] = fmt.Sprintf(
-				"failed to apply version transforms to %s for package %s.  Error: %s",
-				latestVersion, p.Config.Package.Name, err,
-			)
-		}
-
 		latestVersionSemver, err := version.NewVersion(latestVersion)
 		if err != nil {
 			errorMessages[p.Config.Package.Name] = fmt.Sprintf(


### PR DESCRIPTION
…ns are sorted and compared"

This reverts commit bb20ed5595d97624033c9557662e4eeac06cdfa5.

There's more edge cases to consider which will need more test cases.  We've seen an unexpected version update PR come in that uses the version transforms https://github.com/wolfi-dev/os/pull/6255.  Let's roll this commit back and add more tests to cover more edge cases.