### PR TITLE
fix(scan): reduce Java FNs via Maven search

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -167,9 +167,15 @@ func newGrypeVulnerabilityMatcher(datastore store.Store) *grype.VulnerabilityMat
 func createMatchers() []matcher.Matcher {
 	return matcher.NewDefaultMatchers(
 		matcher.Config{
-			Dotnet:     dotnet.MatcherConfig{UseCPEs: false},
-			Golang:     golang.MatcherConfig{UseCPEs: false, AlwaysUseCPEForStdlib: true},
-			Java:       java.MatcherConfig{UseCPEs: false},
+			Dotnet: dotnet.MatcherConfig{UseCPEs: false},
+			Golang: golang.MatcherConfig{UseCPEs: false, AlwaysUseCPEForStdlib: true},
+			Java: java.MatcherConfig{
+				ExternalSearchConfig: java.ExternalSearchConfig{
+					SearchMavenUpstream: true,
+					MavenBaseURL:        mavenSearchBaseURL,
+				},
+				UseCPEs: false,
+			},
 			Javascript: javascript.MatcherConfig{UseCPEs: false},
 			Python:     python.MatcherConfig{UseCPEs: false},
 			Ruby:       ruby.MatcherConfig{UseCPEs: false},
@@ -178,3 +184,5 @@ func createMatchers() []matcher.Matcher {
 		},
 	)
 }
+
+const mavenSearchBaseURL = "https://search.maven.org/solrsearch/select"


### PR DESCRIPTION
Grype misses some Java matches (including some true positives) that other scanners seem to catch.

This change enables [this feature in Grype](https://github.com/anchore/grype#external-sources), which gives Grype better metadata for Maven packages such that it can more reliable find relevant matches when it searches its database for GHSA matches.

cc: @pdeslaur @found-it @rawlingsj @jedsalazar