### PR TITLE
look for GH tokens used by gh CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/charmbracelet/lipgloss v0.9.1
+	github.com/cli/go-gh/v2 v2.4.0
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/dominikbraun/graph v0.23.0
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
@@ -91,6 +92,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	github.com/chainguard-dev/go-pkgconfig v0.0.0-20230818193557-bee0072057ce // indirect
 	github.com/chainguard-dev/kontext v0.1.0 // indirect
+	github.com/cli/safeexec v1.0.0 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
@@ -236,7 +238,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/rivo/uniseg v0.4.3 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/saferwall/pe v1.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,10 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/cli/go-gh/v2 v2.4.0 h1:6j3YxA8uJVOL4lBWjqDmMiAQNnJ2fiZagCuEmQXl+pU=
+github.com/cli/go-gh/v2 v2.4.0/go.mod h1:h3salfqqooVpzKmHp6aUdeNx62UmxQRpLbagFSHTJGQ=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
+github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
@@ -1074,8 +1078,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
-github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
+github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/cli/advisory_alias_discover.go
+++ b/pkg/cli/advisory_alias_discover.go
@@ -19,29 +19,30 @@ func cmdAdvisoryAliasDiscover() *cobra.Command {
 		Short: "Discover new aliases for vulnerabilities in the advisory data",
 		Long: `Discover new aliases for vulnerabilities in the advisory data.
 
-This command reads the advisory data and searches for new aliases for the ID 
-and aliases of each advisory. For any new aliases found, the advisory data is 
+This command reads the advisory data and searches for new aliases for the ID
+and aliases of each advisory. For any new aliases found, the advisory data is
 updated to include the new alias.
 
-This command uses the GitHub API to query GHSA information. Note that GitHub 
-enforces a stricter rate limit against unauthenticated API calls. You can 
-authenticate this command's API calls by setting the environment variable 
-GITHUB_TOKEN to a personal access token. When performing alias discovery across 
-the entire data set, authenticating these API calls is highly recommended.
+This command uses the GitHub API to query GHSA information. Note that GitHub
+enforces a stricter rate limit against unauthenticated API calls. You can
+authenticate this command's API calls by setting the environment variable
+GITHUB_TOKEN to a personal access token, or by setting up the "gh" CLI.
+When performing alias discovery across the entire data set, authenticating
+these API calls is highly recommended.
 
-You may pass one or more instances of -p/--package to have the command operate 
+You may pass one or more instances of -p/--package to have the command operate
 on only one or more packages, rather than on the entire advisory data set.
 
-Where possible, this command also normalizes advisories to use the relevant CVE 
-ID as the advisory ID instead of an ID from another vulnerability namespace. 
-This means, for example, that a non-CVE ID (e.g. a GHSA ID) that was previously 
-the advisory ID will be moved to the advisory's aliases if a canonical CVE ID 
+Where possible, this command also normalizes advisories to use the relevant CVE
+ID as the advisory ID instead of an ID from another vulnerability namespace.
+This means, for example, that a non-CVE ID (e.g. a GHSA ID) that was previously
+the advisory ID will be moved to the advisory's aliases if a canonical CVE ID
 is discovered, since the CVE ID will become the advisory's new ID.
 
-In cases where an advisory's ID is updated, the advisory document will be 
-re-sorted by advisory ID so that the resulting advisories are still sorted 
-correctly. Also, if updating an advisory ID results in an advisory document 
-having two or more advisories with the same ID, the command errors out rather 
+In cases where an advisory's ID is updated, the advisory document will be
+re-sorted by advisory ID so that the resulting advisories are still sorted
+correctly. Also, if updating an advisory ID results in an advisory document
+having two or more advisories with the same ID, the command errors out rather
 than attempting any kind of merge of the separate advisories.
 `,
 		SilenceErrors: true,

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/update"
 )
@@ -58,8 +56,10 @@ func cmdUpdate() *cobra.Command {
 func (o options) UpdateCmd(_ context.Context, repoURI string) error {
 	updateContext := update.New()
 
-	if !o.dryRun && os.Getenv("GITHUB_TOKEN") == "" {
-		return errors.New("no GITHUB_TOKEN token found")
+	if !o.dryRun {
+		if _, err := (ghTokenSource{}).Token(); err != nil {
+			return err
+		}
 	}
 
 	if _, err := url.ParseRequestURI(repoURI); err != nil {

--- a/pkg/cli/update_package.go
+++ b/pkg/cli/update_package.go
@@ -1,9 +1,6 @@
 package cli
 
 import (
-	"os"
-
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/update"
 )
@@ -18,8 +15,10 @@ func Package() *cobra.Command {
 		Example: `wolfictl update package cheese --version v1.2.3 --target-repo https://github.com/wolfi-dev/os`,
 		Args:    cobra.RangeArgs(1, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !o.DryRun && os.Getenv("GITHUB_TOKEN") == "" {
-				return errors.New("no GITHUB_TOKEN token found")
+			if !o.DryRun {
+				if _, err := (ghTokenSource{}).Token(); err != nil {
+					return err
+				}
 			}
 
 			o.PackageName = args[0]


### PR DESCRIPTION
This change makes it so you don't need a `GITHUB_TOKEN` env var set if you've previously set up and authorized [GitHub's `gh` CLI](https://cli.github.com/) -- if you have, the token used by that CLI will be used.

[`TokenForHost`](https://pkg.go.dev/github.com/cli/go-gh/v2/pkg/auth#TokenForHost) checks `GITHUB_TOKEN` and falls back to a plaintext file or secure keyring storage.