### PR TITLE
feat(adv): validate diff in data from base state 

### DIFF
--- a/pkg/advisory/diff_test.go
+++ b/pkg/advisory/diff_test.go
@@ -129,7 +129,7 @@ func TestIndexDiff(t *testing.T) {
 									Events: []v2.Event{
 										{
 											Timestamp: unixEpochTimestamp,
-											Type:      v2.EventTypeFalsePositiveDetermination,
+											Type:      v2.EventTypeTruePositiveDetermination,
 										},
 									},
 								},
@@ -141,7 +141,7 @@ func TestIndexDiff(t *testing.T) {
 									Events: []v2.Event{
 										{
 											Timestamp: unixEpochTimestamp,
-											Type:      v2.EventTypeFalsePositiveDetermination,
+											Type:      v2.EventTypeTruePositiveDetermination,
 										},
 									},
 								},
@@ -169,7 +169,7 @@ func TestIndexDiff(t *testing.T) {
 										},
 										{
 											Timestamp: unixEpochTimestampPlus1Day,
-											Type:      v2.EventTypeFalsePositiveDetermination,
+											Type:      v2.EventTypeTruePositiveDetermination,
 										},
 									},
 								},
@@ -185,7 +185,7 @@ func TestIndexDiff(t *testing.T) {
 								AddedEvents: []v2.Event{
 									{
 										Timestamp: unixEpochTimestampPlus1Day,
-										Type:      v2.EventTypeFalsePositiveDetermination,
+										Type:      v2.EventTypeTruePositiveDetermination,
 									},
 								},
 							},

--- a/pkg/advisory/testdata/diff/added-event/b/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/added-event/b/ko.advisories.yaml
@@ -9,4 +9,4 @@ advisories:
       - timestamp: 1970-01-01T00:00:00Z
         type: true-positive-determination
       - timestamp: 1970-01-02T00:00:00Z
-        type: false-positive-determination
+        type: true-positive-determination

--- a/pkg/advisory/testdata/diff/modified-advisory-outside-of-events/a/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/modified-advisory-outside-of-events/a/ko.advisories.yaml
@@ -9,4 +9,4 @@ advisories:
       - GHSA-2222-2222-2222
     events:
       - timestamp: 1970-01-01T00:00:00Z
-        type: false-positive-determination
+        type: true-positive-determination

--- a/pkg/advisory/testdata/diff/modified-advisory-outside-of-events/b/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/modified-advisory-outside-of-events/b/ko.advisories.yaml
@@ -7,4 +7,4 @@ advisories:
   - id: CVE-2023-24535
     events:
       - timestamp: 1970-01-01T00:00:00Z
-        type: false-positive-determination
+        type: true-positive-determination

