### PR TITLE
fix: find advisories for origin package during scan filtering

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -49,8 +49,19 @@ type Result struct {
 }
 
 type TargetAPK struct {
-	Name    string
-	Version string
+	Name              string
+	Version           string
+	OriginPackageName string
+}
+
+// Origin returns the name of the origin package, if the package's metadata
+// indicates an origin package. Otherwise, it returns the package name.
+func (t TargetAPK) Origin() string {
+	if t.OriginPackageName != "" {
+		return t.OriginPackageName
+	}
+
+	return t.Name
 }
 
 func newTargetAPK(s *sbomSyft.SBOM) (TargetAPK, error) {
@@ -64,9 +75,15 @@ func newTargetAPK(s *sbomSyft.SBOM) (TargetAPK, error) {
 
 	p := pkgs[0]
 
+	metadata, ok := p.Metadata.(pkg.ApkMetadata)
+	if !ok {
+		return TargetAPK{}, fmt.Errorf("expected APK metadata, found %T", p.Metadata)
+	}
+
 	return TargetAPK{
-		Name:    p.Name,
-		Version: p.Version,
+		Name:              p.Name,
+		Version:           p.Version,
+		OriginPackageName: metadata.OriginPackage,
 	}, nil
 }
 

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -25,7 +25,7 @@ func FilterWithAdvisories(result *Result, advisoryCfgs *configs.Index[v2.Documen
 		return nil, fmt.Errorf("advisory configs cannot be nil")
 	}
 
-	documents := advisoryCfgs.Select().WhereName(result.TargetAPK.Name).Configurations()
+	documents := advisoryCfgs.Select().WhereName(result.TargetAPK.Origin()).Configurations()
 	if len(documents) == 0 {
 		// No advisory configs for this package, so we know we wouldn't be able to filter anything.
 		return result.Findings, nil

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -195,6 +195,27 @@ func TestFilterWithAdvisories(t *testing.T) {
 			errAssertion:        assert.NoError,
 		},
 		{
+			name: "filter set resolved, via origin package",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:              "some-ko-subpackage",
+					Version:           "0.13.0-r4",
+					OriginPackageName: "ko",
+				},
+				Findings: []*Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+					},
+				},
+			},
+			advisoryIndexGetter: getAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
+			expectedFindings:    []*Finding{},
+			errAssertion:        assert.NoError,
+		},
+		{
 			name: "filter set resolved, but fixed version not reached",
 			result: &Result{
 				TargetAPK: TargetAPK{


### PR DESCRIPTION
This was something I overlooked in the initial implementation of the filtering flags (i.e. `-f`/`-a`) for `wolfictl scan`.

Now, when scanning a subpackage APK, and applying advisory data to filter out scan results, the command will look up the origin package for the APK, and use that to find advisory entries. (Advisory data is always filed under the origin package name, never for the subpackage directly.)

cc: @vaikas 