### PR TITLE
improve .PKGINFO diff

### DIFF
--- a/pkg/checks/diff.go
+++ b/pkg/checks/diff.go
@@ -234,7 +234,7 @@ func writeDiffLog(diff diffResult, filename string, newPackages map[string]NewAp
 
 		if len(diff.pkginfos) == 2 {
 			cmpdiff := cmp.Diff(diff.pkginfos[0], diff.pkginfos[1])
-			fmt.Fprintf(&builder, "\n.PKGINFO:\n%s\n", cmpdiff)
+			fmt.Fprintf(&builder, "\n`.PKGINFO` metadata:\n```%s```\n", cmpdiff)
 		}
 
 		changes := []string{}

--- a/pkg/checks/diff.go
+++ b/pkg/checks/diff.go
@@ -234,7 +234,7 @@ func writeDiffLog(diff diffResult, filename string, newPackages map[string]NewAp
 
 		if len(diff.pkginfos) == 2 {
 			cmpdiff := cmp.Diff(diff.pkginfos[0], diff.pkginfos[1])
-			fmt.Fprintf(&builder, "\n`.PKGINFO` metadata:\n```%s```\n", cmpdiff)
+			fmt.Fprintf(&builder, "\n`.PKGINFO` metadata:\n```\n%s\n```\n", cmpdiff)
 		}
 
 		changes := []string{}


### PR DESCRIPTION
- use a code block to avoid markdown trying to parse `-`s as bullets
- mention that `.PKGINFO` is metadata, not file contents