### PR TITLE
wolfi bot: we now have ignore-regex update config so removing bad ove…

### DIFF
--- a/pkg/update/githubReleases.go
+++ b/pkg/update/githubReleases.go
@@ -343,7 +343,7 @@ func (o GitHubReleaseOptions) get(requestQuery string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.Logger.Printf("request query, to check visit https://docs.github.com/en/graphql/overview/explorer: %s", requestQuery)
+	o.Logger.Printf("request query, to check visit https://docs.github.com/en/graphql/overview/explorer %s", requestQuery)
 
 	req, err := http.NewRequest("POST", "https://api.github.com/graphql", bytes.NewBuffer(payloadBytes))
 	if err != nil {
@@ -587,9 +587,9 @@ func (o GitHubReleaseOptions) prepareVersion(nameHash, v, id string) (string, er
 		return "", fmt.Errorf("no github update config found for package %s", id)
 	}
 
-	// the github graphql query filter matches any occurrence, we want to make that more strict and remove any tags that do not START with the filter
+	// the github graphql query filter matches any occurrence of the tag filter
 	if ghm.TagFilter != "" {
-		if !strings.HasPrefix(v, ghm.TagFilter) {
+		if !strings.Contains(v, ghm.TagFilter) {
 			return "", nil
 		}
 	}

--- a/pkg/update/githubReleases_test.go
+++ b/pkg/update/githubReleases_test.go
@@ -304,6 +304,14 @@ func TestGitHubReleaseOptions_prepareVersion(t *testing.T) {
 				},
 			},
 		}, version: "v1.2.3", want: "v1.2.3", wantErr: assert.NoError},
+		{name: "tag-filter", melangeConfig: config.Configuration{
+			Update: config.Update{
+				GitHubMonitor: &config.GitHubMonitor{
+					TagFilter:   "-ga",
+					StripSuffix: "-ga",
+				},
+			},
+		}, version: "1.2.3-ga", want: "1.2.3", wantErr: assert.NoError},
 		{name: "transform-version", melangeConfig: config.Configuration{
 			Update: config.Update{
 				VersionTransform: []config.VersionTransform{


### PR DESCRIPTION
…rriding github graphql filter behaviour and defaulting to their api semantics

Important: this could affect existing `tag-filter` usage where we would need to add ingore-regex config to packages that use a filter and rely on matching only the START of the string value.  I'm running tests against my fork of wolfi to identify these cases and will fix any.