### PR TITLE
add option to set a custom path

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -216,14 +216,14 @@ func scanInput(inputFilePath string, p *scanParams) (*inputScan, error) {
 }
 
 type scanParams struct {
+	disableSBOMCache    bool
+	sbomInput           bool
 	requireZeroFindings bool
 	localDBFilePath     string
 	outputFormat        string
-	sbomInput           bool
 	distro              string
 	advisoryFilterSet   string
 	advisoriesRepoDir   string
-	disableSBOMCache    bool
 }
 
 func (p *scanParams) addFlagsTo(cmd *cobra.Command) {

--- a/pkg/sbom/cache.go
+++ b/pkg/sbom/cache.go
@@ -34,7 +34,6 @@ func cachedSBOMPath(inputFilePath string, f io.Reader) (string, error) {
 // a new SBOM.
 func CachedGenerate(inputFilePath string, f io.ReadSeeker, distroID string) (*sbom.SBOM, error) {
 	// Check cache first
-
 	cachedPath, err := cachedSBOMPath(inputFilePath, f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute cached SBOM path: %w", err)

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -40,7 +40,9 @@ var syftCatalogersEnabled = []string{
 // Generate creates an SBOM for the given APK file.
 func Generate(inputFilePath string, f io.Reader, distroID string) (*sbom.SBOM, error) {
 	// Create a temp directory to house the unpacked APK file
-	tempDir, err := os.MkdirTemp("", "wolfictl-sbom-*")
+	// if TMPDIR environment variable is not set, uses the default directory for temporary files
+	tempDirPath := os.Getenv("TMPDIR")
+	tempDir, err := os.MkdirTemp(tempDirPath, "wolfictl-sbom-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
 	}


### PR DESCRIPTION
add an option to set a custom temp path to store the apk for the sbom generation


this is required for our cve automation because we have a rule that denies the usage of the `/tmp` directory in a k8s deployments.