### PR TITLE
fix: use extra repos in graph calculation

### DIFF
--- a/pkg/dag/graph.go
+++ b/pkg/dag/graph.go
@@ -125,8 +125,8 @@ func NewGraph(pkgs *Packages, options ...GraphOptions) (*Graph, error) {
 			localRepo,
 			indexes,
 			keys,
-			c.Environment.Contents.Repositories,
-			c.Environment.Contents.Keyring,
+			append(c.Environment.Contents.Repositories, opts.repos...),
+			append(c.Environment.Contents.Keyring, opts.keys...),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create resolver for %s: %w", c.String(), err)


### PR DESCRIPTION
`--keyring-append` and `--keyring-append` weren't being piped through here, leading to graph breakages when repos/keys were passed this way vs. in the YAML.