### PR TITLE
feat(scan): ability to base scan(s) on a Melange build log

### DIFF
--- a/pkg/buildlog/buildlog.go
+++ b/pkg/buildlog/buildlog.go
@@ -1,0 +1,45 @@
+package buildlog
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Entry represents a single line in a Melange build log.
+type Entry struct {
+	Arch, Origin, Package, FullVersion string
+}
+
+// Parse parses a Melange build log into a slice of entries.
+func Parse(r io.Reader) ([]Entry, error) {
+	splitFunc := func(ru rune) bool {
+		return string(ru) == "|"
+	}
+
+	var entries []Entry
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		fields := strings.FieldsFunc(line, splitFunc)
+		if len(fields) != 4 {
+			return nil, fmt.Errorf("invalid line %q, expected 4 '|'-delimited fields", line)
+		}
+
+		entry := Entry{
+			Arch:        fields[0],
+			Origin:      fields[1],
+			Package:     fields[2],
+			FullVersion: fields[3],
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning lines of build log: %w", err)
+	}
+
+	return entries, nil
+}

--- a/pkg/buildlog/buildlog_test.go
+++ b/pkg/buildlog/buildlog_test.go
@@ -1,0 +1,41 @@
+package buildlog
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	f, err := os.Open("testdata/packages.log")
+	if err != nil {
+		t.Fatalf("unable to open test data: %v", err)
+	}
+	defer f.Close()
+
+	expected := []Entry{
+		{
+			Arch:        "aarch64",
+			Origin:      "tekton-chains",
+			Package:     "tekton-chains",
+			FullVersion: "0.18.0-r3",
+		},
+		{
+			Arch:        "aarch64",
+			Origin:      "jansson",
+			Package:     "jansson",
+			FullVersion: "2.14-r0",
+		},
+		{
+			Arch:        "aarch64",
+			Origin:      "jansson",
+			Package:     "jansson-dev",
+			FullVersion: "2.14-r0",
+		},
+	}
+
+	actual, err := Parse(f)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/buildlog/testdata/packages.log
+++ b/pkg/buildlog/testdata/packages.log
@@ -1,0 +1,3 @@
+aarch64|tekton-chains|tekton-chains|0.18.0-r3
+aarch64|jansson|jansson|2.14-r0
+aarch64|jansson|jansson-dev|2.14-r0

--- a/pkg/cli/sbom.go
+++ b/pkg/cli/sbom.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"sort"
 	"strings"
 
@@ -35,13 +34,17 @@ func cmdSBOM() *cobra.Command {
 				return fmt.Errorf("invalid output format %q, must be one of [%s]", p.outputFormat, strings.Join([]string{sbomFormatOutline, sbomFormatSyftJSON}, ", "))
 			}
 
+			// TODO: Bring input retrieval options in line with `wolfictl scan`.
+
 			apkFilePath := args[0]
 			apkFile, err := os.Open(apkFilePath)
 			if err != nil {
 				return fmt.Errorf("failed to open apk file: %w", err)
 			}
 
-			fmt.Fprintf(os.Stderr, "Will process: %s\n", path.Base(apkFilePath))
+			if p.outputFormat == outputFormatOutline {
+				fmt.Printf("🔎 Scanning %q\n", apkFilePath)
+			}
 
 			var s *sbomSyft.SBOM
 			if p.disableSBOMCache {

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/savioxavier/termlink"
 	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/buildlog"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
@@ -22,6 +24,8 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/scan"
 	"golang.org/x/exp/slices"
 )
+
+const buildLogDefaultName = "packages.log"
 
 func cmdScan() *cobra.Command {
 	p := &scanParams{}
@@ -68,16 +72,42 @@ func cmdScan() *cobra.Command {
 				}
 			}
 
-			// Do a scan for each arg
+			if p.packageBuildLogInput && p.sbomInput {
+				return errors.New("cannot specify both -s/--sbom and --build-log")
+			}
 
-			var scans []inputScan
+			// Use either the build log or the args themselves as scan targets
 
