### PR TITLE
fix: distro detect: better upstream ref resolution

### DIFF
--- a/pkg/distro/detect.go
+++ b/pkg/distro/detect.go
@@ -170,8 +170,11 @@ func findRepoForkPoint(repoDir, remoteName string) (string, error) {
 		return "", fmt.Errorf("unable to find fork point for remote %q: %w", remoteName, err)
 	}
 
-	upstreamRefName := remote.Config().Name + "/main"
-	upstreamRef := plumbing.NewReferenceFromStrings(upstreamRefName, "")
+	upstreamRefName := fmt.Sprintf("refs/remotes/%s/main", remote.Config().Name)
+	upstreamRef, err := repo.Reference(plumbing.ReferenceName(upstreamRefName), true)
+	if err != nil {
+		return "", fmt.Errorf("unable to get upstream ref %q: %w", upstreamRefName, err)
+	}
 	forkPoint, err := wgit.FindForkPoint(repo, head, upstreamRef)
 	if err != nil {
 		return "", fmt.Errorf("unable to find fork point for remote %q: %w", remoteName, err)


### PR DESCRIPTION
This fixes a case where resolving the git ref on the upstream repo wasn't working correctly, where the resulting ref hash was all zeros, and thus the fork point wasn't guaranteed to exist on the upstream commit history.