--- a/pkg/advisory/validate.go
+++ b/pkg/advisory/validate.go
@@ -2,21 +2,82 @@ package advisory
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/samber/lo"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	"github.com/wolfi-dev/wolfictl/pkg/internal/errorhelpers"
 )
 
 type ValidateOptions struct {
-	// AdvisoryCfgs is the Index of advisories on which to operate.
-	AdvisoryCfgs *configs.Index[v2.Document]
+	// AdvisoryDocs is the Index of advisories on which to operate.
+	AdvisoryDocs *configs.Index[v2.Document]
+
+	// BaseAdvisoryDocs is the Index of advisories used as a comparison basis to
+	// understand what is changing in AdvisoryDocs. If nil, no comparison-based
+	// validation will be performed.
+	BaseAdvisoryDocs *configs.Index[v2.Document]
 }
 
 func Validate(opts ValidateOptions) error {
-	documents := opts.AdvisoryCfgs.Select().Configurations()
+	var errs []error
 
-	return errors.Join(lo.Map(documents, func(doc v2.Document, _ int) error {
-		return doc.Validate()
-	})...)
+	documentErrs := lo.Map(
+		opts.AdvisoryDocs.Select().Configurations(),
+		func(doc v2.Document, _ int) error {
+			return doc.Validate()
+		},
+	)
+	errs = append(errs, errorhelpers.LabelError("basic validation failure(s)", errors.Join(documentErrs...)))
+
+	if opts.BaseAdvisoryDocs != nil {
+		diff := IndexDiff(opts.BaseAdvisoryDocs, opts.AdvisoryDocs)
+		errs = append(errs, validateIndexDiff(diff))
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateIndexDiff(diff IndexDiffResult) error {
+	var errs []error
+
+	docRemovedErrs := lo.Map(diff.Removed, func(doc v2.Document, _ int) error {
+		return errorhelpers.LabelError(doc.Name(), errors.New("document was removed"))
+	})
+	errs = append(errs, docRemovedErrs...)
+
+	for _, documentAdvisories := range diff.Modified {
+		var docErrs []error
+
+		advsRemovedErrs := lo.Map(documentAdvisories.Removed, func(adv v2.Advisory, _ int) error {
+			return errorhelpers.LabelError(adv.ID, errors.New("advisory was removed"))
+		})
+		docErrs = append(docErrs, advsRemovedErrs...)
+
+		for i := range documentAdvisories.Modified {
+			adv := documentAdvisories.Modified[i]
+
+			var advErrs []error
+			if len(adv.RemovedEvents) > 0 {
+				if len(adv.AddedEvents) > 0 {
+					// If both removed and added events are non-zero, then it's not easy to
+					// differentiate whether events were modified, or removed and added.
+					advErrs = append(advErrs, fmt.Errorf("one or more events were modified or removed"))
+				} else {
+					advErrs = append(advErrs, errors.New("one or more events were removed"))
+				}
+			}
+			docErrs = append(
+				docErrs,
+				errorhelpers.LabelError(
+					adv.ID,
+					errors.Join(advErrs...),
+				),
+			)
+		}
+		errs = append(errs, errorhelpers.LabelError(documentAdvisories.Name, errors.Join(docErrs...)))
+	}
+
+	return errorhelpers.LabelError("invalid change(s) in diff", errors.Join(errs...))
 }

--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -1,0 +1,74 @@
+package advisory
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+)
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name          string
+		shouldBeValid bool
+	}{
+		{
+			name:          "same",
+			shouldBeValid: true,
+		},
+		{
+			name:          "added-document",
+			shouldBeValid: true,
+		},
+		{
+			name:          "removed-document",
+			shouldBeValid: false,
+		},
+		{
+			name:          "added-advisory",
+			shouldBeValid: true,
+		},
+		{
+			name:          "removed-advisory",
+			shouldBeValid: false,
+		},
+		{
+			name:          "added-event",
+			shouldBeValid: true,
+		},
+		{
+			name:          "removed-event",
+			shouldBeValid: false,
+		},
+		{
+			name:          "modified-advisory-outside-of-events",
+			shouldBeValid: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			aDir := filepath.Join("testdata", "diff", tt.name, "a")
+			bDir := filepath.Join("testdata", "diff", tt.name, "b")
+			aFsys := rwos.DirFS(aDir)
+			bFsys := rwos.DirFS(bDir)
+			aIndex, err := v2.NewIndex(aFsys)
+			require.NoError(t, err)
+			bIndex, err := v2.NewIndex(bFsys)
+			require.NoError(t, err)
+
+			err = Validate(ValidateOptions{
+				AdvisoryDocs:     bIndex,
+				BaseAdvisoryDocs: aIndex,
+			})
+			if tt.shouldBeValid && err != nil {
+				t.Errorf("should be valid but got error: %v", err)
+			}
+			if !tt.shouldBeValid && err == nil {
+				t.Error("shouldn't be valid but got no error")
+			}
+		})
+	}
+}

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -138,28 +138,37 @@ func (p *advisoryRequestParams) advisoryRequest() (advisory.Request, error) {
 	return req, nil
 }
 
