### PR TITLE
feat: add rich support for advisory aliases

### DIFF
--- a/pkg/advisory/alias_finder.go
+++ b/pkg/advisory/alias_finder.go
@@ -60,11 +60,11 @@ func (f *HTTPAliasFinder) GHSAsForCVE(ctx context.Context, cveID string) ([]stri
 		return nil, err
 	}
 
-	cveIDs := lo.Map(ghsas, func(ghsa githubSecurityAdvisoryResponse, _ int) string {
+	ghsaIDs := lo.Map(ghsas, func(ghsa githubSecurityAdvisoryResponse, _ int) string {
 		return ghsa.GHSAID
 	})
 
-	return cveIDs, nil
+	return ghsaIDs, nil
 }
 
 func (f *HTTPAliasFinder) gitHubAPIGet(ctx context.Context, requestPath string, queryParameters map[string]string) (io.ReadCloser, error) {

--- a/pkg/advisory/alias_finder.go
+++ b/pkg/advisory/alias_finder.go
@@ -1,0 +1,176 @@
+package advisory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+type AliasFinder interface {
+	CVEForGHSA(ctx context.Context, ghsaID string) (string, error)
+	GHSAsForCVE(ctx context.Context, cveID string) ([]string, error)
+}
+
+type HTTPAliasFinder struct {
+	client *http.Client
+}
+
+func NewHTTPAliasFinder(client *http.Client) *HTTPAliasFinder {
+	return &HTTPAliasFinder{
+		client: client,
+	}
+}
+
+func (f *HTTPAliasFinder) CVEForGHSA(ctx context.Context, ghsaID string) (string, error) {
+	requestPath := fmt.Sprintf("/advisories/%s", url.PathEscape(ghsaID))
+	respBody, err := f.gitHubAPIGet(ctx, requestPath, nil)
+	if err != nil {
+		return "", err
+	}
+	defer respBody.Close()
+
+	var ghsa githubSecurityAdvisoryResponse
+	if err := json.NewDecoder(respBody).Decode(&ghsa); err != nil {
+		return "", err
+	}
+
+	return ghsa.CVEID, nil
+}
+
+func (f *HTTPAliasFinder) GHSAsForCVE(ctx context.Context, cveID string) ([]string, error) {
+	respBody, err := f.gitHubAPIGet(
+		ctx,
+		"/advisories",
+		map[string]string{"cve_id": cveID},
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer respBody.Close()
+
+	var ghsas []githubSecurityAdvisoryResponse
+	if err := json.NewDecoder(respBody).Decode(&ghsas); err != nil {
+		return nil, err
+	}
+
+	cveIDs := lo.Map(ghsas, func(ghsa githubSecurityAdvisoryResponse, _ int) string {
+		return ghsa.GHSAID
+	})
+
+	return cveIDs, nil
+}
+
+func (f *HTTPAliasFinder) gitHubAPIGet(ctx context.Context, requestPath string, queryParameters map[string]string) (io.ReadCloser, error) {
+	u, err := url.Parse("https://api.github.com")
+	if err != nil {
+		return nil, err
+	}
+	u.Path = requestPath
+	if queryParameters != nil {
+		q := u.Query()
+		for k, v := range queryParameters {
+			q.Set(k, v)
+		}
+		u.RawQuery = q.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header = http.Header{
+		"Accept":               []string{"application/vnd.github+json"},
+		"X-GitHub-Api-Version": []string{"2022-11-28"},
+	}
+
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		var msg []byte
+		if resp.Body != nil {
+			//nolint:errcheck // This is a best-effort attempt to read the body.
+			msg, _ = io.ReadAll(resp.Body)
+		}
+		return nil, fmt.Errorf("unexpected status code %d, body: %s", resp.StatusCode, string(msg))
+	}
+
+	return resp.Body, nil
+}
+
+type githubSecurityAdvisoryResponse struct {
+	ID                    int    `json:"id"`
+	GHSAID                string `json:"ghsa_id"`
+	CVEID                 string `json:"cve_id"`
+	URL                   string `json:"url"`
+	HTMLURL               string `json:"html_url"`
+	RepositoryAdvisoryURL string `json:"repository_advisory_url"`
+	Summary               string `json:"summary"`
+	Description           string `json:"description"`
+	Type                  string `json:"type"`
+	Severity              string `json:"severity"`
+	SourceCodeLocation    string `json:"source_code_location"`
+	Identifiers           []struct {
+		Type  string `json:"type"`
+		Value string `json:"value"`
+	} `json:"identifiers"`
+	References       []string    `json:"references"`
+	PublishedAt      time.Time   `json:"published_at"`
+	UpdatedAt        time.Time   `json:"updated_at"`
+	GitHubReviewedAt time.Time   `json:"github_reviewed_at"`
+	NVDPublishedAt   time.Time   `json:"nvd_published_at"`
+	WithdrawnAt      interface{} `json:"withdrawn_at"`
+	Vulnerabilities  []struct {
+		Package struct {
+			Ecosystem string `json:"ecosystem"`
+			Name      string `json:"name"`
+		} `json:"package"`
+		FirstPatchedVersion    string   `json:"first_patched_version"`
+		VulnerableVersionRange string   `json:"vulnerable_version_range"`
+		VulnerableFunctions    []string `json:"vulnerable_functions"`
+	} `json:"vulnerabilities"`
+	CVSS struct {
+		VectorString string  `json:"vector_string"`
+		Score        float64 `json:"score"`
+	} `json:"cvss"`
+	CWEs []struct {
+		CWEID string `json:"cwe_id"`
+		Name  string `json:"name"`
+	} `json:"cwes"`
+	Credits []struct {
+		User struct {
+			Login             string `json:"login"`
+			ID                int    `json:"id"`
+			NodeID            string `json:"node_id"`
+			AvatarURL         string `json:"avatar_url"`
+			GravatarID        string `json:"gravatar_id"`
+			URL               string `json:"url"`
+			HTMLURL           string `json:"html_url"`
+			FollowersURL      string `json:"followers_url"`
+			FollowingURL      string `json:"following_url"`
+			GistsURL          string `json:"gists_url"`
+			StarredURL        string `json:"starred_url"`
+			SubscriptionsURL  string `json:"subscriptions_url"`
+			OrganizationsURL  string `json:"organizations_url"`
+			ReposURL          string `json:"repos_url"`
+			EventsURL         string `json:"events_url"`
+			ReceivedEventsURL string `json:"received_events_url"`
+			Type              string `json:"type"`
+			SiteAdmin         bool   `json:"site_admin"`
+		} `json:"user"`
+		Type string `json:"type"`
+	} `json:"credits"`
+}

--- a/pkg/advisory/discover_aliases.go
+++ b/pkg/advisory/discover_aliases.go
@@ -3,7 +3,6 @@ package advisory
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 
 	"github.com/samber/lo"
@@ -22,9 +21,9 @@ type DiscoverAliasesOptions struct {
 	// vulnerabilities.
 	AliasFinder AliasFinder
 
-	// SelectedPackages is the list of packages to operate on. If empty, all
-	// packages will be operated on.
-	SelectedPackages []string
+	// SelectedPackages is the set of packages to operate on. If empty, all packages
+	// will be operated on.
+	SelectedPackages map[string]struct{}
 }
 
 // DiscoverAliases queries external data sources for aliases for the
@@ -37,7 +36,8 @@ func DiscoverAliases(ctx context.Context, opts DiscoverAliasesOptions) error {
 	// advisory documents to just those packages.
 	if len(opts.SelectedPackages) > 0 {
 		documents = lo.Filter(documents, func(doc v2.Document, _ int) bool {
-			return slices.Contains(opts.SelectedPackages, doc.Package.Name)
+			_, ok := opts.SelectedPackages[doc.Package.Name]
+			return ok
 		})
 	}
 

--- a/pkg/advisory/discover_aliases.go
+++ b/pkg/advisory/discover_aliases.go
@@ -1,0 +1,150 @@
+package advisory
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/samber/lo"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	"github.com/wolfi-dev/wolfictl/pkg/vuln"
+)
+
+// DiscoverAliasesOptions is the set of options for the DiscoverAliases
+// function.
+type DiscoverAliasesOptions struct {
+	// AdvisoryDocs is the Index of advisory documents on which to operate.
+	AdvisoryDocs *configs.Index[v2.Document]
+
+	// AliasFinder is the alias finder to use for discovering aliases for the given
+	// vulnerabilities.
+	AliasFinder AliasFinder
+
+	// SelectedPackages is the list of packages to operate on. If empty, all
+	// packages will be operated on.
+	SelectedPackages []string
+}
+
+// DiscoverAliases queries external data sources for aliases for the
+// vulnerabilities described in the selected advisories and updates the advisory
+// documents with the discovered aliases.
+func DiscoverAliases(ctx context.Context, opts DiscoverAliasesOptions) error {
+	documents := opts.AdvisoryDocs.Select().Configurations()
+
+	// If the caller selected specific packages (by name), filter the set of
+	// advisory documents to just those packages.
+	if len(opts.SelectedPackages) > 0 {
+		documents = lo.Filter(documents, func(doc v2.Document, _ int) bool {
+			return slices.Contains(opts.SelectedPackages, doc.Package.Name)
+		})
+	}
+
+	for _, doc := range documents {
+		for _, adv := range doc.Advisories {
+			// If the advisory ID is already a CVE ID, do a lookup and ensure the discovered
+			// aliases are present in the advisory's list of aliases.
+			if vuln.RegexCVE.MatchString(adv.ID) {
+				ghsas, err := opts.AliasFinder.GHSAsForCVE(ctx, adv.ID)
+				if err != nil {
+					return err
+				}
+				updatedAliases := lo.Uniq(append(adv.Aliases, ghsas...))
+				adv.Aliases = updatedAliases
+
+				u := v2.NewAdvisoriesSectionUpdater(func(doc v2.Document) (v2.Advisories, error) {
+					advisories := doc.Advisories.Update(adv.ID, adv)
+
+					// Ensure the package's advisory list is sorted before returning it.
+					sort.Sort(advisories)
+
+					return advisories, nil
+				})
+				err = opts.AdvisoryDocs.Select().WhereName(doc.Name()).Update(u)
+				if err != nil {
+					return err
+				}
+
+				continue
+			}
+
+			// If the advisory ID isn't a CVE ID, lookup aliases for this ID, and see if
+			// there exists a CVE ID among those aliases. If so, adjust the advisory so that
+			// the advisory ID is this CVE ID, and ensure all other IDs are present in the
+			// advisory's list of aliases (including the advisory's original ID).
+			if vuln.RegexGHSA.MatchString(adv.ID) {
+				cve, err := opts.AliasFinder.CVEForGHSA(ctx, adv.ID)
+				if err != nil {
+					return err
+				}
+				if cve == "" {
+					// No CVE ID was found for this GHSA ID, so there's nothing else we can do here.
+					continue
+				}
+
+				// Rearrange the data so that the advisory ID is set to the CVE ID, and the GHSA
+				// ID, which was originally the value of the advisory ID, is now an alias.
+				ghsaFromAdvisoryID := adv.ID
+				adv.ID = cve
+				adv.Aliases = append(adv.Aliases, ghsaFromAdvisoryID)
+
+				if _, ok := doc.Advisories.Get(cve); ok {
+					// This CVE ID is already present in the document as the ID of another advisory.
+					// This means we'd end up with two advisories with the same ID, which is not
+					// allowed. Rather than try any kind of merging operation, this should be
+					// resolved manually, so we'll error out here.
+					return DuplicateAdvisoryIDError{
+						Package:    doc.Package.Name,
+						AdvisoryID: cve,
+					}
+				}
+
+				ghsas, err := opts.AliasFinder.GHSAsForCVE(ctx, cve)
+				if err != nil {
+					return err
+				}
+
+				updatedAliases := lo.Uniq(append(adv.Aliases, ghsas...))
+				adv.Aliases = updatedAliases
+
+				u := v2.NewAdvisoriesSectionUpdater(func(doc v2.Document) (v2.Advisories, error) {
+					// First, check if there would be a collision with the new CVE ID. If so, error
+					// out.
+
+					// Note: Until updated, the advisory in the document still has the original
+					// ID (i.e. the GHSA ID).
+					advisories := doc.Advisories.Update(ghsaFromAdvisoryID, adv)
+
+					// Ensure the package's advisory list is sorted before returning it.
+					sort.Sort(advisories)
+
+					return advisories, nil
+				})
+				err = opts.AdvisoryDocs.Select().WhereName(doc.Name()).Update(u)
+				if err != nil {
+					return err
+				}
+
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+// DuplicateAdvisoryIDError is returned when an attempt is made to add an
+// advisory with an ID that already exists in the document.
+type DuplicateAdvisoryIDError struct {
+	// Package is the name of the package that already has an advisory with the same
+	// ID.
+	Package string
+
+	// AdvisoryID is the ID of the advisory that already exists in the document.
+	AdvisoryID string
+}
+
+func (e DuplicateAdvisoryIDError) Error() string {
+	return fmt.Sprintf("package %q: rejecting duplicate advisory ID: %q", e.Package, e.AdvisoryID)
+}

--- a/pkg/advisory/discover_aliases_test.go
+++ b/pkg/advisory/discover_aliases_test.go
@@ -148,7 +148,7 @@ func TestDiscoverAliases(t *testing.T) {
 			opts := DiscoverAliasesOptions{
 				AdvisoryDocs:     advisoryDocs,
 				AliasFinder:      mockAF,
-				SelectedPackages: []string{tt.selectedPackage},
+				SelectedPackages: map[string]struct{}{tt.selectedPackage: {}},
 			}
 
 			err = DiscoverAliases(context.Background(), opts)

--- a/pkg/advisory/discover_aliases_test.go
+++ b/pkg/advisory/discover_aliases_test.go
@@ -1,0 +1,183 @@
+package advisory
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	"github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os/memfs"
+)
+
+func TestDiscoverAliases(t *testing.T) {
+	cases := []struct {
+		name                    string
+		selectedPackage         string
+		expectedUpdatedDocument v2.Document
+		wantErr                 bool
+	}{
+		{
+			name:            "find GHSA alias for a CVE",
+			selectedPackage: "scenario-1",
+			expectedUpdatedDocument: v2.Document{
+				SchemaVersion: "2",
+				Package: v2.Package{
+					Name: "scenario-1",
+				},
+				Advisories: v2.Advisories{
+					{
+						ID:      "CVE-2222-2222",
+						Aliases: []string{"GHSA-2222-2222-2222"},
+					},
+				},
+			},
+		},
+		{
+			name:            "find CVE for GHSA advisory ID and move GHSA ID to aliases",
+			selectedPackage: "scenario-2",
+			expectedUpdatedDocument: v2.Document{
+				SchemaVersion: "2",
+				Package: v2.Package{
+					Name: "scenario-2",
+				},
+				Advisories: v2.Advisories{
+					{
+						ID:      "CVE-2222-2222",
+						Aliases: []string{"GHSA-2222-2222-2222"},
+					},
+				},
+			},
+		},
+		{
+			name:            "no-op for non-CVE, non-GHSA advisory ID",
+			selectedPackage: "scenario-3",
+			expectedUpdatedDocument: v2.Document{
+				SchemaVersion: "2",
+				Package: v2.Package{
+					Name: "scenario-3",
+				},
+				Advisories: v2.Advisories{
+					{
+						ID: "FOO-2222-2222",
+					},
+				},
+			},
+		},
+		{
+			name:            "no-op for CVE advisory ID with no discoverable aliases",
+			selectedPackage: "scenario-4",
+			expectedUpdatedDocument: v2.Document{
+				SchemaVersion: "2",
+				Package: v2.Package{
+					Name: "scenario-4",
+				},
+				Advisories: v2.Advisories{
+					{
+						ID: "CVE-4444-4444",
+					},
+				},
+			},
+		},
+		{
+			name:            "no-op for GHSA advisory ID with no discoverable aliases",
+			selectedPackage: "scenario-5",
+			expectedUpdatedDocument: v2.Document{
+				SchemaVersion: "2",
+				Package: v2.Package{
+					Name: "scenario-5",
+				},
+				Advisories: v2.Advisories{
+					{
+						ID: "GHSA-3333-3333-3333",
+					},
+				},
+			},
+		},
+		{
+			name:            "advisory ID changing to a CVE necessitates a re-sort of advisories",
+			selectedPackage: "scenario-6",
+			expectedUpdatedDocument: v2.Document{
+				SchemaVersion: "2",
+				Package: v2.Package{
+					Name: "scenario-6",
+				},
+				Advisories: v2.Advisories{
+					{
+						ID: "CVE-1111-1111",
+						Aliases: []string{
+							"GHSA-5555-5555-5555",
+						},
+					},
+					{
+						ID: "GHSA-3333-3333-3333",
+					},
+				},
+			},
+		},
+		{
+			name:            "advisory ID changing to a CVE creates a duplicate advisory ID, which should error out",
+			selectedPackage: "scenario-7",
+			wantErr:         true,
+		},
+	}
+
+	mockAF := &mockAliasFinder{
+		cveByGHSA: map[string]string{
+			"GHSA-2222-2222-2222": "CVE-2222-2222",
+			"GHSA-3333-3333-3333": "",
+			"GHSA-5555-5555-5555": "CVE-1111-1111",
+		},
+		ghsasByCVE: map[string][]string{
+			"CVE-2222-2222": {"GHSA-2222-2222-2222"},
+			"CVE-4444-4444": nil,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// We'll use the memfs implementation so that our updates don't actually write
+			// back to disk.
+			fsys := memfs.New(os.DirFS("testdata/discover_aliases/advisories"))
+
+			advisoryDocs, err := v2.NewIndex(fsys)
+			if err != nil {
+				t.Fatalf("unable to create advisory docs index: %v", err)
+			}
+
+			opts := DiscoverAliasesOptions{
+				AdvisoryDocs:     advisoryDocs,
+				AliasFinder:      mockAF,
+				SelectedPackages: []string{tt.selectedPackage},
+			}
+
+			err = DiscoverAliases(context.Background(), opts)
+
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("DiscoverAliases() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// If we got an error, and we expected one, we're done.
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.expectedUpdatedDocument, advisoryDocs.Select().WhereName(tt.selectedPackage).Configurations()[0]); diff != "" {
+				t.Errorf("DiscoverAliases() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type mockAliasFinder struct {
+	cveByGHSA  map[string]string
+	ghsasByCVE map[string][]string
+}
+
+func (f *mockAliasFinder) CVEForGHSA(_ context.Context, ghsaID string) (string, error) {
+	return f.cveByGHSA[ghsaID], nil
+}
+
+func (f *mockAliasFinder) GHSAsForCVE(_ context.Context, cveID string) ([]string, error) {
+	return f.ghsasByCVE[cveID], nil
+}

--- a/pkg/advisory/export.go
+++ b/pkg/advisory/export.go
@@ -41,7 +41,9 @@ func ExportCSV(opts ExportOptions) (io.Reader, error) {
 
 					switch event.Type {
 					case v2.EventTypeTruePositiveDetermination:
-						note = event.Data.(v2.TruePositiveDetermination).Note
+						if event.Data != nil {
+							note = event.Data.(v2.TruePositiveDetermination).Note
+						}
 
 					case v2.EventTypeFalsePositiveDetermination:
 						fp, _ := event.Data.(v2.FalsePositiveDetermination) //nolint:errcheck

--- a/pkg/advisory/testdata/discover_aliases/advisories/.yam.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/.yam.yaml
@@ -1,0 +1,5 @@
+gap:
+  - "."
+  - ".advisories"
+
+indent: 2

--- a/pkg/advisory/testdata/discover_aliases/advisories/scenario-1.advisories.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/scenario-1.advisories.yaml
@@ -1,0 +1,7 @@
+schema-version: "2"
+
+package:
+  name: scenario-1
+
+advisories:
+  - id: CVE-2222-2222

--- a/pkg/advisory/testdata/discover_aliases/advisories/scenario-2.advisories.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/scenario-2.advisories.yaml
@@ -1,0 +1,7 @@
+schema-version: "2"
+
+package:
+  name: scenario-2
+
+advisories:
+  - id: GHSA-2222-2222-2222

--- a/pkg/advisory/testdata/discover_aliases/advisories/scenario-3.advisories.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/scenario-3.advisories.yaml
@@ -1,0 +1,7 @@
+schema-version: "2"
+
+package:
+  name: scenario-3
+
+advisories:
+  - id: FOO-2222-2222

--- a/pkg/advisory/testdata/discover_aliases/advisories/scenario-4.advisories.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/scenario-4.advisories.yaml
@@ -1,0 +1,7 @@
+schema-version: "2"
+
+package:
+  name: scenario-4
+
+advisories:
+  - id: CVE-4444-4444

--- a/pkg/advisory/testdata/discover_aliases/advisories/scenario-5.advisories.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/scenario-5.advisories.yaml
@@ -1,0 +1,7 @@
+schema-version: "2"
+
+package:
+  name: scenario-5
+
+advisories:
+  - id: GHSA-3333-3333-3333

--- a/pkg/advisory/testdata/discover_aliases/advisories/scenario-6.advisories.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/scenario-6.advisories.yaml
@@ -1,0 +1,9 @@
+schema-version: "2"
+
+package:
+  name: scenario-6
+
+advisories:
+  - id: GHSA-3333-3333-3333
+
+  - id: GHSA-5555-5555-5555

--- a/pkg/advisory/testdata/discover_aliases/advisories/scenario-7.advisories.yaml
+++ b/pkg/advisory/testdata/discover_aliases/advisories/scenario-7.advisories.yaml
@@ -1,0 +1,9 @@
+schema-version: "2"
+
+package:
+  name: scenario-7
+
+advisories:
+  - id: CVE-2222-2222
+
+  - id: GHSA-2222-2222-2222

--- a/pkg/advisory/update.go
+++ b/pkg/advisory/update.go
@@ -32,8 +32,6 @@ func Update(req Request, opts UpdateOptions) error {
 			return nil, fmt.Errorf("advisory %q does not exist", vulnID)
 		}
 
-		// TODO: update the advisory's aliases, too
-
 		adv.Events = append(adv.Events, req.Event)
 		advisories = advisories.Update(vulnID, adv)
 

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -32,14 +32,17 @@ func cmdAdvisory() *cobra.Command {
 		Short:         "Utilities for viewing and modifying Wolfi advisory data",
 	}
 
-	cmd.AddCommand(cmdAdvisoryList())
-	cmd.AddCommand(cmdAdvisoryCreate())
-	cmd.AddCommand(cmdAdvisoryUpdate())
-	cmd.AddCommand(cmdAdvisoryDiscover())
-	cmd.AddCommand(cmdAdvisoryDB())
-	cmd.AddCommand(cmdAdvisoryValidate())
-	cmd.AddCommand(cmdAdvisoryExport())
-	cmd.AddCommand(cmdAdvisoryMigrate())
+	cmd.AddCommand(
+		cmdAdvisoryAlias(),
+		cmdAdvisoryCreate(),
+		cmdAdvisoryDB(),
+		cmdAdvisoryDiscover(),
+		cmdAdvisoryExport(),
+		cmdAdvisoryList(),
+		cmdAdvisoryMigrate(),
+		cmdAdvisoryUpdate(),
+		cmdAdvisoryValidate(),
+	)
 
 	return cmd
 }
@@ -52,7 +55,7 @@ func resolveDistroDir(cliFlagValue string) string {
 	return os.Getenv(envVarNameForDistroDir)
 }
 
-func resolveAdvisoriesDir(cliFlagValue string) string {
+func resolveAdvisoriesDirInput(cliFlagValue string) string {
 	if v := cliFlagValue; v != "" {
 		return v
 	}

--- a/pkg/cli/advisory_alias.go
+++ b/pkg/cli/advisory_alias.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func cmdAdvisoryAlias() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alias",
+		Short: "Utilities for viewing and modifying Wolfi advisory aliases",
+	}
+
+	cmd.AddCommand(
+		cmdAdvisoryAliasDiscover(),
+		cmdAdvisoryAliasFind(),
+	)
+
+	return cmd
+}

--- a/pkg/cli/advisory_alias_discover.go
+++ b/pkg/cli/advisory_alias_discover.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+	"github.com/wolfi-dev/wolfictl/pkg/distro"
+)
+
+func cmdAdvisoryAliasDiscover() *cobra.Command {
+	p := &aliasDiscoverParams{}
+	cmd := &cobra.Command{
+		Use:   "discover",
+		Short: "discover new aliases for vulnerabilities in the advisory data",
+		Long: `Discover new aliases for vulnerabilities in the advisory data.
+
+This command reads the advisory data and searches for new aliases for the ID 
+and aliases of each advisory. For any new aliases found, the advisory data is 
+updated to include the new alias.
+
+This command uses the GitHub API to query GHSA information. Note that GitHub 
+enforces a stricter rate limit against unauthenticated API calls. You can 
+authenticate this command's API calls by setting the environment variable 
+GITHUB_TOKEN to a personal access token. When performing alias discovery across 
+the entire data set, authenticating these API calls is highly recommended.
+
+You may pass one or more instances of -p/--package to have the command operate 
+on only one or more packages, rather than on the entire advisory data set.
+
+Where possible, this command also normalizes advisories to use the relevant CVE 
+ID as the advisory ID instead of an ID from another vulnerability namespace. 
+This means, for example, that a non-CVE ID (e.g. a GHSA ID) that was previously 
+the advisory ID will be moved to the advisory's aliases if a canonical CVE ID 
+is discovered, since the CVE ID will become the advisory's new ID.
+
+In cases where an advisory's ID is updated, the advisory document will be 
+re-sorted by advisory ID so that the resulting advisories are still sorted 
+correctly. Also, if updating an advisory ID results in an advisory document 
+having two or more advisories with the same ID, the command errors out rather 
+than attempting any kind of merge of the separate advisories.
+`,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			advisoriesRepoDir := resolveAdvisoriesDirInput(p.advisoriesRepoDir)
+			if advisoriesRepoDir == "" {
+				if p.doNotDetectDistro {
+					return fmt.Errorf("no advisories repo dir specified")
+				}
+
+				d, err := distro.Detect()
+				if err != nil {
+					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
+				}
+
+				advisoriesRepoDir = d.AdvisoriesRepoDir
+				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
+			}
+
+			advisoriesFsys := rwos.DirFS(advisoriesRepoDir)
+			advisoryDocs, err := v2.NewIndex(advisoriesFsys)
+			if err != nil {
+				return err
+			}
+
+			opts := advisory.DiscoverAliasesOptions{
+				AdvisoryDocs:     advisoryDocs,
+				AliasFinder:      advisory.NewHTTPAliasFinder(http.DefaultClient),
+				SelectedPackages: p.packages,
+			}
+
+			return advisory.DiscoverAliases(cmd.Context(), opts)
+		},
+	}
+
+	p.addFlagsTo(cmd)
+	return cmd
+}
+
+type aliasDiscoverParams struct {
+	advisoriesRepoDir string
+	doNotDetectDistro bool
+
+	packages []string
+}
+
+func (p *aliasDiscoverParams) addFlagsTo(cmd *cobra.Command) {
+	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
+	addNoDistroDetectionFlag(&p.doNotDetectDistro, cmd)
+
+	cmd.Flags().StringSliceVarP(&p.packages, "package", "p", nil, "packages to operate on")
+}

--- a/pkg/cli/advisory_alias_discover.go
+++ b/pkg/cli/advisory_alias_discover.go
@@ -68,10 +68,15 @@ than attempting any kind of merge of the separate advisories.
 				return err
 			}
 
+			selectedPackageSet := make(map[string]struct{})
+			for _, pkg := range p.packages {
+				selectedPackageSet[pkg] = struct{}{}
+			}
+
 			opts := advisory.DiscoverAliasesOptions{
 				AdvisoryDocs:     advisoryDocs,
 				AliasFinder:      advisory.NewHTTPAliasFinder(http.DefaultClient),
-				SelectedPackages: p.packages,
+				SelectedPackages: selectedPackageSet,
 			}
 
 			return advisory.DiscoverAliases(cmd.Context(), opts)

--- a/pkg/cli/advisory_alias_find.go
+++ b/pkg/cli/advisory_alias_find.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	"github.com/wolfi-dev/wolfictl/pkg/vuln"
+)
+
+func cmdAdvisoryAliasFind() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "find <vulnerability ID> [<vulnerability ID>...]",
+		Short: "query upstream data sources for aliases for the given vulnerability ID(s)",
+		Long: `This is a utility command to query upstream data sources to find aliases for 
+the given vulnerability ID(s).
+
+Vulnerability IDs can be CVE IDs (e.g. CVE-2021-44228) or GHSA IDs (e.g. 
+GHSA-jfh8-c2jp-5v3q).
+
+You may specify multiple vulnerability IDs at once.
+
+If your terminal supports hyperlinks, vulnerability IDs in the output will be 
+hyperlinked to the upstream data source.
+`,
+		Example: `
+$ wolfictl advisory alias find CVE-2021-44228                   
+Aliases for CVE-2021-44228:
+  - GHSA-jfh8-c2jp-5v3q
+
+$ wolfictl advisory alias find GHSA-f9jg-8p32-2f55 CVE-2020-8552
+Aliases for GHSA-f9jg-8p32-2f55:
+  - CVE-2021-25743
+
+Aliases for CVE-2020-8552:
+  - GHSA-82hx-w2r5-c2wq`,
+		SilenceErrors: true,
+		Args:          cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			af := advisory.NewHTTPAliasFinder(http.DefaultClient)
+
+			for i, arg := range args {
+				aliases, err := findAliases(cmd.Context(), af, arg)
+				if err != nil {
+					return fmt.Errorf("unable to find aliases for vulnerability %q: %w", arg, err)
+				}
+
+				fmt.Printf("Aliases for %s:\n", hyperlinkVulnerabilityID(arg))
+
+				for _, alias := range aliases {
+					fmt.Printf("  - %s\n", hyperlinkVulnerabilityID(alias))
+				}
+
+				// Add a blank line between queries.
+				if i < len(args)-1 {
+					fmt.Println()
+				}
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func findAliases(ctx context.Context, af advisory.AliasFinder, vulnerabilityID string) ([]string, error) {
+	switch {
+	case vuln.RegexCVE.MatchString(vulnerabilityID):
+		return af.GHSAsForCVE(ctx, vulnerabilityID)
+
+	case vuln.RegexGHSA.MatchString(vulnerabilityID):
+		cve, err := af.CVEForGHSA(ctx, vulnerabilityID)
+		if err != nil {
+			return nil, err
+		}
+		if cve == "" {
+			return nil, nil
+		}
+
+		return []string{cve}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown vulnerability ID format: %q", vulnerabilityID)
+	}
+}

--- a/pkg/cli/advisory_create.go
+++ b/pkg/cli/advisory_create.go
@@ -29,7 +29,7 @@ func cmdAdvisoryCreate() *cobra.Command {
 			archs := p.archs
 			packageRepositoryURL := p.packageRepositoryURL
 			distroRepoDir := resolveDistroDir(p.distroRepoDir)
-			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
+			advisoriesRepoDir := resolveAdvisoriesDirInput(p.advisoriesRepoDir)
 			if distroRepoDir == "" || advisoriesRepoDir == "" {
 				if p.doNotDetectDistro {
 					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified")

--- a/pkg/cli/advisory_discover.go
+++ b/pkg/cli/advisory_discover.go
@@ -36,7 +36,7 @@ func cmdAdvisoryDiscover() *cobra.Command {
 			packageRepositoryURL := p.packageRepositoryURL
 
 			distroRepoDir := resolveDistroDir(p.distroRepoDir)
-			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
+			advisoriesRepoDir := resolveAdvisoriesDirInput(p.advisoriesRepoDir)
 			if distroRepoDir == "" || advisoriesRepoDir == "" {
 				if p.doNotDetectDistro {
 					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified")

--- a/pkg/cli/advisory_update.go
+++ b/pkg/cli/advisory_update.go
@@ -29,7 +29,7 @@ func cmdAdvisoryUpdate() *cobra.Command {
 			archs := p.archs
 			packageRepositoryURL := p.packageRepositoryURL
 			distroRepoDir := resolveDistroDir(p.distroRepoDir)
-			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
+			advisoriesRepoDir := resolveAdvisoriesDirInput(p.advisoriesRepoDir)
 			if distroRepoDir == "" || advisoriesRepoDir == "" {
 				if p.doNotDetectDistro {
 					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified")

--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -21,7 +21,7 @@ func cmdAdvisoryValidate() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			advisoriesRepoDir := resolveAdvisoriesDir(p.advisoriesRepoDir)
+			advisoriesRepoDir := resolveAdvisoriesDirInput(p.advisoriesRepoDir)
 			if advisoriesRepoDir == "" {
 				if p.doNotDetectDistro {
 					return fmt.Errorf("advisories repo dir was left unspecified")

--- a/pkg/configs/advisory/v2/advisory_test.go
+++ b/pkg/configs/advisory/v2/advisory_test.go
@@ -85,6 +85,64 @@ func TestAdvisory_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "duplicate aliases",
+			adv: Advisory{
+				ID: "CVE-2020-0001",
+				Aliases: []string{
+					"GHSA-5j9q-4xjw-3j3q",
+					"GHSA-5j9q-4xjw-3j3q",
+				},
+				Events: []Event{
+					{
+						Timestamp: testTime,
+						Type:      EventTypeDetection,
+						Data: Detection{
+							Type: DetectionTypeManual,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "alias duplicates advisory ID",
+			adv: Advisory{
+				ID: "GHSA-5j9q-4xjw-3j3q",
+				Aliases: []string{
+					"GHSA-5j9q-4xjw-3j3q",
+				},
+				Events: []Event{
+					{
+						Timestamp: testTime,
+						Type:      EventTypeDetection,
+						Data: Detection{
+							Type: DetectionTypeManual,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "CVE in alias instead of advisory ID",
+			adv: Advisory{
+				ID: "GHSA-5j9q-4xjw-3j3q",
+				Aliases: []string{
+					"CVE-2020-0001",
+				},
+				Events: []Event{
+					{
+						Timestamp: testTime,
+						Type:      EventTypeDetection,
+						Data: Detection{
+							Type: DetectionTypeManual,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "no events",
 			adv: Advisory{
 				ID:     "CVE-2020-0001",

--- a/pkg/configs/advisory/v2/event.go
+++ b/pkg/configs/advisory/v2/event.go
@@ -102,6 +102,10 @@ func decodeTypedEventData[T EventTypeData](pe partialEvent) (Event, error) {
 		Type:      pe.Type,
 	}
 
+	if pe.Data.IsZero() {
+		return event, nil
+	}
+
 	data, err := strictUnmarshal[T](&pe.Data)
 	if err != nil {
 		return Event{}, fmt.Errorf("strict YAML unmarshaling failed: %w", err)

--- a/pkg/configs/advisory/v2/migrate.go
+++ b/pkg/configs/advisory/v2/migrate.go
@@ -63,8 +63,6 @@ func migrateV1Advisory(v1Advisory []v1.Entry, advisoryID string) (*Advisory, err
 		events = append(events, *event)
 	}
 
-	// TODO: sort out CVE vs. GHSA in ID and Aliases
-
 	return &Advisory{
 		ID:     advisoryID,
 		Events: events,

--- a/pkg/configs/selection.go
+++ b/pkg/configs/selection.go
@@ -18,29 +18,30 @@ type Selection[T Configuration] struct {
 // WhereName filters the selection down to entries whose name match the given
 // parameter.
 func (s Selection[T]) WhereName(name string) Selection[T] {
-	var entries []Entry[T]
-	for _, e := range s.entries {
+	return s.Where(func(e Entry[T]) bool {
 		cfg := e.Configuration()
 		if cfg == nil {
-			continue
+			return false
 		}
-		if name == (*cfg).Name() {
-			entries = append(entries, e)
-		}
-	}
 
-	return Selection[T]{
-		entries: entries,
-		index:   s.index,
-	}
+		return name == (*cfg).Name()
+	})
 }
 
 // WhereFilePath filters the selection down to entries whose configuration file
 // path match the given parameter.
 func (s Selection[T]) WhereFilePath(p string) Selection[T] {
+	return s.Where(func(e Entry[T]) bool {
+		return p == e.getPath()
+	})
+}
+
+// Where filters the selection down to entries for which the given condition is
+// true.
+func (s Selection[T]) Where(condition func(Entry[T]) bool) Selection[T] {
 	var entries []Entry[T]
 	for _, e := range s.entries {
-		if p == e.getPath() {
+		if condition(e) {
 			entries = append(entries, e)
 		}
 	}


### PR DESCRIPTION
This PR adds two new commands:

- `wolfictl adv alias discover`: looks up aliases in supported vulnerability data sources (for now, just GHSA) to populate the `aliases` field on existing advisories.
- `wolfictl adv alias find`: a simple utility command that looks up aliases for the vulnerability IDs provided as arguments on the command line. (This command doesn't touch any advisory data.)

This PR makes it easier to ensure we stay aware of relevant vulnerability records in the upstream data sources we care about.

### Future work

This is already a large PR, but future PRs could look at the following enhancements to take this PR's functionality further...

1. Automatically discover aliases as part of the `wolfictl adv create` command.
2. Automatically discover aliases as part of the `wolfictl adv discover` command.
3. Add support for the [Go Vulnerability Database](https://go.dev/security/vuln/database) as a source of aliases.
4. Add support for the [PSF Advisory Database](https://github.com/psf/advisory-database) as a source of aliases.
5. Add a flag to the `wolfictl adv alias discover` command to perform discovery only on advisories that have no alias data yet.
6. Cache API queries in memory during command execution, since there's a decent amount of redundancy today of vulnerability IDs in our advisory data set.