### PR TITLE
feat(scan): ability to scan Wolfi packages remotely by name

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -655,8 +655,14 @@ func renderTriaging(verticalLine string, trs []scan.TriageAssessment) string {
 		return ""
 	}
 
+	// Only show one line per triage source
+	seen := make(map[string]struct{})
 	var lines []string
 	for _, tr := range trs {
+		if _, ok := seen[tr.Source]; ok {
+			continue
+		}
+		seen[tr.Source] = struct{}{}
 		lines = append(lines, renderTriageAssessment(verticalLine, tr))
 	}
 

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -173,7 +173,7 @@ func (p *scanParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&p.disableSBOMCache, "disable-sbom-cache", false, "don't use the SBOM cache")
 	cmd.Flags().BoolVar(&p.triageWithGoVulnCheck, "govulncheck", false, "EXPERIMENTAL: triage vulnerabilities in Go binaries using govulncheck")
 	_ = cmd.Flags().MarkHidden("govulncheck") //nolint:errcheck
-	cmd.Flags().BoolVarP(&p.remoteScanning, "remote", "r", false, "treat input(s) as the name(s) of package(s) in the Wolfi package repository to scan the latest versions of")
+	cmd.Flags().BoolVarP(&p.remoteScanning, "remote", "r", false, "treat input(s) as the name(s) of package(s) in the Wolfi package repository to download and scan the latest versions of")
 }
 
 func (p *scanParams) resolveInputsToScan(ctx context.Context, args []string) ([]string, error) {


### PR DESCRIPTION
A frequent pain in today's scanning is having to get a hold of a particular APK file _before you can scan it_. This means you either have to wait to _build it_ first (with melange), or you need to _find the APK_ in the APKINDEX (or in the backend infrastructure), and you need to figure out which version+epoch is the latest one.

When investigating a report of a vulnerability in package, the person doing the investigation often doesn't have the APK already at the time they're beginning their task.

This PR adds a new `--remote`/`-r` flag to `wolfictl scan`, that tells the command to interpret the arg(s) as package names (e.g. "crane") instead of as paths to APK files.

When this flag is used, `wolfictl` will dynamically figure out the latest published version of the package with the specified name (for each architecture), download the APKs to a temp directory, and then proceed with scanning.

For now, this only works with **_Wolfi_** packages.

<img width="1348" alt="image" src="https://github.com/wolfi-dev/wolfictl/assets/5199289/77aaf33c-33a7-4e55-b415-5dbc4409b676">

(This PR also fixes subtle functional issues and does some light code reorganization.)