+const (
+	flagNamePackage           = "package"
+	flagNameVuln              = "vuln"
+	flagNameDistroRepoDir     = "distro-repo-dir"
+	flagNameAdvisoriesRepoDir = "advisories-repo-dir"
+	flagNameNoPrompt          = "no-prompt"
+	flagNameNoDistroDetection = "no-distro-detection"
+)
+
 func addPackageFlag(val *string, cmd *cobra.Command) {
-	cmd.Flags().StringVarP(val, "package", "p", "", "package name")
+	cmd.Flags().StringVarP(val, flagNamePackage, "p", "", "package name")
 }
 
 func addVulnFlag(val *string, cmd *cobra.Command) {
-	cmd.Flags().StringVarP(val, "vuln", "V", "", "vulnerability ID for advisory")
+	cmd.Flags().StringVarP(val, flagNameVuln, "V", "", "vulnerability ID for advisory")
 }
 
 func addDistroDirFlag(val *string, cmd *cobra.Command) {
-	cmd.Flags().StringVarP(val, "distro-repo-dir", "d", "", "directory containing the distro repository")
+	cmd.Flags().StringVarP(val, flagNameDistroRepoDir, "d", "", "directory containing the distro repository")
 }
 
 func addAdvisoriesDirFlag(val *string, cmd *cobra.Command) {
-	cmd.Flags().StringVarP(val, "advisories-repo-dir", "a", "", "directory containing the advisories repository")
+	cmd.Flags().StringVarP(val, flagNameAdvisoriesRepoDir, "a", "", "directory containing the advisories repository")
 }
 
 func addNoPromptFlag(val *bool, cmd *cobra.Command) {
-	cmd.Flags().BoolVar(val, "no-prompt", false, "do not prompt the user for input")
+	cmd.Flags().BoolVar(val, flagNameNoPrompt, false, "do not prompt the user for input")
 }
 
 func addNoDistroDetectionFlag(val *bool, cmd *cobra.Command) {
-	cmd.Flags().BoolVar(val, "no-distro-detection", false, "do not attempt to auto-detect the distro")
+	cmd.Flags().BoolVar(val, flagNameNoDistroDetection, false, "do not attempt to auto-detect the distro")
 }
 
 func newAllowedFixedVersionsFunc(apkindexes []*apk.APKIndex, buildCfgs *configs.Index[config.Configuration]) func(packageName string) []string {

--- a/pkg/cli/advisory_alias_discover.go
+++ b/pkg/cli/advisory_alias_discover.go
@@ -59,7 +59,7 @@ than attempting any kind of merge of the separate advisories.
 					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
 				}
 
-				advisoriesRepoDir = d.Local.AdvisoriesRepoDir
+				advisoriesRepoDir = d.Local.AdvisoriesRepo.Dir
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 

--- a/pkg/cli/advisory_create.go
+++ b/pkg/cli/advisory_create.go
@@ -69,8 +69,8 @@ newly created advisory and any other advisories for the same package.`,
 					packageRepositoryURL = d.Absolute.APKRepositoryURL
 				}
 
-				distroRepoDir = d.Local.DistroRepoDir
-				advisoriesRepoDir = d.Local.AdvisoriesRepoDir
+				distroRepoDir = d.Local.PackagesRepo.Dir
+				advisoriesRepoDir = d.Local.AdvisoriesRepo.Dir
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 

--- a/pkg/cli/advisory_discover.go
+++ b/pkg/cli/advisory_discover.go
@@ -47,8 +47,8 @@ func cmdAdvisoryDiscover() *cobra.Command {
 					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified, and distro auto-detection failed: %w", err)
 				}
 
-				distroRepoDir = d.Local.DistroRepoDir
-				advisoriesRepoDir = d.Local.AdvisoriesRepoDir
+				distroRepoDir = d.Local.PackagesRepo.Dir
+				advisoriesRepoDir = d.Local.AdvisoriesRepo.Dir
 
 				if packageRepositoryURL == "" {
 					packageRepositoryURL = d.Absolute.APKRepositoryURL

--- a/pkg/cli/advisory_export.go
+++ b/pkg/cli/advisory_export.go
@@ -33,7 +33,7 @@ func cmdAdvisoryExport() *cobra.Command {
 					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
 				}
 
-				p.advisoriesRepoDirs = append(p.advisoriesRepoDirs, d.Local.AdvisoriesRepoDir)
+				p.advisoriesRepoDirs = append(p.advisoriesRepoDirs, d.Local.AdvisoriesRepo.Dir)
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 

--- a/pkg/cli/advisory_list.go
+++ b/pkg/cli/advisory_list.go
@@ -59,7 +59,7 @@ investigation over time for a given package/vulnerability match.'
 					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
 				}
 
-				advisoriesRepoDir = d.Local.AdvisoriesRepoDir
+				advisoriesRepoDir = d.Local.AdvisoriesRepo.Dir
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 

--- a/pkg/cli/advisory_secdb.go
+++ b/pkg/cli/advisory_secdb.go
@@ -31,7 +31,7 @@ func cmdAdvisorySecDB() *cobra.Command {
 					return fmt.Errorf("no advisories repo dir specified, and distro auto-detection failed: %w", err)
 				}
 
-				p.advisoriesRepoDirs = append(p.advisoriesRepoDirs, d.Local.AdvisoriesRepoDir)
+				p.advisoriesRepoDirs = append(p.advisoriesRepoDirs, d.Local.AdvisoriesRepo.Dir)
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 

--- a/pkg/cli/advisory_update.go
+++ b/pkg/cli/advisory_update.go
@@ -65,8 +65,8 @@ required fields are missing.`,
 					packageRepositoryURL = d.Absolute.APKRepositoryURL
 				}
 
