### PR TITLE
feature: add tag-filter-prefix and tag-filter-contains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.21.1
 
 require (
 	chainguard.dev/apko v0.11.2
-	chainguard.dev/melange v0.5.2-0.20231027223504-2bcfbe6439a5
+	chainguard.dev/melange v0.5.2
 	github.com/adrg/xdg v0.4.0
 	github.com/anchore/grype v0.73.1
 	github.com/anchore/syft v0.96.0
-	github.com/chainguard-dev/go-apk v0.0.0-20231030174812-a5114d436c7a
+	github.com/chainguard-dev/go-apk v0.0.0-20231101222019-fa53d0b1c274
 	github.com/chainguard-dev/yam v0.0.0-20230807153807-4de7c531f3e1
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 chainguard.dev/apko v0.11.2 h1:icb1fePk3bpd+l44gIwjxr8I+aYjR/Ct60E6BGjJqmo=
 chainguard.dev/apko v0.11.2/go.mod h1:sfyKwVYDN78vg9mNakjecTCcaoNvASSTE6LELBA8es8=
-chainguard.dev/melange v0.5.2-0.20231027223504-2bcfbe6439a5 h1:5+kosrUUTfHu7rcHRrJ//KYVgnk7FlRVlKzpqSq9oJU=
-chainguard.dev/melange v0.5.2-0.20231027223504-2bcfbe6439a5/go.mod h1:DO2BkyJW5tEK9Ie7JiQxNDnzzREmiuTFZwq9c7jrIgs=
+chainguard.dev/melange v0.5.2 h1:ORGsgypDhKggtM1thq1j2CJpz8vGue3QxysHT1MQCm4=
+chainguard.dev/melange v0.5.2/go.mod h1:yprMYoVZYj6Zxn3BpiALuhgQhxQd4EUlP/mdUSSMzog=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -310,8 +310,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chainguard-dev/go-apk v0.0.0-20231030174812-a5114d436c7a h1:f3m/NBTfmlLkwJ65s/4352OfuwQI/5cKWGT/MSgdwAw=
-github.com/chainguard-dev/go-apk v0.0.0-20231030174812-a5114d436c7a/go.mod h1:LHiVwyOFfuMy/j+HPkAqow7c/+frfMBqaEkKChgG3HA=
+github.com/chainguard-dev/go-apk v0.0.0-20231101222019-fa53d0b1c274 h1:PlOfjQS/GCu9qT0PwLWtvzNj5YaETpCbuddoNQ56DQY=
+github.com/chainguard-dev/go-apk v0.0.0-20231101222019-fa53d0b1c274/go.mod h1:dEGwmNDWi/bctcKpACkvkVHMzrd1xKE7SPeye/1MWjs=
 github.com/chainguard-dev/go-pkgconfig v0.0.0-20230818193557-bee0072057ce h1:v3SY2sW8rUIxG9wXMxXlMN7sd9VNUSdZ+FnVqOrm2nI=
 github.com/chainguard-dev/go-pkgconfig v0.0.0-20230818193557-bee0072057ce/go.mod h1:obzGv2cx3tkRgkLQADSPaRl3OEsYmyfSv7t2Wu60tZw=
 github.com/chainguard-dev/kontext v0.1.0 h1:GFnDRZiqa+anUi7tzZMECXr0nwt4Eo/zMzTQPLRXUIs=

--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -230,7 +230,7 @@ func (o CheckUpdateOptions) processUpdates(latestVersions map[string]update.NewV
 			Build: &build.Build{
 				Configuration: *updated,
 			},
-			Package: &build.PackageContext{Package: &updated.Package},
+			Package: &updated.Package,
 		}
 
 		// get a map of variable mutations we can substitute vars in URLs

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -89,7 +89,7 @@ func (p *Packages) addProvides(c *Configuration, provides []string) error {
 			Build: &build.Build{
 				Configuration: *c.Configuration,
 			},
-			Package: &build.PackageContext{Package: &c.Package},
+			Package: &c.Package,
 		}
 		template, err := build.MutateWith(pctx, nil)
 		if err != nil {
@@ -199,7 +199,7 @@ func NewPackages(fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
 					PipelineDir:   pipelineDir,
 					Configuration: *c.Configuration,
 				},
-				Package: &build.PackageContext{Package: &c.Package},
+				Package: &c.Package,
 			}
 			for i := range c.Pipeline {
 				s := &build.PipelineContext{Pipeline: &c.Pipeline[i]}

--- a/pkg/update/githubReleases.go
+++ b/pkg/update/githubReleases.go
@@ -588,8 +588,23 @@ func (o GitHubReleaseOptions) prepareVersion(nameHash, v, id string) (string, er
 	}
 
 	// the github graphql query filter matches any occurrence, we want to make that more strict and remove any tags that do not START with the filter
+	// deprecated: todo: ajayk remove this once we have migrated over to TagFilterPrefix
 	if ghm.TagFilter != "" {
 		if !strings.HasPrefix(v, ghm.TagFilter) {
+			return "", nil
+		}
+	}
+	// TagFilterPrefix replaces TagFilter so we can be explicit about what the filter does
+	// TagFilterPrefix searches for prefix match only
+	if ghm.TagFilterPrefix != "" {
+		if !strings.HasPrefix(v, ghm.TagFilterPrefix) {
+			return "", nil
+		}
+	}
+
+	// TagFilterContains searches for substring match
+	if ghm.TagFilterContains != "" {
+		if !strings.Contains(v, ghm.TagFilterContains) {
 			return "", nil
 		}
 	}

--- a/pkg/update/githubReleases_test.go
+++ b/pkg/update/githubReleases_test.go
@@ -304,6 +304,32 @@ func TestGitHubReleaseOptions_prepareVersion(t *testing.T) {
 				},
 			},
 		}, version: "v1.2.3", want: "v1.2.3", wantErr: assert.NoError},