-			for _, input := range args {
-				if p.outputFormat == outputFormatOutline {
-					fmt.Printf("🔎 Scanning %q\n", input)
+			var scanInputPaths []string
+			if p.packageBuildLogInput {
+				if len(args) != 1 {
+					return fmt.Errorf("must specify exactly one build log file (or a directory that contains a %q build log file)", buildLogDefaultName)
 				}
 
-				scannedInput, err := scanInput(input, p)
+				var err error
+				scanInputPaths, err = resolveInputFilePathsFromBuildLog(args[0])
+				if err != nil {
+					return fmt.Errorf("failed to resolve scan inputs from build log: %w", err)
+				}
+			} else {
+				scanInputPaths = args
+			}
+
+			// Do a scan for each scan target
+
+			var scans []inputScan
+			for _, scanInputPath := range scanInputPaths {
+				if p.outputFormat == outputFormatOutline {
+					fmt.Printf("🔎 Scanning %q\n", scanInputPath)
+				}
+
+				inputFile, err := resolveInputFileFromArg(scanInputPath)
+				if err != nil {
+					return fmt.Errorf("failed to open input file: %w", err)
+				}
+				defer inputFile.Close()
+
+				scannedInput, err := scanInput(inputFile, p)
 				if err != nil {
 					return err
 				}
@@ -87,7 +117,7 @@ func cmdScan() *cobra.Command {
 				if set := p.advisoryFilterSet; set != "" {
 					findings, err := scan.FilterWithAdvisories(scannedInput.Result, advisoryCfgs, set)
 					if err != nil {
-						return fmt.Errorf("failed to filter scan results with advisories during scan of %q: %w", input, err)
+						return fmt.Errorf("failed to filter scan results with advisories during scan of %q: %w", scanInputPath, err)
 					}
 
 					scannedInput.Result.Findings = findings
@@ -130,24 +160,21 @@ func cmdScan() *cobra.Command {
 	return cmd
 }
 
-func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
-	inputFile, err := openInputFile(inputFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open input file: %w", err)
-	}
-	defer inputFile.Close()
+func scanInput(inputFile *os.File, p *scanParams) (*inputScan, error) {
+	inputFileName := inputFile.Name()
 
-	// Get SBOM of the APK
-
+	// Get the SBOM of the APK
 	var apkSBOM io.Reader
 	if p.sbomInput {
 		apkSBOM = inputFile
 	} else {
 		var s *sbomSyft.SBOM
+		var err error
+
 		if p.disableSBOMCache {
-			s, err = sbom.Generate(inputFilePath, inputFile, p.distro)
+			s, err = sbom.Generate(inputFileName, inputFile, p.distro)
 		} else {
-			s, err = sbom.CachedGenerate(inputFilePath, inputFile, p.distro)
+			s, err = sbom.CachedGenerate(inputFileName, inputFile, p.distro)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate SBOM: %w", err)
@@ -160,23 +187,65 @@ func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
 		apkSBOM = reader
 	}
 
-	// Do vulnerability scan!
-
+	// Do the vulnerability scan based on the SBOM
 	result, err := scan.APKSBOM(apkSBOM, p.localDBFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to scan APK using %q: %w", inputFilePath, err)
+		return nil, fmt.Errorf("failed to scan APK using %q: %w", inputFileName, err)
 	}
 
 	is := &inputScan{
-		InputFile: inputFilePath,
+		InputFile: inputFileName,
 		Result:    result,
 	}
 
 	return is, nil
 }
 
-// openInputFile figures out how to interpret the given input file path to find
-// a file to scan.
+// resolveInputFilePathsFromBuildLog takes the given path to a Melange build log
+// file (or a directory that contains the build log as a "packages.log" file).
+// Once it finds the build log, it parses it, and returns a slice of file paths
+// to APKs to be scanned. Each APK path is created with the assumption that the
+// APKs are located at "./packages/$ARCH/$PACKAGE-$VERSION.apk".
+func resolveInputFilePathsFromBuildLog(buildLogPath string) ([]string, error) {
+	pathToFileOrDirectory := filepath.Clean(buildLogPath)
+
+	info, err := os.Stat(pathToFileOrDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat build log input: %w", err)
+	}
+
+	var pathToFile string
+	if info.IsDir() {
+		pathToFile = filepath.Join(pathToFileOrDirectory, buildLogDefaultName)
+	} else {
+		pathToFile = pathToFileOrDirectory
+	}
+
+	file, err := os.Open(pathToFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open build log: %w", err)
+	}
+	defer file.Close()
+
+	buildLogEntries, err := buildlog.Parse(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse build log: %w", err)
+	}
+
+	scanInputs := make([]string, 0, len(buildLogEntries))
+	for _, entry := range buildLogEntries {
+		apkName := fmt.Sprintf("%s-%s.apk", entry.Package, entry.FullVersion)
+		apkPath := filepath.Join("packages", entry.Arch, apkName)
+		scanInputs = append(scanInputs, apkPath)
+	}
+
+	return scanInputs, nil
+}
+
+// resolveInputFileFromArg figures out how to interpret the given input file path
+// to find a file to scan. This input file could be either an APK or an SBOM.
+// The objective of this function is to find the file to scan and return a file
+// handle to it.
 //
 // In order, it will:
 //
@@ -185,7 +254,7 @@ func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
 // 2. If the path starts with "https://", download the remote file into a temp file and return that.
 //
 // 3. Otherwise, open the file at the given path and return that.
-func openInputFile(inputFilePath string) (*os.File, error) {
+func resolveInputFileFromArg(inputFilePath string) (*os.File, error) {
 	switch {
 	case inputFilePath == "-":
 		// Read stdin into a temp file.
@@ -240,14 +309,15 @@ func openInputFile(inputFilePath string) (*os.File, error) {
 }
 
 type scanParams struct {
-	requireZeroFindings bool
-	localDBFilePath     string
-	outputFormat        string
-	sbomInput           bool
-	distro              string
-	advisoryFilterSet   string
-	advisoriesRepoDir   string
-	disableSBOMCache    bool
+	requireZeroFindings  bool
+	localDBFilePath      string
+	outputFormat         string
+	sbomInput            bool
+	packageBuildLogInput bool
+	distro               string
+	advisoryFilterSet    string
+	advisoriesRepoDir    string
+	disableSBOMCache     bool
 }
 
 func (p *scanParams) addFlagsTo(cmd *cobra.Command) {
@@ -255,6 +325,7 @@ func (p *scanParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&p.localDBFilePath, "local-file-grype-db", "", "import a local grype db file")
 	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", "", fmt.Sprintf("output format (%s), defaults to %s", strings.Join(validOutputFormats, "|"), outputFormatOutline))
 	cmd.Flags().BoolVarP(&p.sbomInput, "sbom", "s", false, "treat input(s) as SBOM(s) of APK(s) instead of as actual APK(s)")
+	cmd.Flags().BoolVar(&p.packageBuildLogInput, "build-log", false, "treat input as a package build log file (or a directory that contains a packages.log file)")
 	cmd.Flags().StringVar(&p.distro, "distro", "wolfi", "distro to use during vulnerability matching")
 	cmd.Flags().StringVarP(&p.advisoryFilterSet, "advisory-filter", "f", "", fmt.Sprintf("exclude vulnerability matches that are referenced from the specified set of advisories (%s)", strings.Join(scan.ValidAdvisoriesSets, "|")))
 	cmd.Flags().StringVarP(&p.advisoriesRepoDir, "advisories-repo-dir", "a", "", "local directory for advisory data")


### PR DESCRIPTION
## Background

In some workflows, when we build packages, we ask Melange to create a "build log" of the packages that it outputs. (This can be accomplished with the `melange build` flag called `--create-build-log`.)

## What's new

This PR adds an enhancement to the `wolfictl scan` command to determine the set of APKs to scan off the build log, so we can scan _N_ packages that we just built.

For example, I just did a Melange build of the "jansson" package, which also has 1 subpackage:

```console
$ cat packages.log 
aarch64|jansson|jansson|2.14-r0
aarch64|jansson|jansson-dev|2.14-r0
$ wolfictl scan --build-log .                                        
🔎 Scanning "packages/aarch64/jansson-2.14-r0.apk"
✅ No vulnerabilities found
🔎 Scanning "packages/aarch64/jansson-dev-2.14-r0.apk"
✅ No vulnerabilities found
```

The new `--build-log` flag requires that the command is only given a single argument. This argument can be either a filepath to a build log, or a path to a directory that contains the build log as `packages.log`.

In a future PR, it'd be great to catch up `wolfictl sbom` to support all the kinds of input that `wolfictl scan` supports now.

Big shout out to @rawlingsj for thinking of this feature! 🎉 