### PR TITLE
feat(adv): validate timestamp on new events

### DIFF
--- a/pkg/advisory/diff_test.go
+++ b/pkg/advisory/diff_test.go
@@ -39,7 +39,7 @@ func TestIndexDiff(t *testing.T) {
 								ID: "CVE-2023-24535",
 								Events: []v2.Event{
 									{
-										Timestamp: unixEpochTimestamp,
+										Timestamp: v2.Timestamp(now),
 										Type:      v2.EventTypeTruePositiveDetermination,
 									},
 								},
@@ -84,7 +84,7 @@ func TestIndexDiff(t *testing.T) {
 								ID: "CVE-2023-11111",
 								Events: []v2.Event{
 									{
-										Timestamp: unixEpochTimestamp,
+										Timestamp: v2.Timestamp(now),
 										Type:      v2.EventTypeTruePositiveDetermination,
 									},
 								},
@@ -168,7 +168,7 @@ func TestIndexDiff(t *testing.T) {
 											Type:      v2.EventTypeTruePositiveDetermination,
 										},
 										{
-											Timestamp: unixEpochTimestampPlus1Day,
+											Timestamp: v2.Timestamp(now),
 											Type:      v2.EventTypeTruePositiveDetermination,
 										},
 									},
@@ -184,7 +184,7 @@ func TestIndexDiff(t *testing.T) {
 								},
 								AddedEvents: []v2.Event{
 									{
-										Timestamp: unixEpochTimestampPlus1Day,
+										Timestamp: v2.Timestamp(now),
 										Type:      v2.EventTypeTruePositiveDetermination,
 									},
 								},

--- a/pkg/advisory/testdata/diff/added-advisory/b/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/added-advisory/b/ko.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
 
   - id: CVE-2023-11111
     events:
-      - timestamp: 1970-01-01T00:00:00Z
+      - timestamp: 2023-11-11T00:00:00Z
         type: true-positive-determination

--- a/pkg/advisory/testdata/diff/added-document/b/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/added-document/b/ko.advisories.yaml
@@ -6,5 +6,5 @@ package:
 advisories:
   - id: CVE-2023-24535
     events:
-      - timestamp: 1970-01-01T00:00:00Z
+      - timestamp: 2023-11-11T00:00:00Z
         type: true-positive-determination

--- a/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/a/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/a/ko.advisories.yaml
@@ -8,5 +8,3 @@ advisories:
     events:
       - timestamp: 1970-01-01T00:00:00Z
         type: true-positive-determination
-      - timestamp: 2023-11-11T00:00:00Z
-        type: true-positive-determination

--- a/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/b/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/b/ko.advisories.yaml
@@ -8,5 +8,5 @@ advisories:
     events:
       - timestamp: 1970-01-01T00:00:00Z
         type: true-positive-determination
-      - timestamp: 2023-11-11T00:00:00Z
+      - timestamp: 2023-11-02T00:00:00Z # Not recent enough!
         type: true-positive-determination

--- a/pkg/advisory/validate.go
+++ b/pkg/advisory/validate.go
@@ -3,6 +3,7 @@ package advisory
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
@@ -18,6 +19,9 @@ type ValidateOptions struct {
 	// understand what is changing in AdvisoryDocs. If nil, no comparison-based
 	// validation will be performed.
 	BaseAdvisoryDocs *configs.Index[v2.Document]
+
+	// Now is the time to use as the current time for recency validation.
+	Now time.Time
 }
 
 func Validate(opts ValidateOptions) error {
@@ -33,13 +37,13 @@ func Validate(opts ValidateOptions) error {
 
 	if opts.BaseAdvisoryDocs != nil {
 		diff := IndexDiff(opts.BaseAdvisoryDocs, opts.AdvisoryDocs)
-		errs = append(errs, validateIndexDiff(diff))
+		errs = append(errs, opts.validateIndexDiff(diff))
 	}
 
 	return errors.Join(errs...)
 }
 
-func validateIndexDiff(diff IndexDiffResult) error {
+func (opts ValidateOptions) validateIndexDiff(diff IndexDiffResult) error {
 	var errs []error
 
 	docRemovedErrs := lo.Map(diff.Removed, func(doc v2.Document, _ int) error {
@@ -68,6 +72,11 @@ func validateIndexDiff(diff IndexDiffResult) error {
 					advErrs = append(advErrs, errors.New("one or more events were removed"))
 				}
 			}
+
+			for i, event := range adv.AddedEvents {
+				advErrs = append(advErrs, errorhelpers.LabelError(fmt.Sprintf("event %d (just added)", i+1), opts.validateRecency(event)))
+			}
+
 			docErrs = append(
 				docErrs,
 				errorhelpers.LabelError(
@@ -76,8 +85,66 @@ func validateIndexDiff(diff IndexDiffResult) error {
 				),
 			)
 		}
+
+		for i := range documentAdvisories.Added {
+			adv := documentAdvisories.Added[i]
+
+			var advErrs []error
+			for i, event := range adv.Events {
+				advErrs = append(advErrs, errorhelpers.LabelError(fmt.Sprintf("event %d (just added)", i+1), opts.validateRecency(event)))
+			}
+			docErrs = append(
+				docErrs,
+				errorhelpers.LabelError(
+					adv.ID,
+					errors.Join(advErrs...),
+				),
+			)
+		}
+
 		errs = append(errs, errorhelpers.LabelError(documentAdvisories.Name, errors.Join(docErrs...)))
 	}
 
+	for i := range diff.Added {
+		doc := diff.Added[i]
+
+		var docErrs []error
+		for advIndex := range doc.Advisories {
+			adv := doc.Advisories[advIndex]
+
+			var advErrs []error
+			for i, event := range adv.Events {
+				advErrs = append(advErrs, errorhelpers.LabelError(fmt.Sprintf("event %d (just added)", i+1), opts.validateRecency(event)))
+			}
+			docErrs = append(
+				docErrs,
+				errorhelpers.LabelError(
+					adv.ID,
+					errors.Join(advErrs...),
+				),
+			)
+		}
+
+		errs = append(errs, errorhelpers.LabelError(doc.Name(), errors.Join(docErrs...)))
+	}
+
 	return errorhelpers.LabelError("invalid change(s) in diff", errors.Join(errs...))
+}
+
+const eventMaxValidAgeInDays = 3
+
+func (opts ValidateOptions) isRecent(t time.Time) bool {
+	const maxAge = eventMaxValidAgeInDays * 24 * time.Hour // 3 days
+	return opts.Now.Sub(t) < maxAge
+}
+
+func (opts ValidateOptions) validateRecency(event v2.Event) error {
+	if !opts.isRecent(time.Time(event.Timestamp)) {
+		return fmt.Errorf(
+			"event's timestamp (%s) set to more than %d days ago; timestamps should accurately capture event creation time",
+			event.Timestamp,
+			eventMaxValidAgeInDays,
+		)
+	}
+	return nil
 }

--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -3,6 +3,7 @@ package advisory
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
@@ -46,6 +47,10 @@ func TestValidate(t *testing.T) {
 			name:          "modified-advisory-outside-of-events",
 			shouldBeValid: true,
 		},
+		{
+			name:          "added-event-with-non-recent-timestamp",
+			shouldBeValid: false,
+		},
 	}
 
 	for _, tt := range cases {
@@ -62,6 +67,7 @@ func TestValidate(t *testing.T) {
 			err = Validate(ValidateOptions{
 				AdvisoryDocs:     bIndex,
 				BaseAdvisoryDocs: aIndex,
+				Now:              now,
 			})
 			if tt.shouldBeValid && err != nil {
 				t.Errorf("should be valid but got error: %v", err)
@@ -72,3 +78,6 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+
+// now establishes a fixed time for testing recency validation, for deterministic test runs.
+var now = time.Unix(1699660800, 0) // Nov 11 2023 00:00:00 UTC

--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -123,6 +124,7 @@ print an error message that specifies where and how the data is invalid.`,
 			opts := advisory.ValidateOptions{
 				AdvisoryDocs:     advisoriesIndex,
 				BaseAdvisoryDocs: baseAdvisoriesIndex,
+				Now:              time.Now(),
 			}
 
 			validationErr := advisory.Validate(opts)


### PR DESCRIPTION
This adds a component to advisory diff validation, where events that were just added must have a timestamp that's "recent".

"Recent" is currently defined as being no more than 3 days old, but that's up for discussion if anyone has an argument for adjusting this to be more loose or more strict.

Here's an example of what a validation failure looks like using this new feature:

```console
$ w adv validate
Auto-detected distro: Wolfi

❌ advisory data is not valid.

invalid change(s) in diff:
    syft:
        CVE-3333-33333:
            event 1 (just added):
                event's timestamp (2023-11-11T23:40:17Z) set to more than 3 days ago; timestamps should accurately capture event creation time
```