### PR TITLE
wolfictl scan: various improvements

### DIFF
--- a/pkg/buildlog/buildlog.go
+++ b/pkg/buildlog/buildlog.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// DefaultName is the default name used for a Melange build log file.
+const DefaultName = "packages.log"
+
 // Entry represents a single line in a Melange build log.
 type Entry struct {
 	Arch, Origin, Package, FullVersion string

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -94,6 +94,7 @@ func cmdScan() *cobra.Command {
 			// Do a scan for each scan target
 
 			var scans []inputScan
+			var inputPathsFailingRequireZero []string
 			for _, scanInputPath := range scanInputPaths {
 				if p.outputFormat == outputFormatOutline {
 					fmt.Printf("🔎 Scanning %q\n", scanInputPath)
@@ -137,8 +138,8 @@ func cmdScan() *cobra.Command {
 					}
 				}
 				if p.requireZeroFindings && len(findings) > 0 {
-					// Exit with error immediately if any vulnerabilities are found
-					return fmt.Errorf("more than 0 vulnerabilities found")
+					// Accumulate the list of failures to be returned at the end, but we still want to complete all scans
+					inputPathsFailingRequireZero = append(inputPathsFailingRequireZero, scanInputPath)
 				}
 			}
 
@@ -148,6 +149,10 @@ func cmdScan() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to marshal scans to JSON: %w", err)
 				}
+			}
+
+			if len(inputPathsFailingRequireZero) > 0 {
+				return fmt.Errorf("vulnerabilities found in the following package(s):\n%s", strings.Join(inputPathsFailingRequireZero, "\n"))
 			}
 
 			return nil

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -16,74 +16,93 @@ const (
 var ValidAdvisoriesSets = []string{AdvisoriesSetResolved, AdvisoriesSetAll}
 
 // FilterWithAdvisories filters the findings in the result based on the advisories for the target APK.
-func FilterWithAdvisories(result *Result, advisoryCfgs *configs.Index[v2.Document], advisoryFilterSet string) ([]*Finding, error) {
+func FilterWithAdvisories(result *Result, advisoryDocIndices []*configs.Index[v2.Document], advisoryFilterSet string) ([]*Finding, error) {
 	if result == nil {
 		return nil, fmt.Errorf("result cannot be nil")
 	}
 
-	if advisoryCfgs == nil {
+	if advisoryDocIndices == nil {
 		return nil, fmt.Errorf("advisory configs cannot be nil")
 	}
 
-	documents := advisoryCfgs.Select().WhereName(result.TargetAPK.Origin()).Configurations()
+	var documents []v2.Document
+	for _, index := range advisoryDocIndices {
+		docs := index.Select().WhereName(result.TargetAPK.Origin()).Configurations()
+		documents = append(documents, docs...)
+	}
+
+	// TODO: Should we error out if we end up with multiple documents for a single package?
+
 	if len(documents) == 0 {
 		// No advisory configs for this package, so we know we wouldn't be able to filter anything.
 		return result.Findings, nil
 	}
 
-	// We know there's an advisories document for this package, so we can get the advisories.
-	packageAdvisories := documents[0].Advisories
+	// Use a copy of the findings so we don't mutate the original result.
+	filteredFindings := make([]*Finding, len(result.Findings))
+	copy(filteredFindings, result.Findings)
 
-	switch advisoryFilterSet {
-	case AdvisoriesSetAll:
-		resultFindings := lo.Filter(result.Findings, func(finding *Finding, _ int) bool {
-			adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
-			// If the advisory contains any events, filter it out!
-			if ok && len(adv.Events) >= 1 {
-				return false
-			}
+	for _, document := range documents {
+		packageAdvisories := document.Advisories
 
-			// Also check any listed aliases
-			for _, alias := range finding.Vulnerability.Aliases {
-				adv, ok := packageAdvisories.GetByVulnerability(alias)
-				if !ok {
-					continue
-				}
+		switch advisoryFilterSet {
+		case AdvisoriesSetAll:
+			filteredFindings = filterFindingsWithAllAdvisories(filteredFindings, packageAdvisories)
 
-				if len(adv.Events) >= 1 {
-					return false
-				}
-			}
+		case AdvisoriesSetResolved:
+			filteredFindings = filterFindingsWithResolvedAdvisories(filteredFindings, packageAdvisories, result.TargetAPK.Version)
 
-			return true
-		})
-
-		return resultFindings, nil
-
-	case AdvisoriesSetResolved:
-		resultFindings := lo.Filter(result.Findings, func(finding *Finding, _ int) bool {
-			adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
-			if ok && adv.ResolvedAtVersion(result.TargetAPK.Version) {
-				return false
-			}
-
-			// Also check any listed aliases
-			for _, alias := range finding.Vulnerability.Aliases {
-				adv, ok := packageAdvisories.GetByVulnerability(alias)
-				if !ok {
-					continue
-				}
-
-				if adv.ResolvedAtVersion(result.TargetAPK.Version) {
-					return false
-				}
-			}
-
-			return true
-		})
-
-		return resultFindings, nil
+		default:
+			return nil, fmt.Errorf("unknown advisory filter set: %s", advisoryFilterSet)
+		}
 	}
 
-	return nil, fmt.Errorf("unknown advisory filter set: %s", advisoryFilterSet)
+	return filteredFindings, nil
+}
+
+func filterFindingsWithAllAdvisories(findings []*Finding, packageAdvisories v2.Advisories) []*Finding {
+	return lo.Filter(findings, func(finding *Finding, _ int) bool {
+		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
+		// If the advisory contains any events, filter it out!
+		if ok && len(adv.Events) >= 1 {
+			return false
+		}
+
+		// Also check any listed aliases
+		for _, alias := range finding.Vulnerability.Aliases {
+			adv, ok := packageAdvisories.GetByVulnerability(alias)
+			if !ok {
+				continue
+			}
+
+			if len(adv.Events) >= 1 {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
+func filterFindingsWithResolvedAdvisories(findings []*Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []*Finding {
+	return lo.Filter(findings, func(finding *Finding, _ int) bool {
+		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
+		if ok && adv.ResolvedAtVersion(currentPackageVersion) {
+			return false
+		}
+
+		// Also check any listed aliases
+		for _, alias := range finding.Vulnerability.Aliases {
+			adv, ok := packageAdvisories.GetByVulnerability(alias)
+			if !ok {
+				continue
+			}
+
+			if adv.ResolvedAtVersion(currentPackageVersion) {
+				return false
+			}
+		}
+
+		return true
+	})
 }

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
@@ -38,9 +39,8 @@ func FilterWithAdvisories(result *Result, advisoryDocIndices []*configs.Index[v2
 		return result.Findings, nil
 	}
 
-	// Use a copy of the findings so we don't mutate the original result.
-	filteredFindings := make([]*Finding, len(result.Findings))
-	copy(filteredFindings, result.Findings)
+	// Use a copy of the findings, so we don't mutate the original result.
+	filteredFindings := slices.Clone(result.Findings)
 
 	for _, document := range documents {
 		packageAdvisories := document.Advisories

--- a/pkg/scan/testdata/advisories-additional/.yam.yaml
+++ b/pkg/scan/testdata/advisories-additional/.yam.yaml
@@ -1,0 +1,5 @@
+gap:
+  - "."
+  - ".advisories"
+
+indent: 2

--- a/pkg/scan/testdata/advisories-additional/ko.advisories.yaml
+++ b/pkg/scan/testdata/advisories-additional/ko.advisories.yaml
@@ -1,0 +1,11 @@
+schema-version: "2"
+
+package:
+  name: ko
+
+advisories:
+  - id: GHSA-bbbb-bbbb-bbbb
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: true-positive-determination
+


### PR DESCRIPTION
This PR makes the following improvements to `wolfictl scan`:

- When using `--build-log`, APK package paths are now resolved relative to the provided build log path, rather than to the current working directory (since build logs and `packages/<arch>/*.apk` files are virtually always colocated)
- When using `--require-zero` to exit 1 on a failed scan, we now allow all scans to complete before exiting, rather than exiting on the first failed scan in a group
- You can now use the `-a` flag multiple times to leverage advisory data from multiple local directories at the same time (when filtering scan results)