### PR TITLE
Fix linter parity with local development

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.54
+          version: v1.55.1

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -70,7 +70,7 @@ func loadLongDescription(cmd *cobra.Command, path ...string) error {
 		if c.Name() == "" {
 			continue
 		}
-		fullpath := filepath.Join(path[0], strings.Join(append(path[1:], c.Name()), "_")+".md")
+		fullpath := filepath.Join(path[0], strings.Join(append(path[1:], c.Name()), "_")+markdownExtension)
 		if c.HasSubCommands() {
 			if err := loadLongDescription(c, path[0], c.Name()); err != nil {
 				return err

--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const markdownExtension = ".md"
+
 func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
@@ -88,7 +90,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		if cmd.HasParent() {
 			parent := cmd.Parent()
 			pname := parent.CommandPath()
-			link := pname + ".md"
+			link := pname + markdownExtension
 			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short))
 			cmd.VisitParents(func(c *cobra.Command) {
@@ -106,7 +108,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 				continue
 			}
 			cname := name + " " + child.Name()
-			link := cname + ".md"
+			link := cname + markdownExtension
 			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", cname, linkHandler(link), child.Short))
 		}
@@ -143,7 +145,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 		}
 	}
 
-	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + ".md"
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + markdownExtension
 	filename := filepath.Join(dir, basename)
 	f, err := os.Create(filename)
 	if err != nil {

--- a/pkg/checks/diff_test.go
+++ b/pkg/checks/diff_test.go
@@ -22,9 +22,10 @@ func TestDiff(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create a test server to download the test apk from
+	const apkindexEndpoint = "/APKINDEX.tar.gz"
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/APKINDEX.tar.gz":
+		case apkindexEndpoint:
 			_, err = rw.Write(apkIndexData)
 			assert.NoError(t, err)
 		case "/test-1.2.3-r0.apk":
@@ -39,7 +40,7 @@ func TestDiff(t *testing.T) {
 	}))
 
 	diffOpts := DiffOptions{
-		ApkIndexURL:         server.URL + "/APKINDEX.tar.gz",
+		ApkIndexURL:         server.URL + apkindexEndpoint,
 		Client:              server.Client(),
 		PackageListFilename: filepath.Join(dir, "packages.log"),
 		Dir:                 resultDir,

--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -73,6 +73,8 @@ func (o CheckUpdateOptions) CheckUpdates(files []string) error {
 	return checkErrors.WrapErrors()
 }
 
+const yamlExtension = ".yaml"
+
 // validates update configuration
 func validateUpdateConfig(files []string, checkErrors *lint.EvalRuleErrors) {
 	for _, file := range files {
@@ -82,8 +84,8 @@ func validateUpdateConfig(files []string, checkErrors *lint.EvalRuleErrors) {
 		}
 
 		// first need to read raw bytes as unmarshalling a struct without a pointer means update will never be nil
-		if !strings.HasSuffix(file, ".yaml") {
-			file += ".yaml"
+		if !strings.HasSuffix(file, yamlExtension) {
+			file += yamlExtension
 		}
 		yamlData, err := os.ReadFile(file)
 		if err != nil {
@@ -140,7 +142,7 @@ func containsKey(parentNode *yaml.Node, key string) error {
 func GetPackagesToUpdate(files []string) []string {
 	packagesToUpdate := []string{}
 	for _, f := range files {
-		packagesToUpdate = append(packagesToUpdate, strings.TrimSuffix(f, ".yaml"))
+		packagesToUpdate = append(packagesToUpdate, strings.TrimSuffix(f, yamlExtension))
 	}
 
 	return packagesToUpdate
@@ -161,7 +163,7 @@ func handleErrorMessages(updateOpts *update.Options, checkErrors *lint.EvalRuleE
 // check if the current package.version is the latest according to the update config
 func (o CheckUpdateOptions) checkForLatestVersions(latestVersions map[string]update.NewVersionResults, checkErrors *lint.EvalRuleErrors) {
 	for k, v := range latestVersions {
-		c, err := config.ParseConfiguration(filepath.Join(o.Dir, k+".yaml"))
+		c, err := config.ParseConfiguration(filepath.Join(o.Dir, k+yamlExtension))
 		if err != nil {
 			addCheckError(checkErrors, err)
 			continue
@@ -193,7 +195,7 @@ func (o CheckUpdateOptions) processUpdates(latestVersions map[string]update.NewV
 	defer os.RemoveAll(tempDir)
 
 	for packageName, newVersion := range latestVersions {
-		srcConfigFile := filepath.Join(o.Dir, packageName+".yaml")
+		srcConfigFile := filepath.Join(o.Dir, packageName+yamlExtension)
 
 		dryRunConfig, err := config.ParseConfiguration(srcConfigFile)
 		if err != nil {
@@ -206,7 +208,7 @@ func (o CheckUpdateOptions) processUpdates(latestVersions map[string]update.NewV
 			return err
 		}
 
-		tmpConfigFile := filepath.Join(tempDir, packageName+".yaml")
+		tmpConfigFile := filepath.Join(tempDir, packageName+yamlExtension)
 		err = os.WriteFile(tmpConfigFile, data, os.FileMode(0o644))
 		if err != nil {
 			return err

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	envVarNameForDistroDir     = "WOLFICTL_DISTRO_REPO_DIR" //nolint:gosec // This isn't a hardcoded credential.
+	envVarNameForDistroDir     = "WOLFICTL_DISTRO_REPO_DIR"
 	envVarNameForAdvisoriesDir = "WOLFICTL_ADVISORIES_REPO_DIR"
 )
 


### PR DESCRIPTION
We were seeing different results in CI vs. the local experience — including a case where applying a local "fix" _breaks_ the results in CI — which makes it painful to run the check locally. Ideally running the local check rewards developers by shifting "left" feedback that would come back in CI to the local iteration workflow.

This PR updates CI to use the latest version of `golangci-lint` and fixes the new linting issues that get reported.