+		{name: "tag-filter-contains", melangeConfig: config.Configuration{
+			Update: config.Update{
+				GitHubMonitor: &config.GitHubMonitor{
+					TagFilterContains: "-ga",
+					StripSuffix:       "-ga",
+				},
+			},
+		}, version: "1.2.3-ga", want: "1.2.3", wantErr: assert.NoError},
+		{name: "tag-filter-contains", melangeConfig: config.Configuration{
+			Update: config.Update{
+				GitHubMonitor: &config.GitHubMonitor{
+					TagFilterContains: "-ga",
+					TagFilterPrefix:   "v",
+					StripSuffix:       "-ga",
+					StripPrefix:       "v",
+				},
+			},
+		}, version: "v1.2.3-ga", want: "1.2.3", wantErr: assert.NoError},
+		{name: "tag-filter-prefix", melangeConfig: config.Configuration{
+			Update: config.Update{
+				GitHubMonitor: &config.GitHubMonitor{
+					TagFilterPrefix: "v1.",
+					StripSuffix:     "-ga",
+				},
+			},
+		}, version: "v1.2.3-ga", want: "v1.2.3", wantErr: assert.NoError},
 		{name: "transform-version", melangeConfig: config.Configuration{
 			Update: config.Update{
 				VersionTransform: []config.VersionTransform{


### PR DESCRIPTION
This PR introduces two new filters  **`tag-filter-prefix`** and **`tag-filter-contains`**, to the GitHub Release filtering . These features enhance the filtering capabilities when preparing versions.

 `tag-filter-prefix` option ensures that only tags that start with the specified prefix are considered. the functionality is same as the `tag-filter`

`tag-filter-contains` option ensures that only tags containing the specified substring are considered.

**``deprecation-notice``** : we would like to deprecate `tag-filter` in favor of `tag-filter-prefix`  , once all the configurations are moved over , we will remove supporting `tag-filter`