-				distroRepoDir = d.Local.DistroRepoDir
-				advisoriesRepoDir = d.Local.AdvisoriesRepoDir
+				distroRepoDir = d.Local.PackagesRepo.Dir
+				advisoriesRepoDir = d.Local.AdvisoriesRepo.Dir
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 

--- a/pkg/cli/ls.go
+++ b/pkg/cli/ls.go
@@ -32,7 +32,7 @@ func cmdLs() *cobra.Command {
 					return fmt.Errorf("no distro repo dir specified, and distro auto-detection failed: %w", err)
 				}
 
-				p.distroRepoDirs = append(p.distroRepoDirs, d.Local.DistroRepoDir)
+				p.distroRepoDirs = append(p.distroRepoDirs, d.Local.PackagesRepo.Dir)
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 

--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/samber/lo"
+	"github.com/wolfi-dev/wolfictl/pkg/internal/errorhelpers"
 	"github.com/wolfi-dev/wolfictl/pkg/versions"
 	"github.com/wolfi-dev/wolfictl/pkg/vuln"
 )
@@ -112,7 +113,7 @@ func (adv Advisory) ResolvedAtVersion(version string) bool {
 
 // Validate returns an error if the advisory is invalid.
 func (adv Advisory) Validate() error {
-	return labelError(adv.ID,
+	return errorhelpers.LabelError(adv.ID,
 		errors.Join(
 			vuln.ValidateID(adv.ID),
 			adv.validateAliases(),
@@ -135,7 +136,7 @@ func (adv Advisory) validateAliases() error {
 		)
 	}
 
-	return labelError("aliases", errors.Join(errs...))
+	return errorhelpers.LabelError("aliases", errors.Join(errs...))
 }
 
 func (adv Advisory) validateEvents() error {
@@ -143,12 +144,12 @@ func (adv Advisory) validateEvents() error {
 		return fmt.Errorf("there must be at least one event")
 	}
 
-	return labelError("events",
+	return errorhelpers.LabelError("events",
 		errors.Join(lo.Map(adv.Events, func(event Event, i int) error {
 			err := event.Validate()
 			if err != nil {
 				// show the event index as 1-based, not 0-based, just for ease of understanding
-				return labelError(fmt.Sprintf("event %d", i+1), err)
+				return errorhelpers.LabelError(fmt.Sprintf("event %d", i+1), err)
 			}
 			return nil
 		})...),
@@ -161,7 +162,7 @@ func validateAliasFormat(alias string) error {
 		vuln.RegexGO.MatchString(alias):
 		return nil
 	default:
-		return fmt.Errorf("alias %q is not a valid GHSA ID or Go vuln ID", alias)
+		return fmt.Errorf("%q is not a valid GHSA ID or Go vuln ID", alias)
 	}
 }
 

--- a/pkg/configs/advisory/v2/detection.go
+++ b/pkg/configs/advisory/v2/detection.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/wolfi-dev/wolfictl/pkg/internal/errorhelpers"
 	"github.com/wolfi-dev/wolfictl/pkg/vuln"
 	"gopkg.in/yaml.v3"
 )
@@ -116,10 +117,10 @@ type DetectionNVDAPI struct {
 
 // Validate returns an error if the DetectionNVDAPI data is invalid.
 func (d DetectionNVDAPI) Validate() error {
-	return labelError("nvdapi detection data",
+	return errorhelpers.LabelError("nvdapi detection data",
 		errors.Join(
-			labelError("cpeSearched", vuln.ValidateCPE(d.CPESearched)),
-			labelError("cpeFound", vuln.ValidateCPE(d.CPEFound)),
+			errorhelpers.LabelError("cpeSearched", vuln.ValidateCPE(d.CPESearched)),
+			errorhelpers.LabelError("cpeFound", vuln.ValidateCPE(d.CPEFound)),
 		),
 	)
 }

--- a/pkg/configs/advisory/v2/document.go
+++ b/pkg/configs/advisory/v2/document.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/samber/lo"
+	"github.com/wolfi-dev/wolfictl/pkg/internal/errorhelpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -27,7 +28,7 @@ func (doc Document) Name() string {
 }
 
 func (doc Document) Validate() error {
-	return labelError(doc.Name(),
+	return errorhelpers.LabelError(doc.Name(),
 		errors.Join(
 			doc.ValidateSchemaVersion(),
 			doc.Package.Validate(),
@@ -96,7 +97,7 @@ func (advs Advisories) Validate() error {
 		return fmt.Errorf("this file should not exist if there are no advisories recorded")
 	}
 
-	return labelError("advisories",
+	return errorhelpers.LabelError("advisories",
 		errors.Join(lo.Map(advs, func(adv Advisory, _ int) error {
 			return adv.Validate()
 		})...),

--- a/pkg/distro/detect.go
+++ b/pkg/distro/detect.go
@@ -6,52 +6,99 @@ import (
 	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	wgit "github.com/wolfi-dev/wolfictl/pkg/git"
 	"golang.org/x/exp/slices"
 )
 
-// Detect tries to automatically detect which distro the user wants to
-// operate on, and the corresponding directory paths for the distro and
-// advisories repos.
+// Detect tries to automatically detect which distro the user wants to operate
+// on by trying to match the current working directory with a known repository
+// for a distro's packages or advisories.
 func Detect() (Distro, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return Distro{}, err
 	}
 
-	distro, err := identifyDistroFromLocalRepoDir(cwd)
+	d, err := DetectFromDir(cwd)
+	if err != nil {
+		return Distro{}, err
+	}
+
+	return d, nil
+}
+
+// DetectFromDir tries to identify a Distro by inspecting the given directory to
+// see if it is a repository for a distro's packages or advisories.
+func DetectFromDir(dir string) (Distro, error) {
+	distro, err := identifyDistroFromLocalRepoDir(dir)
 	if err != nil {
 		return Distro{}, err
 	}
 
 	// We assume that the parent directory of the initially found repo directory is
 	// a directory that contains all the relevant repo directories.
-	dirOfRepos := filepath.Dir(cwd)
+	dirOfRepos := filepath.Dir(dir)
 
 	// We either have a distro (packages) repo or an advisories repo, but not both.
 	// Now we need to find the other one.
 
 	switch {
-	case distro.Local.DistroRepoDir == "":
+	case distro.Local.PackagesRepo.Dir == "":
 		distroDir, err := findDistroDir(distro.Absolute, dirOfRepos)
 		if err != nil {
-			return Distro{}, err
+			return Distro{}, fmt.Errorf("unable to find distro (packages) dir: %w", err)
 		}
-		distro.Local.DistroRepoDir = distroDir
-		return distro, nil
-
-	case distro.Local.AdvisoriesRepoDir == "":
-		advisoryDir, err := findAdvisoriesDir(distro.Absolute, dirOfRepos)
+		distro.Local.PackagesRepo.Dir = distroDir
+		d, err := identifyDistroFromLocalRepoDir(distroDir)
 		if err != nil {
 			return Distro{}, err
 		}
-		distro.Local.AdvisoriesRepoDir = advisoryDir
+		distro.Local.PackagesRepo.UpstreamName = d.Local.PackagesRepo.UpstreamName
+		forkPoint, err := findRepoForkPoint(distroDir, d.Local.PackagesRepo.UpstreamName)
+		if err != nil {
+			return Distro{}, err
+		}
+		distro.Local.PackagesRepo.ForkPoint = forkPoint
+
+		// We also still need to get the advisories repo fork point.
+		fp, err := findRepoForkPoint(distro.Local.AdvisoriesRepo.Dir, distro.Local.AdvisoriesRepo.UpstreamName)
+		if err != nil {
+			return Distro{}, err
+		}
+		distro.Local.AdvisoriesRepo.ForkPoint = fp
+		return distro, nil
+
+	case distro.Local.AdvisoriesRepo.Dir == "":
+		advisoryDir, err := findAdvisoriesDir(distro.Absolute, dirOfRepos)
+		if err != nil {
+			return Distro{}, fmt.Errorf("unable to find advisories dir: %w", err)
+		}
+		distro.Local.AdvisoriesRepo.Dir = advisoryDir
+		d, err := identifyDistroFromLocalRepoDir(advisoryDir)
+		if err != nil {
+			return Distro{}, err
+		}
+		distro.Local.AdvisoriesRepo.UpstreamName = d.Local.AdvisoriesRepo.UpstreamName
+		forkPoint, err := findRepoForkPoint(advisoryDir, d.Local.AdvisoriesRepo.UpstreamName)
+		if err != nil {
+			return Distro{}, err
+		}
+		distro.Local.AdvisoriesRepo.ForkPoint = forkPoint
+
+		// We also still need to get the distro (packages) repo fork point.
+		fp, err := findRepoForkPoint(distro.Local.PackagesRepo.Dir, distro.Local.PackagesRepo.UpstreamName)
+		if err != nil {
+			return Distro{}, err
+		}
+		distro.Local.PackagesRepo.ForkPoint = fp
 		return distro, nil
 	}
 
 	return Distro{}, fmt.Errorf("unable to detect distro")
 }
 
-var errNotDistroRepo = fmt.Errorf("current directory is not a distro (packages) or advisories repository")
+var errNotDistroRepo = fmt.Errorf("directory is not a distro (packages) or advisories repository")
 
 func identifyDistroFromLocalRepoDir(dir string) (Distro, error) {
 	repo, err := git.PlainOpen(dir)
@@ -73,12 +120,18 @@ func identifyDistroFromLocalRepoDir(dir string) (Distro, error) {
 		url := urls[0]
 
 		for _, d := range []AbsoluteProperties{wolfiDistro, chainguardDistro} {
+			// Fill in the local properties that we can cheaply here. We'll fill in the rest
+			// later, outside of this function call.
+
 			if slices.Contains(d.DistroRemoteURLs, url) {
 				return Distro{
 					Absolute: d,
 					Local: LocalProperties{
-						DistroRepoDir:     dir,
-						AdvisoriesRepoDir: "", // This gets filled in later outside of this function.
+						PackagesRepo: LocalRepo{
+							Dir:          dir,
+							UpstreamName: remoteConfig.Name,
+							ForkPoint:    "", // This is slightly expensive to compute, so we do it later and only once per repo.
+						},
 					},
 				}, nil
 			}
@@ -87,8 +140,11 @@ func identifyDistroFromLocalRepoDir(dir string) (Distro, error) {
 				return Distro{
 					Absolute: d,
 					Local: LocalProperties{
-						DistroRepoDir:     "", // This gets filled in later outside of this function.
-						AdvisoriesRepoDir: dir,
+						AdvisoriesRepo: LocalRepo{
+							Dir:          dir,
+							UpstreamName: remoteConfig.Name,
+							ForkPoint:    "", // This is slightly expensive to compute, so we do it later and only once per repo.
+						},
 					},
 				}, nil
 			}
@@ -98,12 +154,38 @@ func identifyDistroFromLocalRepoDir(dir string) (Distro, error) {
 	return Distro{}, errNotDistroRepo
 }
 
+func findRepoForkPoint(repoDir, remoteName string) (string, error) {
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		return "", fmt.Errorf("unable to find fork point for remote %q: %w", remoteName, err)
+	}
+
+	remote, err := repo.Remote(remoteName)
+	if err != nil {
+		return "", fmt.Errorf("unable to find fork point for remote %q: %w", remoteName, err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("unable to find fork point for remote %q: %w", remoteName, err)
+	}
+
+	upstreamRefName := remote.Config().Name + "/main"
+	upstreamRef := plumbing.NewReferenceFromStrings(upstreamRefName, "")
+	forkPoint, err := wgit.FindForkPoint(repo, head, upstreamRef)
+	if err != nil {
+		return "", fmt.Errorf("unable to find fork point for remote %q: %w", remoteName, err)
+	}
+
+	return forkPoint.String(), nil
+}
+
 // findDistroDir returns the local filesystem path to the directory for the
 // distro (packages) repo for the given targetDistro, by examining the child
 // directories within dirOfRepos.
 func findDistroDir(targetDistro AbsoluteProperties, dirOfRepos string) (string, error) {
 	return findRepoDir(targetDistro, dirOfRepos, func(d Distro) string {
-		return d.Local.DistroRepoDir
+		return d.Local.PackagesRepo.Dir
 	})
 }
 
@@ -112,7 +194,7 @@ func findDistroDir(targetDistro AbsoluteProperties, dirOfRepos string) (string, 
 // directories within dirOfRepos.
 func findAdvisoriesDir(targetDistro AbsoluteProperties, dirOfRepos string) (string, error) {
 	return findRepoDir(targetDistro, dirOfRepos, func(d Distro) string {
-		return d.Local.AdvisoriesRepoDir
+		return d.Local.AdvisoriesRepo.Dir
 	})
 }
 

--- a/pkg/distro/detect_test.go
+++ b/pkg/distro/detect_test.go
@@ -4,9 +4,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,6 +74,11 @@ func TestDetect(t *testing.T) {
 		require.NoError(t, err)
 		_, err = w.Commit("Initial commit", &git.CommitOptions{
 			AllowEmptyCommits: true,
+			Author: &object.Signature{
+				Name:  "test",
+				Email: "test@test.com",
+				When:  time.Unix(0, 0),
+			},
 		})
 		require.NoError(t, err)
 	}

--- a/pkg/distro/detect_test.go
+++ b/pkg/distro/detect_test.go
@@ -66,6 +66,14 @@ func TestDetect(t *testing.T) {
 			URLs: r.remoteURLs,
 		})
 		require.NoError(t, err)
+
+		// We need to create a commit so that HEAD exists.
+		w, err := repo.Worktree()
+		require.NoError(t, err)
+		_, err = w.Commit("Initial commit", &git.CommitOptions{
+			AllowEmptyCommits: true,
+		})
+		require.NoError(t, err)
 	}
 
 	originalWorkDir, err := os.Getwd()
@@ -92,7 +100,7 @@ func TestDetect(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "Wolfi", d.Absolute.Name)
-	assert.Equal(t, expectedDistroRepoDir, d.Local.DistroRepoDir)
-	assert.Equal(t, expectedAdvisoriesRepoDir, d.Local.AdvisoriesRepoDir)
+	assert.Equal(t, expectedDistroRepoDir, d.Local.PackagesRepo.Dir)
+	assert.Equal(t, expectedAdvisoriesRepoDir, d.Local.AdvisoriesRepo.Dir)
 	assert.Equal(t, "https://packages.wolfi.dev/os", d.Absolute.APKRepositoryURL)
 }

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -10,13 +10,28 @@ type Distro struct {
 // LocalProperties describe the aspects of the distro that are specific to the
 // context of the user's local environment.
 type LocalProperties struct {
-	// DistroRepoDir is the path to the directory containing the user's clone of the
-	// distro repo, i.e. the repo containing the distro's build configurations.
-	DistroRepoDir string
+	// PackagesRepo is the context about the user's local clone of the distro's
+	// packages repo.
+	PackagesRepo LocalRepo
 
-	// AdvisoriesRepoDir is the path to the directory containing the user's clone of
-	// the advisories repo, i.e. the repo containing the distro's advisory data.
-	AdvisoriesRepoDir string
+	// AdvisoriesRepo is the context about the user's local clone of the distro's
+	// advisories repo.
+	AdvisoriesRepo LocalRepo
+}
+
+// LocalRepo stores the context about a local git repository that is needed for
+// interacting with this distro.
+type LocalRepo struct {
+	// Dir is the path to the directory containing the user's clone of the repo.
+	Dir string
+
+	// UpstreamName is the name of the locally configured git remote that the
+	// user's clone of the repo uses to reference the upstream repo.
+	UpstreamName string
+
+	// ForkPoint is the commit hash of the latest commit had in common between the
+	// local repo and the upstream repo main branch.
+	ForkPoint string
 }
 
 // AbsoluteProperties describe the aspects of the distro that are constant and

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/pkg/errors"
 
 	"github.com/go-git/go-git/v5"
@@ -150,4 +153,111 @@ func SetGitSignOptions(repoPath string) error {
 	}
 
 	return nil
+}
+
+// TempClone clones the repo using the provided HTTPS URL to a temp directory,
+// and returns the path to the temp directory.
+//
+// If hash is non-empty, the repo will be checked out to that commit hash.
+//
+// If user authentication is requested, a personal access token will be read in
+// from the GITHUB_TOKEN environment variable.
+//
+// The caller is responsible for cleaning up the temp directory.
+func TempClone(gitURL, hash string, useAuth bool) (repoDir string, err error) {
+	dir, err := os.MkdirTemp("", "wolfictl-git-clone-*")
+	if err != nil {
+		return dir, fmt.Errorf("unable to create temp directory for git clone: %w", err)
+	}
+
+	var auth transport.AuthMethod
+	if useAuth {
+		auth = GetGitAuth()
+	}
+
+	repo, err := git.PlainClone(dir, false, &git.CloneOptions{
+		Auth: auth,
+		URL:  gitURL,
+	})
+	if err != nil {
+		return dir, fmt.Errorf("unable to clone repo %q to temp directory: %w", gitURL, err)
+	}
+
+	if hash != "" {
+		w, err := repo.Worktree()
+		if err != nil {
+			return "", fmt.Errorf("unable to get worktree for repo %q: %w", gitURL, err)
+		}
+		err = w.Checkout(&git.CheckoutOptions{
+			Hash: plumbing.NewHash(hash),
+		})
+		if err != nil {
+			return "", fmt.Errorf("unable to checkout hash %q for repo %q: %w", hash, gitURL, err)
+		}
+	}
+
+	return dir, nil
+}
+
+// FindForkPoint finds the fork point between the local branch and the upstream
+// branch.
+//
+// The fork point is the commit hash of the latest commit had in common between
+// the local branch and the upstream branch.
+//
+// The local branch is the branch pointed to by the provided branchRef.
+//
+// The upstream branch is the branch pointed to by the provided upstreamRef.
+//
+// The caller is responsible for closing the provided repo.
+func FindForkPoint(repo *git.Repository, branchRef, upstreamRef *plumbing.Reference) (*plumbing.Hash, error) {
+	// Get the commit object for the local branch
+	localCommit, err := repo.CommitObject(branchRef.Hash())
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the commit iterator for the upstream branch
+	upstreamIter, err := repo.Log(&git.LogOptions{From: upstreamRef.Hash()})
+	if err != nil {
+		return nil, err
+	}
+	defer upstreamIter.Close()
+
+	// Collect all upstream commit hashes for comparison
+	upstreamCommits := make(map[plumbing.Hash]bool)
+	err = upstreamIter.ForEach(func(c *object.Commit) error {
+		upstreamCommits[c.Hash] = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Now walk through the local branch commits to find where it diverged
+	localIter, err := repo.Log(&git.LogOptions{From: localCommit.Hash})
+	if err != nil {
+		return nil, err
+	}
+	defer localIter.Close()
+
+	var forkPoint *plumbing.Hash
+	err = localIter.ForEach(func(c *object.Commit) error {
+		if _, exists := upstreamCommits[c.Hash]; exists {
+			// This commit exists in both histories, so it's a common ancestor and potential fork point
+			forkPoint = &c.Hash
+			// We stop iterating as we found the most recent common commit
+			return storer.ErrStop
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if forkPoint == nil {
+		return nil, fmt.Errorf("fork point not found")
+	}
+
+	return forkPoint, nil
 }

--- a/pkg/internal/errorhelpers/labeled_error.go
+++ b/pkg/internal/errorhelpers/labeled_error.go
@@ -1,34 +1,34 @@
-package v2
+package errorhelpers
 
 import (
 	"fmt"
 )
 
-type labeledError struct {
+type LabeledError struct {
 	label string
 	err   error
 }
 
 // Error returns the error as a message string (to implement the error
 // interface).
-func (l labeledError) Error() string {
+func (l LabeledError) Error() string {
 	return fmt.Sprintf("%s: %s", l.label, l.err.Error())
 }
 
 // Label returns the label for the error.
-func (l labeledError) Label() string {
+func (l LabeledError) Label() string {
 	return l.label
 }
 
 // Unwrap returns the underlying error.
-func (l labeledError) Unwrap() error {
+func (l LabeledError) Unwrap() error {
 	return l.err
 }
 
-func labelError(label string, err error) error {
+func LabelError(label string, err error) error {
 	if err == nil {
 		return nil
 	}
 
-	return &labeledError{label, err}
+	return &LabeledError{label, err}
 }


### PR DESCRIPTION
This PR enhances the `wolfictl adv validate` command by validating the "diff" of advisory data relative to a known base state. This PR takes advantage of and extends the advisory diffing functionality introduced in #478.