### PR TITLE
feat(scan): experimental `--govulncheck` flag for triaging

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,7 @@ linters:
     - gofmt
     - goheader
     - goimports
-    - gomoddirectives
+    # - gomoddirectives is disabled because it wasn't allowing the 'replace' directive, and it didn't look possible to exempt a single line of a go.mod. I'm not a fan of replaces, but they're useful as temporary measures.
     - gomodguard
     - goprintffuncname
     - gosec

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	golang.org/x/sync v0.4.0
 	golang.org/x/text v0.13.0
 	golang.org/x/time v0.3.0
+	golang.org/x/vuln v1.0.1
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/release-utils v0.7.5
 )
@@ -318,3 +319,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace golang.org/x/vuln => github.com/luhring/golang-vuln v1.0.2-0.20231029212121-c364fd4725dc

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRn
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/luhring/golang-vuln v1.0.2-0.20231029212121-c364fd4725dc h1:xBZQlANkBN45jHwta/fZRXZLEkumSBMi6Y0FYyYHgBs=
+github.com/luhring/golang-vuln v1.0.2-0.20231029212121-c364fd4725dc/go.mod h1:bb2hMwln/tqxg32BNY4CcxHWtHXuYa3SbIBmtsyjxtM=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -17,11 +17,7 @@ const (
 var ValidAdvisoriesSets = []string{AdvisoriesSetResolved, AdvisoriesSetAll}
 
 // FilterWithAdvisories filters the findings in the result based on the advisories for the target APK.
-func FilterWithAdvisories(result *Result, advisoryDocIndices []*configs.Index[v2.Document], advisoryFilterSet string) ([]*Finding, error) {
-	if result == nil {
-		return nil, fmt.Errorf("result cannot be nil")
-	}
-
+func FilterWithAdvisories(result Result, advisoryDocIndices []*configs.Index[v2.Document], advisoryFilterSet string) ([]Finding, error) {
 	if advisoryDocIndices == nil {
 		return nil, fmt.Errorf("advisory configs cannot be nil")
 	}
@@ -60,8 +56,8 @@ func FilterWithAdvisories(result *Result, advisoryDocIndices []*configs.Index[v2
 	return filteredFindings, nil
 }
 
-func filterFindingsWithAllAdvisories(findings []*Finding, packageAdvisories v2.Advisories) []*Finding {
-	return lo.Filter(findings, func(finding *Finding, _ int) bool {
+func filterFindingsWithAllAdvisories(findings []Finding, packageAdvisories v2.Advisories) []Finding {
+	return lo.Filter(findings, func(finding Finding, _ int) bool {
 		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
 		// If the advisory contains any events, filter it out!
 		if ok && len(adv.Events) >= 1 {
@@ -84,8 +80,8 @@ func filterFindingsWithAllAdvisories(findings []*Finding, packageAdvisories v2.A
 	})
 }
 
-func filterFindingsWithResolvedAdvisories(findings []*Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []*Finding {
-	return lo.Filter(findings, func(finding *Finding, _ int) bool {
+func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []Finding {
+	return lo.Filter(findings, func(finding Finding, _ int) bool {
 		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
 		if ok && adv.ResolvedAtVersion(currentPackageVersion) {
 			return false

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -16,17 +16,9 @@ func TestFilterWithAdvisories(t *testing.T) {
 		result                *Result
 		advisoryIndicesGetter func(t *testing.T) []*configs.Index[v2.Document]
 		advisoryFilterSet     string
-		expectedFindings      []*Finding
+		expectedFindings      []Finding
 		errAssertion          assert.ErrorAssertionFunc
 	}{
-		{
-			name:                  "nil result",
-			result:                nil,
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "",
-			expectedFindings:      nil,
-			errAssertion:          assert.Error,
-		},
 		{
 			name:                  "nil advisory index",
 			result:                &Result{},
@@ -42,7 +34,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Name:    "ko",
 					Version: "42",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Package: Package{
 							Name:    "compliancebot",
@@ -66,7 +58,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Name:    "ko",
 					Version: "42",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Vulnerability: Vulnerability{
 							ID: "CVE-2023-1234",
@@ -91,7 +83,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			advisoryIndicesGetter: getSingleAdvisoriesIndex,
 			advisoryFilterSet:     "all",
-			expectedFindings: []*Finding{
+			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
 						ID: "CVE-2023-1234",
@@ -107,7 +99,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Name:    "ko",
 					Version: "42",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Vulnerability: Vulnerability{
 							ID:      "GHSA-1234-1234-1234",
@@ -124,7 +116,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			advisoryIndicesGetter: getSingleAdvisoriesIndex,
 			advisoryFilterSet:     "all",
-			expectedFindings:      []*Finding{},
+			expectedFindings:      []Finding{},
 			errAssertion:          assert.NoError,
 		},
 		{
@@ -134,7 +126,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Name:    "ko",
 					Version: "42",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Vulnerability: Vulnerability{
 							ID: "CVE-2023-1234",
@@ -159,7 +151,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			advisoryIndicesGetter: getSingleAdvisoriesIndex,
 			advisoryFilterSet:     "resolved",
-			expectedFindings: []*Finding{
+			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
 						ID: "CVE-2023-1234",
@@ -180,7 +172,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Name:    "ko",
 					Version: "42",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Vulnerability: Vulnerability{
 							ID:      "GHSA-abcd-abcd-abcd",
@@ -191,7 +183,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			advisoryIndicesGetter: getSingleAdvisoriesIndex,
 			advisoryFilterSet:     "resolved",
-			expectedFindings:      []*Finding{},
+			expectedFindings:      []Finding{},
 			errAssertion:          assert.NoError,
 		},
 		{
@@ -202,7 +194,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Version:           "0.13.0-r4",
 					OriginPackageName: "ko",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Vulnerability: Vulnerability{
 							ID: "GHSA-2h5h-59f5-c5x9",
@@ -212,7 +204,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			advisoryIndicesGetter: getSingleAdvisoriesIndex,
 			advisoryFilterSet:     "resolved",
-			expectedFindings:      []*Finding{},
+			expectedFindings:      []Finding{},
 			errAssertion:          assert.NoError,
 		},
 		{
@@ -222,7 +214,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Name:    "ko",
 					Version: "0.13.0-r2",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Vulnerability: Vulnerability{
 							ID: "GHSA-2h5h-59f5-c5x9",
@@ -232,7 +224,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			advisoryIndicesGetter: getSingleAdvisoriesIndex,
 			advisoryFilterSet:     "resolved",
-			expectedFindings: []*Finding{
+			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
 						ID: "GHSA-2h5h-59f5-c5x9",
@@ -248,7 +240,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 					Name:    "ko",
 					Version: "0.13.0-r2",
 				},
-				Findings: []*Finding{
+				Findings: []Finding{
 					{
 						Vulnerability: Vulnerability{
 							ID: "GHSA-2h5h-59f5-c5x9", // In first advisories index (as fixed)
@@ -268,7 +260,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			advisoryIndicesGetter: getMultipleAdvisoriesIndices,
 			advisoryFilterSet:     "all",
-			expectedFindings: []*Finding{
+			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
 						ID: "GHSA-cccc-cccc-cccc",
@@ -283,10 +275,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			index := tt.advisoryIndicesGetter(t)
 
-			var resultFindings []*Finding
+			var resultFindings []Finding
 			var err error
 			assert.NotPanics(t, func() {
-				resultFindings, err = FilterWithAdvisories(tt.result, index, tt.advisoryFilterSet)
+				resultFindings, err = FilterWithAdvisories(*tt.result, index, tt.advisoryFilterSet)
 			})
 			tt.errAssertion(t, err)
 			assert.Equal(t, tt.expectedFindings, resultFindings)

--- a/pkg/scan/finding.go
+++ b/pkg/scan/finding.go
@@ -1,0 +1,102 @@
+package scan
+
+import (
+	"fmt"
+	"strings"
+
+	v5 "github.com/anchore/grype/grype/db/v5"
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/store"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/file"
+	"github.com/samber/lo"
+)
+
+// Finding represents a vulnerability finding for a single package.
+type Finding struct {
+	Package           Package
+	Vulnerability     Vulnerability
+	TriageAssessments []TriageAssessment
+}
+
+type Package struct {
+	ID       string
+	Name     string
+	Version  string
+	Type     string
+	Location string
+}
+
+type Vulnerability struct {
+	ID           string
+	Severity     string
+	Aliases      []string
+	FixedVersion string
+}
+
+type TriageAssessment struct {
+	// Source is the name of the source of the triage assessment, e.g.
+	// "govulncheck".
+	Source string
+
+	// TruePositive indicates whether the vulnerability is a true positive. A value
+	// of false indicates that the vulnerability has been assessed to be a false
+	// positive.
+	TruePositive bool
+
+	// Reason is the explanation of the triage assessment.
+	Reason string
+}
+
+func mapMatchToFinding(m match.Match, datastore *store.Store) (*Finding, error) {
+	metadata, err := datastore.MetadataProvider.GetMetadata(m.Vulnerability.ID, m.Vulnerability.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get metadata for vulnerability %s: %w", m.Vulnerability.ID, err)
+	}
+
+	var relatedMetadatas []*vulnerability.Metadata
+	for _, relatedRef := range m.Vulnerability.RelatedVulnerabilities {
+		relatedMetadata, err := datastore.MetadataProvider.GetMetadata(relatedRef.ID, relatedRef.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get metadata for related vulnerability %s: %w", relatedRef.ID, err)
+		}
+		if relatedMetadata == nil {
+			continue
+		}
+		relatedMetadatas = append(relatedMetadatas, relatedMetadata)
+	}
+
+	aliases := lo.Map(relatedMetadatas, func(m *vulnerability.Metadata, _ int) string {
+		return m.ID
+	})
+
+	locations := lo.Map(m.Package.Locations.ToSlice(), func(l file.Location, _ int) string {
+		return "/" + l.RealPath
+	})
+
+	f := &Finding{
+		Package: Package{
+			ID:       string(m.Package.ID),
+			Name:     m.Package.Name,
+			Version:  m.Package.Version,
+			Type:     string(m.Package.Type),
+			Location: strings.Join(locations, ", "),
+		},
+		Vulnerability: Vulnerability{
+			ID:           m.Vulnerability.ID,
+			Severity:     metadata.Severity,
+			Aliases:      aliases,
+			FixedVersion: getFixedVersion(m.Vulnerability),
+		},
+	}
+
+	return f, nil
+}
+
+func getFixedVersion(vuln vulnerability.Vulnerability) string {
+	if vuln.Fix.State != v5.FixedState {
+		return ""
+	}
+
+	return strings.Join(vuln.Fix.Versions, ", ")
+}

--- a/pkg/scan/govulncheck.go
+++ b/pkg/scan/govulncheck.go
@@ -1,0 +1,90 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/vuln/pkg/client"
+	"golang.org/x/vuln/pkg/govulncheck"
+	vulnscan "golang.org/x/vuln/pkg/scan"
+	"golang.org/x/vuln/pkg/vulncheck"
+)
+
+const (
+	govulncheckDB = "https://vuln.go.dev"
+	indexEndpoint = "/index/vulns.json"
+)
+
+// runGovulncheck is our entrypoint for running govulncheck on a Go binary (as
+// the exe parameter).
+func runGovulncheck(ctx context.Context, exe io.ReaderAt) (*vulncheck.Result, error) {
+	// TODO: implement a smarter client that can cache the DB locally.
+	c, err := client.NewClient(govulncheckDB, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating DB client: %w", err)
+	}
+
+	cfg := &govulncheck.Config{
+		ScanLevel: "symbol",
+	}
+	result, err := vulncheck.Binary(ctx, exe, cfg, c)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Vulns = vulnscan.UniqueVulns(result.Vulns)
+
+	return result, nil
+}
+
+type GoVulnDBIndex struct {
+	index map[string]GoVulnDBIndexEntry
+}
+
+type GoVulnDBIndexEntry struct {
+	ID       string    `json:"id"`
+	Modified time.Time `json:"modified"`
+	Aliases  []string  `json:"aliases,omitempty"`
+}
+
+// BuildIndexForGoVulnDB builds an index of GoVulnDB entries, keyed by aliases
+// (like CVE IDs and GHSA IDs).
+func BuildIndexForGoVulnDB(ctx context.Context) (*GoVulnDBIndex, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", govulncheckDB+indexEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var entries []GoVulnDBIndexEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, err
+	}
+
+	index := make(map[string]GoVulnDBIndexEntry)
+	for _, entry := range entries {
+		index[entry.ID] = entry
+		for _, alias := range entry.Aliases {
+			index[alias] = entry
+		}
+	}
+
+	return &GoVulnDBIndex{index}, nil
+}
+
+// Get returns the GoVulnDB index entry for the given ID, or false if it doesn't
+// exist.
+func (i *GoVulnDBIndex) Get(id string) (GoVulnDBIndexEntry, bool) {
+	entry, ok := i.index[id]
+	return entry, ok
+}

--- a/pkg/scan/triage.go
+++ b/pkg/scan/triage.go
@@ -1,0 +1,172 @@
+package scan
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/anchore/syft/syft/pkg"
+	"golang.org/x/vuln/pkg/vulncheck"
+)
+
+const TriageSourceGovulncheck = "govulncheck"
+
+// Triage inspects an existing scan Result and attempts to triage each finding,
+// returning a copy of the Result's list of findings, modified to include
+// TriageAssessments where applicable.
+func Triage(ctx context.Context, result Result, apkFile io.ReadSeeker) ([]Finding, error) {
+	findings := slices.Clone(result.Findings)
+
+	// Get the list of findings that are matched against a module in a Go binary,
+	// and for each finding, also get the Go binary's name, so we can send the Go
+	// binary to govulncheck for scanning.
+
+	locationsForGovulncheck := make(map[string]*vulncheck.Result)
+
+	for i := range result.Findings {
+		f := result.Findings[i]
+		if f.Package.Type != string(pkg.GoModulePkg) {
+			continue
+		}
+
+		l := f.Package.Location
+		if l == "" {
+			return nil, fmt.Errorf("package %q location should not be empty", f.Package.Name)
+		}
+
+		// Add a sentinel value that will be replaced with the govulncheck result, to
+		// signal that these location in the APK needs to be scanned by govulncheck.
+		locationsForGovulncheck[l] = &vulncheck.Result{}
+	}
+
+	_, err := apkFile.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, fmt.Errorf("failed to seek to start of APK file: %w", err)
+	}
+
+	gr, err := gzip.NewReader(apkFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader for APK file: %w", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read next tar header: %w", err)
+		}
+
+		if _, ok := locationsForGovulncheck["/"+hdr.Name]; ok {
+			by, err := io.ReadAll(io.LimitReader(tr, hdr.Size))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read tar entry %q: %w", hdr.Name, err)
+			}
+
+			r := bytes.NewReader(by)
+			result, err := runGovulncheck(ctx, r)
+			if err != nil {
+				return nil, err
+			}
+
+			locationsForGovulncheck["/"+hdr.Name] = result
+		}
+	}
+
+	govulnDBIndex, err := BuildIndexForGoVulnDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now go back through findings and leverage the govulncheck results.
+	for i := range findings {
+		f := findings[i]
+		if f.Package.Type != string(pkg.GoModulePkg) {
+			continue
+		}
+
+		l := f.Package.Location
+		if l == "" {
+			return nil, fmt.Errorf("package %q location cannot be empty", f.Package.Name)
+		}
+
+		result := locationsForGovulncheck[l]
+		if result == nil {
+			return nil, fmt.Errorf("missing expected govulncheck result for location %q", l)
+		}
+
+		foundByGovulncheck := false
+		for _, vuln := range result.Vulns {
+			gvAliases := vuln.OSV.Aliases
+			for _, alias := range gvAliases {
+				if !slices.Contains(append(f.Vulnerability.Aliases, f.Vulnerability.ID), alias) {
+					// This govulncheck result vuln alias is not relevant to this finding.
+					continue
+				}
+
+				foundByGovulncheck = true
+
+				assessment := TriageAssessment{
+					Source:       TriageSourceGovulncheck,
+					TruePositive: true,
+					Reason: fmt.Sprintf(
+						"affected symbol %q is present in Go binary (see %s)",
+						vuln.Symbol,
+						vuln.OSV.ID,
+					),
+				}
+				findings[i].TriageAssessments = append(findings[i].TriageAssessments, assessment)
+
+				// Other aliases might provide the same confirmation, but that would be
+				// redundant, so we can stop here.
+				break
+			}
+		}
+
+		if !foundByGovulncheck {
+			// If govulncheck didn't confirm the finding, but it did know what to look for
+			// (that is, the vulnerability exists in Go's vulndb), then we can assume it's a
+			// false positive. Otherwise, we can't make any assumptions, because govulncheck
+			// didn't even consider the vulnerability.
+			if !isKnownToGoVulnDB(f.Vulnerability, govulnDBIndex) {
+				continue
+			}
+
+			assessment := TriageAssessment{
+				Source:       TriageSourceGovulncheck,
+				TruePositive: false,
+				Reason: fmt.Sprintf(
+					"no known affected symbols present in Go binary (see %s)",
+					f.Vulnerability.ID,
+				),
+			}
+			findings[i].TriageAssessments = append(findings[i].TriageAssessments, assessment)
+		}
+	}
+
+	return findings, nil
+}
+
+func isKnownToGoVulnDB(v Vulnerability, govulnDBIndex *GoVulnDBIndex) bool {
+	_, ok := govulnDBIndex.Get(v.ID)
+	if ok {
+		return true
+	}
+
+	for _, alias := range v.Aliases {
+		_, ok := govulnDBIndex.Get(alias)
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Adds a new **experimental** flag `--govulncheck` to the `wolfictl scan` command.

This feature integrates with [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) (as a library, so no extra installation is needed), to follow up the Grype scan with an extra close inspection of the APK's _Go binaries_ that were referenced by the vulnerability matching output from Grype.

Govulncheck is great because it crosschecks binaries' symbol table data with symbol-level vulnerability data in the Go Vuln DB, which helps users understand if a specific symbol (function/method) that's known to be vulnerable is actually present in a compiled Go binary. This level of granularity can help confirm that an initially reported vulnerability match (typically at the coarser "Go module" level) is a true positive (the affected function is included) or a false positive (the affected function isn't found in the compiled binary).

With respect to `wolfictl scan`, this PR introduces the beginnings of a _"triaging framework"_, where reported findings can be assessed by one or more triage sources (like "govulncheck") as a true or false positive. This framework is expected to evolve heavily over time and should be considered unstable for the time being.

<img width="1336" alt="image" src="https://github.com/wolfi-dev/wolfictl/assets/5199289/0598c355-4dbf-43c1-9a1a-9f8379f0ea88">

When `--govulncheck` is used, triage assessments are added to the default (tree) command output, and a bit more information is found in the JSON (`-o json`) output as well.

**NOTE:** One useful aspect of this feature **that isn't included in this PR** (but would be great to add soon) is to assess a finding as a false positive when the match is in a dependency module and the vulnerability has been **excluded** from the Go Vuln DB on the grounds that the affected functionality is "NOT_IMPORTABLE". These entries are not included in the Go Vuln DB, so adding this feature to `wolfictl` will require creating an additional data source.

Feedback on this feature is very much welcomed!