### PR TITLE
Better version validation

### DIFF
--- a/pkg/configs/advisory/v2/fixed.go
+++ b/pkg/configs/advisory/v2/fixed.go
@@ -1,6 +1,10 @@
 package v2
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/wolfi-dev/wolfictl/pkg/versions"
+)
 
 // Fixed is an event that indicates that a vulnerability has been remediated in
 // an updated version of the distribution package.
@@ -15,5 +19,10 @@ func (f Fixed) Validate() error {
 	if f.FixedVersion == "" {
 		return fmt.Errorf("fixed version cannot be empty")
 	}
+
+	if err := versions.ValidateWithEpoch(f.FixedVersion); err != nil {
+		return fmt.Errorf("invalid fixed version: %w", err)
+	}
+
 	return nil
 }

--- a/pkg/configs/advisory/v2/fixed_test.go
+++ b/pkg/configs/advisory/v2/fixed_test.go
@@ -13,9 +13,28 @@ func TestFixed_Validate(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		f := Fixed{}
-		if err := f.Validate(); err == nil {
-			t.Errorf("expected error, got nil")
+		cases := []struct {
+			name string
+			f    Fixed
+		}{
+			{
+				name: "empty",
+				f:    Fixed{},
+			},
+			{
+				name: "missing epoch",
+				f: Fixed{
+					FixedVersion: "1.2.3",
+				},
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := tt.f.Validate(); err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			})
 		}
 	})
 }

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"chainguard.dev/melange/pkg/renovate"
+	"github.com/wolfi-dev/wolfictl/pkg/versions"
 
 	"github.com/dprotaso/go-yit"
 	"gopkg.in/yaml.v3"
@@ -29,15 +30,9 @@ var (
 	forbiddenKeyrings = []string{
 		"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
 	}
-
-	// versionRegex how to parse versions.
-	// see https://github.com/alpinelinux/apk-tools/blob/50ab589e9a5a84592ee4c0ac5a49506bb6c552fc/src/version.c#
-	versionRegex = regexp.MustCompile(`^([0-9]+)((\.[0-9]+)*)([a-z]?)((_alpha|_beta|_pre|_rc)([0-9]*))?((_cvs|_svn|_git|_hg|_p)([0-9]*))?((-r)([0-9]+))?$`)
 )
 
 const gitCheckout = "git-checkout"
