### PR TITLE
Advisory schema v2.0.1: new PendingUpstreamFix event type

### DIFF
--- a/pkg/advisory/create.go
+++ b/pkg/advisory/create.go
@@ -57,6 +57,12 @@ func Create(req Request, opts CreateOptions) error {
 			return fmt.Errorf("unable to create advisory %q for %q: %w", newAdvisoryID, req.Package, err)
 		}
 
+		// Update the schema version to the latest version.
+		err = documents.Update(v2.NewSchemaVersionSectionUpdater(v2.SchemaVersion))
+		if err != nil {
+			return fmt.Errorf("unable to update schema version for %q: %w", req.Package, err)
+		}
+
 		return nil
 	}
 

--- a/pkg/advisory/discover_aliases_test.go
+++ b/pkg/advisory/discover_aliases_test.go
@@ -21,7 +21,7 @@ func TestDiscoverAliases(t *testing.T) {
 			name:            "find GHSA alias for a CVE",
 			selectedPackage: "scenario-1",
 			expectedUpdatedDocument: v2.Document{
-				SchemaVersion: "2",
+				SchemaVersion: v2.SchemaVersion,
 				Package: v2.Package{
 					Name: "scenario-1",
 				},
@@ -37,7 +37,7 @@ func TestDiscoverAliases(t *testing.T) {
 			name:            "find CVE for GHSA advisory ID and move GHSA ID to aliases",
 			selectedPackage: "scenario-2",
 			expectedUpdatedDocument: v2.Document{
-				SchemaVersion: "2",
+				SchemaVersion: v2.SchemaVersion,
 				Package: v2.Package{
 					Name: "scenario-2",
 				},
@@ -53,7 +53,7 @@ func TestDiscoverAliases(t *testing.T) {
 			name:            "no-op for non-CVE, non-GHSA advisory ID",
 			selectedPackage: "scenario-3",
 			expectedUpdatedDocument: v2.Document{
-				SchemaVersion: "2",
+				SchemaVersion: "2", // i.e. doesn't get updated
 				Package: v2.Package{
 					Name: "scenario-3",
 				},
@@ -68,7 +68,7 @@ func TestDiscoverAliases(t *testing.T) {
 			name:            "no-op for CVE advisory ID with no discoverable aliases",
 			selectedPackage: "scenario-4",
 			expectedUpdatedDocument: v2.Document{
-				SchemaVersion: "2",
+				SchemaVersion: "2", // i.e. doesn't get updated
 				Package: v2.Package{
 					Name: "scenario-4",
 				},
@@ -83,7 +83,7 @@ func TestDiscoverAliases(t *testing.T) {
 			name:            "no-op for GHSA advisory ID with no discoverable aliases",
 			selectedPackage: "scenario-5",
 			expectedUpdatedDocument: v2.Document{
-				SchemaVersion: "2",
+				SchemaVersion: "2", // i.e. doesn't get updated
 				Package: v2.Package{
 					Name: "scenario-5",
 				},
@@ -98,7 +98,7 @@ func TestDiscoverAliases(t *testing.T) {
 			name:            "advisory ID changing to a CVE necessitates a re-sort of advisories",
 			selectedPackage: "scenario-6",
 			expectedUpdatedDocument: v2.Document{
-				SchemaVersion: "2",
+				SchemaVersion: v2.SchemaVersion,
 				Package: v2.Package{
 					Name: "scenario-6",
 				},

--- a/pkg/advisory/export.go
+++ b/pkg/advisory/export.go
@@ -58,6 +58,9 @@ func ExportCSV(opts ExportOptions) (io.Reader, error) {
 
 					case v2.EventTypeAnalysisNotPlanned:
 						note = event.Data.(v2.AnalysisNotPlanned).Note
+
+					case v2.EventTypePendingUpstreamFix:
+						note = event.Data.(v2.PendingUpstreamFix).Note
 					}
 
 					row := []string{

--- a/pkg/advisory/update.go
+++ b/pkg/advisory/update.go
@@ -45,5 +45,11 @@ func Update(req Request, opts UpdateOptions) error {
 		return fmt.Errorf("unable to add entry for advisory %q in %q: %w", vulnID, req.Package, err)
 	}
 
+	// Update the schema version to the latest version.
+	err = documents.Update(v2.NewSchemaVersionSectionUpdater(v2.SchemaVersion))
+	if err != nil {
+		return fmt.Errorf("unable to update schema version for %q: %w", req.Package, err)
+	}
+
 	return nil
 }

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	envVarNameForDistroDir     = "WOLFICTL_DISTRO_REPO_DIR" //nolint:gosec
+	envVarNameForDistroDir     = "WOLFICTL_DISTRO_REPO_DIR" //nolint:gosec // This isn't a hardcoded credential.
 	envVarNameForAdvisoriesDir = "WOLFICTL_ADVISORIES_REPO_DIR"
 )
 

--- a/pkg/cli/advisory_list.go
+++ b/pkg/cli/advisory_list.go
@@ -158,7 +158,9 @@ func (p *listParams) addFlagsTo(cmd *cobra.Command) {
 
 func renderListItem(event v2.Event) string {
 	switch t := event.Type; t {
-	case v2.EventTypeAnalysisNotPlanned, v2.EventTypeFixNotPlanned:
+	case v2.EventTypeAnalysisNotPlanned,
+		v2.EventTypeFixNotPlanned,
+		v2.EventTypePendingUpstreamFix:
 		return t
 
 	case v2.EventTypeDetection:

--- a/pkg/configs/advisory/SCHEMA_VERSIONS.md
+++ b/pkg/configs/advisory/SCHEMA_VERSIONS.md
@@ -88,6 +88,9 @@ Log the new schema version in this document, at the top of the section [Version 
 `(vNext goes here)`
 - (list what was changed)
 
+`v2.0.1`
+- Added new event type "pending-upstream-fix", with a required "note" data field.
+
 `v2`
 - The first officially versioned advisory document schema. ("v1" refers to the prior document format derived from OpenVEX, although these documents were never explicitly given a schema version.)
 - Advisory documents now declare their schema version.

--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -78,7 +78,10 @@ func (adv Advisory) ResolvedAtVersion(version string) bool {
 	}
 
 	switch latest := adv.Latest(); latest.Type {
-	case EventTypeFalsePositiveDetermination, EventTypeFixNotPlanned, EventTypeAnalysisNotPlanned:
+	case EventTypeFalsePositiveDetermination,
+		EventTypeFixNotPlanned,
+		EventTypeAnalysisNotPlanned,
+		EventTypePendingUpstreamFix:
 		return true
 
 	case EventTypeFixed:

--- a/pkg/configs/advisory/v2/analysis_not_planned.go
+++ b/pkg/configs/advisory/v2/analysis_not_planned.go
@@ -2,6 +2,9 @@ package v2
 
 import "errors"
 
+// AnalysisNotPlanned is an event type that indicates that the vulnerability's
+// match to the package that this advisory refers to is not expected to be
+// analyzed further by the distro maintainers.
 type AnalysisNotPlanned struct {
 	// Note should explain why there is no plan to analyze the vulnerability match.
 	Note string `yaml:"note"`

--- a/pkg/configs/advisory/v2/document.go
+++ b/pkg/configs/advisory/v2/document.go
@@ -14,7 +14,7 @@ import (
 // Wolfictl can only operate on documents that use a schema version that is
 // equal to or earlier than this version and that is not earlier than this
 // version's MAJOR number.
-const SchemaVersion = "2"
+const SchemaVersion = "2.0.1"
 
 type Document struct {
 	SchemaVersion string     `yaml:"schema-version"`

--- a/pkg/configs/advisory/v2/document_test.go
+++ b/pkg/configs/advisory/v2/document_test.go
@@ -230,6 +230,13 @@ func TestDocument_full_coverage(t *testing.T) {
 							Note: "Something something fix not planned.",
 						},
 					},
+					{
+						Timestamp: testTime,
+						Type:      EventTypePendingUpstreamFix,
+						Data: PendingUpstreamFix{
+							Note: "Something something pending upstream fix.",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/configs/advisory/v2/event.go
+++ b/pkg/configs/advisory/v2/event.go
@@ -16,10 +16,17 @@ const (
 	EventTypeFalsePositiveDetermination = "false-positive-determination"
 	EventTypeAnalysisNotPlanned         = "analysis-not-planned"
 	EventTypeFixNotPlanned              = "fix-not-planned"
+	EventTypePendingUpstreamFix         = "pending-upstream-fix"
 )
 
 type EventTypeData interface {
-	Detection | TruePositiveDetermination | Fixed | FalsePositiveDetermination | AnalysisNotPlanned | FixNotPlanned
+	Detection |
+		TruePositiveDetermination |
+		Fixed |
+		FalsePositiveDetermination |
+		AnalysisNotPlanned |
+		FixNotPlanned |
+		PendingUpstreamFix
 }
 
 var (
@@ -31,6 +38,7 @@ var (
 		EventTypeFalsePositiveDetermination,
 		EventTypeAnalysisNotPlanned,
 		EventTypeFixNotPlanned,
+		EventTypePendingUpstreamFix,
 	}
 )
 
@@ -83,6 +91,9 @@ func (e *Event) UnmarshalYAML(v *yaml.Node) error {
 
 	case EventTypeFixNotPlanned:
 		event, err = decodeTypedEventData[FixNotPlanned](eventData)
+
+	case EventTypePendingUpstreamFix:
+		event, err = decodeTypedEventData[PendingUpstreamFix](eventData)
 
 	default:
 		return fmt.Errorf("unrecognized event type %q, must be one of [%s]", eventData.Type, strings.Join(EventTypes, ", "))
@@ -163,6 +174,9 @@ func (e Event) validateData() error {
 
 	case EventTypeFixNotPlanned:
 		return validateTypedEventData[FixNotPlanned](e.Data)
+
+	case EventTypePendingUpstreamFix:
+		return validateTypedEventData[PendingUpstreamFix](e.Data)
 	}
 
 	return nil

--- a/pkg/configs/advisory/v2/fix_not_planned.go
+++ b/pkg/configs/advisory/v2/fix_not_planned.go
@@ -2,6 +2,8 @@ package v2
 
 import "errors"
 
+// FixNotPlanned is an event type that indicates that the package is expected
+// not to receive a fix for the vulnerability.
 type FixNotPlanned struct {
 	// Note should explain why there is no plan to fix the vulnerability.
 	Note string `yaml:"note"`

--- a/pkg/configs/advisory/v2/pending_upstream_fix.go
+++ b/pkg/configs/advisory/v2/pending_upstream_fix.go
@@ -1,0 +1,25 @@
+package v2
+
+import "errors"
+
+// PendingUpstreamFix is an event type that indicates that the package is
+// expected to remain unfixed until the maintainers of the package's upstream
+// project implement a fix themselves.
+//
+// This event type is distinct from FixNotPlanned, which signals an expectation
+// that no fix is ever coming.
+//
+// PendingUpstreamFix is used in cases where a fix requires nontrivial upstream
+// changes that should be managed by the upstream maintainers.
+type PendingUpstreamFix struct {
+	// Note should explain why an upstream fix is anticipated or necessary.
+	Note string `yaml:"note"`
+}
+
+// Validate returns an error if the PendingUpstreamFix data is invalid.
+func (f PendingUpstreamFix) Validate() error {
+	if f.Note == "" {
+		return errors.New("note must not be empty")
+	}
+	return nil
+}

--- a/pkg/configs/advisory/v2/section_updaters.go
+++ b/pkg/configs/advisory/v2/section_updaters.go
@@ -2,6 +2,23 @@ package v2
 
 import "github.com/wolfi-dev/wolfictl/pkg/configs"
 
+func NewSchemaVersionSectionUpdater(newSchemaVersion string) configs.EntryUpdater[Document] {
+	updater := func(_ Document) (string, error) {
+		return newSchemaVersion, nil
+	}
+
+	yamlASTMutater := configs.NewTargetedYAMLASTMutater[string, Document](
+		"schema-version",
+		updater,
+		func(doc Document, data string) Document {
+			doc.SchemaVersion = data
+			return doc
+		},
+	)
+
+	return configs.NewYAMLUpdateFunc[Document](yamlASTMutater)
+}
+
 func NewAdvisoriesSectionUpdater(
 	updater configs.SectionUpdater[Advisories, Document],
 ) configs.EntryUpdater[Document] {

--- a/pkg/configs/advisory/v2/testdata/full.advisories.yaml
+++ b/pkg/configs/advisory/v2/testdata/full.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: full
@@ -71,3 +71,7 @@ advisories:
         type: fix-not-planned
         data:
           note: Something something fix not planned.
+      - timestamp: 2000-01-01T00:00:00Z
+        type: pending-upstream-fix
+        data:
+          note: Something something pending upstream fix.

--- a/pkg/scan/testdata/advisories/ko.advisories.yaml
+++ b/pkg/scan/testdata/advisories/ko.advisories.yaml
@@ -24,3 +24,24 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.13.0-r3
+
+  - id: CVE-2001-33333
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: fix-not-planned
+        data:
+          note: Just because.
+
+  - id: CVE-2002-44444
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: analysis-not-planned
+        data:
+          note: Just because.
+
+  - id: CVE-2003-55555
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: pending-upstream-fix
+        data:
+          note: Just because.


### PR DESCRIPTION
This revs the advisory schema to version `2.0.1`, which adds a non-breaking change:

- A new event type `PendingUpstreamFix`

This addresses an emergent need where the distro staff either isn't able to implement the fix on the upstream maintainers' behalf in a reasonable amount of time, or where doing so introduces more risk to the security of the software than leaving the fix to the upstream maintainers to take on.

This is a distinct state from `FixNotPlanned`, which says that a fix is never coming.

It's also distinct from `TruePositiveDetermination`, which acknowledges the vulnerability's impact on the package but doesn't communicate the distro staff's plan for remediation.