-
-func init() { versionRegex.Longest() }
 
 // AllRules is a list of all available rules to evaluate.
 var AllRules = func(l *Linter) Rules { //nolint:gocyclo
@@ -254,7 +249,7 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				version := config.Package.Version
-				if len(versionRegex.FindAllStringSubmatch(version, -1)) == 0 {
+				if err := versions.Validate(version); err != nil {
 					return fmt.Errorf("invalid version %s, could not parse", version)
 				}
 				return nil

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -249,7 +249,7 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				version := config.Package.Version
-				if err := versions.Validate(version); err != nil {
+				if err := versions.ValidateWithoutEpoch(version); err != nil {
 					return fmt.Errorf("invalid version %s, could not parse", version)
 				}
 				return nil

--- a/pkg/versions/validate.go
+++ b/pkg/versions/validate.go
@@ -5,25 +5,50 @@ import (
 	"regexp"
 )
 
-// versionRegex how to parse versions.
-// see https://github.com/alpinelinux/apk-tools/blob/50ab589e9a5a84592ee4c0ac5a49506bb6c552fc/src/version.c#
-var versionRegex = func() *regexp.Regexp {
-	re := regexp.MustCompile(`^([0-9]+)((\.[0-9]+)*)([a-z]?)((_alpha|_beta|_pre|_rc)([0-9]*))?((_cvs|_svn|_git|_hg|_p)([0-9]*))?((-r)([0-9]+))?$`)
-	re.Longest()
-	return re
-}
+var (
+	// versionRegex how to parse versions.
+	// see https://github.com/alpinelinux/apk-tools/blob/50ab589e9a5a84592ee4c0ac5a49506bb6c552fc/src/version.c#
+	versionRegex = func() *regexp.Regexp {
+		re := regexp.MustCompile(`^([0-9]+)((\.[0-9]+)*)([a-z]?)((_alpha|_beta|_pre|_rc)([0-9]*))?((_cvs|_svn|_git|_hg|_p)([0-9]*))?((-r)([0-9]+))?$`)
+		re.Longest()
+		return re
+	}()
 
-// Validate checks if the version string is a Wolfi-compatible version, and it
-// returns an error if not.
-//
-// This is meant to check the package version WITHOUT the epoch suffix.
-func Validate(v string) error {
-	if !versionRegex().MatchString(v) {
+	// versionWithEpochRegex how to parse versions that include the epoch suffix.
+	versionWithEpochRegex = func() *regexp.Regexp {
+		re := regexp.MustCompile(`^([0-9]+)((\.[0-9]+)*)([a-z]?)((_alpha|_beta|_pre|_rc)([0-9]*))?((_cvs|_svn|_git|_hg|_p)([0-9]*))?((-r)([0-9]+))?(-r[0-9]+)$`)
+		re.Longest()
+		return re
+	}()
+)
+
+var (
+	// ErrInvalidVersion is returned when a version string doesn't meet the
+	// requirements of a Wolfi-compatible version.
+	ErrInvalidVersion = errors.New("not a valid Wolfi package version")
+
+	// ErrInvalidFullVersion is returned when a version string doesn't meet the
+	// requirements of a Wolfi-compatible "full" version (which should include the
+	// epoch suffix).
+	ErrInvalidFullVersion = errors.New("not a valid full Wolfi package version (with epoch)")
+)
+
+// ValidateWithoutEpoch checks if the given package version, which is expected
+// NOT to include the epoch component, is a Wolfi-compatible version. It returns
+// an error if not.
+func ValidateWithoutEpoch(v string) error {
+	if !versionRegex.MatchString(v) {
 		return ErrInvalidVersion
 	}
 	return nil
 }
 
-// ErrInvalidVersion is returned when a version string doesn't meet the
-// requirements of a Wolfi-compatible version.
-var ErrInvalidVersion = errors.New("not a valid Wolfi package version")
+// ValidateWithEpoch checks if the given package version, which is expected to
+// include the epoch component, is a Wolfi-compatible "full" version. It returns
+// an error if not.
+func ValidateWithEpoch(v string) error {
+	if !versionWithEpochRegex.MatchString(v) {
+		return ErrInvalidFullVersion
+	}
+	return nil
+}

--- a/pkg/versions/validate.go
+++ b/pkg/versions/validate.go
@@ -1,0 +1,29 @@
+package versions
+
+import (
+	"errors"
+	"regexp"
+)
+
+// versionRegex how to parse versions.
+// see https://github.com/alpinelinux/apk-tools/blob/50ab589e9a5a84592ee4c0ac5a49506bb6c552fc/src/version.c#
+var versionRegex = func() *regexp.Regexp {
+	re := regexp.MustCompile(`^([0-9]+)((\.[0-9]+)*)([a-z]?)((_alpha|_beta|_pre|_rc)([0-9]*))?((_cvs|_svn|_git|_hg|_p)([0-9]*))?((-r)([0-9]+))?$`)
+	re.Longest()
+	return re
+}
+
+// Validate checks if the version string is a Wolfi-compatible version, and it
+// returns an error if not.
+//
+// This is meant to check the package version WITHOUT the epoch suffix.
+func Validate(v string) error {
+	if !versionRegex().MatchString(v) {
+		return ErrInvalidVersion
+	}
+	return nil
+}
+
+// ErrInvalidVersion is returned when a version string doesn't meet the
+// requirements of a Wolfi-compatible version.
+var ErrInvalidVersion = errors.New("not a valid Wolfi package version")

--- a/pkg/versions/validate_test.go
+++ b/pkg/versions/validate_test.go
@@ -2,7 +2,7 @@ package versions
 
 import "testing"
 
-func TestValidate(t *testing.T) {
+func TestValidateWithoutEpoch(t *testing.T) {
 	cases := []struct {
 		v             string
 		shouldBeValid bool
@@ -35,7 +35,42 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.v, func(t *testing.T) {
-			err := Validate(tt.v)
+			err := ValidateWithoutEpoch(tt.v)
+			if tt.shouldBeValid && err != nil {
+				t.Errorf("expected %q to be valid, but got error %q", tt.v, err)
+			}
+			if !tt.shouldBeValid && err == nil {
+				t.Errorf("expected %q to be invalid, but got no error", tt.v)
+			}
+		})
+	}
+}
+
+func TestValidateWithEpoch(t *testing.T) {
+	cases := []struct {
+		v             string
+		shouldBeValid bool
+	}{
+		// These are all valid full versions.
+		{"1-r0", true},
+		{"1.0-r0", true},
+		{"1.0.0-r0", true},
+		{"1.0.0-r4-r5", true},
+		{"1.0.0_alpha-r0", true},
+		{"1.0.0-r100000000000000000", true},
+
+		// These are all invalid full versions.
+		{"1.0.0", false},
+		{"1.0.0-r5.2", false},
+		{"1.0.0-r5_pre", false},
+		{"1r6", false},
+		{"1.0.0-r", false},
+		{"1.0-r1-r2-r3", false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.v, func(t *testing.T) {
+			err := ValidateWithEpoch(tt.v)
 			if tt.shouldBeValid && err != nil {
 				t.Errorf("expected %q to be valid, but got error %q", tt.v, err)
 			}

--- a/pkg/versions/validate_test.go
+++ b/pkg/versions/validate_test.go
@@ -1,0 +1,47 @@
+package versions
+
+import "testing"
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		v             string
+		shouldBeValid bool
+	}{
+		// These are all valid versions.
+		{"1", true},
+		{"1.0", true},
+		{"1.0.0", true},
+		{"3000.200.10", true},
+		{"1.0.0_alpha", true},
+		{"1.0.0-r100000000000000000", true},
+		{"1.2.3.4.5.6.7.8.9", true},
+		{"1.0.0z_p", true},
+		{"1.0.0_p5", true},
+		{"1.2.2_git20230928", true},
+
+		// Yes, this is valid, and the "-r0" is NOT the epoch here. 🤯
+		{"1.0.0-r0", true},
+
+		// These are all invalid versions.
+		{"1.0.0-alpha", false},
+		{"1.0.0_alpha.1", false},
+		{"1.0.0\n2.0.0", false},
+		{"1.0.0nevergonnagiveyouu_p", false},
+		{"pre-1.0.0", false},
+		{"jenkins-7", false},
+		{"1.0.0 ", false},
+		{"1_0", false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.v, func(t *testing.T) {
+			err := Validate(tt.v)
+			if tt.shouldBeValid && err != nil {
+				t.Errorf("expected %q to be valid, but got error %q", tt.v, err)
+			}
+			if !tt.shouldBeValid && err == nil {
+				t.Errorf("expected %q to be invalid, but got no error", tt.v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, `wolfictl adv validate`, when validating `v2.Fixed` data, would only check that the fixed version field was not empty. The expectation should have been that these versions are valid for Wolfi, and that they include an epoch suffix (in fact, some of our current data is invalid in this regard and needs to be fixed!).

This PR makes the fixed version more robust, by leveraging an existing version check used in Melange file linting. That check has been moved to the `versions` package and exported for broader use.

cc: @imjasonh 