### PR TITLE
feat(adv): validate completeness of alias sets

### DIFF
--- a/pkg/advisory/diff_test.go
+++ b/pkg/advisory/diff_test.go
@@ -14,6 +14,9 @@ import (
 var (
 	unixEpochTimestamp         = v2.Timestamp(time.Unix(0, 0))
 	unixEpochTimestampPlus1Day = v2.Timestamp(time.Unix(0, 0).AddDate(0, 0, 1))
+
+	// now establishes a fixed time for testing recency validation, for deterministic test runs.
+	now = time.Unix(1699660800, 0) // Nov 11 2023 00:00:00 UTC
 )
 
 func TestIndexDiff(t *testing.T) {

--- a/pkg/advisory/testdata/validate/alias-missing-cve/ko.advisories.yaml
+++ b/pkg/advisory/testdata/validate/alias-missing-cve/ko.advisories.yaml
@@ -1,0 +1,10 @@
+schema-version: 2.0.1
+
+package:
+  name: ko
+
+advisories:
+  - id: GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination

--- a/pkg/advisory/testdata/validate/alias-missing-ghsa/ko.advisories.yaml
+++ b/pkg/advisory/testdata/validate/alias-missing-ghsa/ko.advisories.yaml
@@ -1,0 +1,10 @@
+schema-version: 2.0.1
+
+package:
+  name: ko
+
+advisories:
+  - id: CVE-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination

--- a/pkg/advisory/testdata/validate/alias-not-missing/ko.advisories.yaml
+++ b/pkg/advisory/testdata/validate/alias-not-missing/ko.advisories.yaml
@@ -1,0 +1,12 @@
+schema-version: 2.0.1
+
+package:
+  name: ko
+
+advisories:
+  - id: CVE-2222-2222
+    aliases:
+      - GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination

--- a/pkg/advisory/validate.go
+++ b/pkg/advisory/validate.go
@@ -23,6 +23,10 @@ type ValidateOptions struct {
 	// validation will be performed.
 	BaseAdvisoryDocs *configs.Index[v2.Document]
 
+	// SelectedPackages is the set of packages to operate on. If empty, all packages
+	// will be operated on.
+	SelectedPackages map[string]struct{}
+
 	// Now is the time to use as the current time for recency validation.
 	Now time.Time
 
@@ -37,6 +41,13 @@ func Validate(ctx context.Context, opts ValidateOptions) error {
 	documentErrs := lo.Map(
 		opts.AdvisoryDocs.Select().Configurations(),
 		func(doc v2.Document, _ int) error {
+			if len(opts.SelectedPackages) > 0 {
+				if _, ok := opts.SelectedPackages[doc.Name()]; !ok {
+					// Skip this document, since it's not in the set of selected packages.
+					return nil
+				}
+			}
+
 			return doc.Validate()
 		},
 	)
@@ -60,6 +71,14 @@ func (opts ValidateOptions) validateAliasSetCompleteness(ctx context.Context) er
 	documents := opts.AdvisoryDocs.Select().Configurations()
 	for i := range documents {
 		doc := documents[i]
+
+		if len(opts.SelectedPackages) > 0 {
+			if _, ok := opts.SelectedPackages[doc.Name()]; !ok {
+				// Skip this document, since it's not in the set of selected packages.
+				continue
+			}
+		}
+
 		var docErrs []error
 
 		for i := range doc.Advisories {
@@ -101,11 +120,25 @@ func (opts ValidateOptions) validateIndexDiff(diff IndexDiffResult) error {
 	var errs []error
 
 	docRemovedErrs := lo.Map(diff.Removed, func(doc v2.Document, _ int) error {
+		if len(opts.SelectedPackages) > 0 {
+			if _, ok := opts.SelectedPackages[doc.Name()]; !ok {
+				// Skip this document, since it's not in the set of selected packages.
+				return nil
+			}
+		}
+
 		return errorhelpers.LabelError(doc.Name(), errors.New("document was removed"))
 	})
 	errs = append(errs, docRemovedErrs...)
 
 	for _, documentAdvisories := range diff.Modified {
+		if len(opts.SelectedPackages) > 0 {
+			if _, ok := opts.SelectedPackages[documentAdvisories.Name]; !ok {
+				// Skip this document, since it's not in the set of selected packages.
+				continue
+			}
+		}
+
 		var docErrs []error
 
 		advsRemovedErrs := lo.Map(documentAdvisories.Removed, func(adv v2.Advisory, _ int) error {
@@ -161,6 +194,13 @@ func (opts ValidateOptions) validateIndexDiff(diff IndexDiffResult) error {
 
 	for i := range diff.Added {
 		doc := diff.Added[i]
+
+		if len(opts.SelectedPackages) > 0 {
+			if _, ok := opts.SelectedPackages[doc.Name()]; !ok {
+				// Skip this document, since it's not in the set of selected packages.
+				continue
+			}
+		}
 
 		var docErrs []error
 		for advIndex := range doc.Advisories {

--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -1,9 +1,9 @@
 package advisory
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
@@ -11,73 +11,121 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	cases := []struct {
-		name          string
-		shouldBeValid bool
-	}{
-		{
-			name:          "same",
-			shouldBeValid: true,
-		},
-		{
-			name:          "added-document",
-			shouldBeValid: true,
-		},
-		{
-			name:          "removed-document",
-			shouldBeValid: false,
-		},
-		{
-			name:          "added-advisory",
-			shouldBeValid: true,
-		},
-		{
-			name:          "removed-advisory",
-			shouldBeValid: false,
-		},
-		{
-			name:          "added-event",
-			shouldBeValid: true,
-		},
-		{
-			name:          "removed-event",
-			shouldBeValid: false,
-		},
-		{
-			name:          "modified-advisory-outside-of-events",
-			shouldBeValid: true,
-		},
-		{
-			name:          "added-event-with-non-recent-timestamp",
-			shouldBeValid: false,
-		},
-	}
+	t.Run("diff", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			shouldBeValid bool
+		}{
+			{
+				name:          "same",
+				shouldBeValid: true,
+			},
+			{
+				name:          "added-document",
+				shouldBeValid: true,
+			},
+			{
+				name:          "removed-document",
+				shouldBeValid: false,
+			},
+			{
+				name:          "added-advisory",
+				shouldBeValid: true,
+			},
+			{
+				name:          "removed-advisory",
+				shouldBeValid: false,
+			},
+			{
+				name:          "added-event",
+				shouldBeValid: true,
+			},
+			{
+				name:          "removed-event",
+				shouldBeValid: false,
+			},
+			{
+				name:          "modified-advisory-outside-of-events",
+				shouldBeValid: true,
+			},
+			{
+				name:          "added-event-with-non-recent-timestamp",
+				shouldBeValid: false,
+			},
+		}
 
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			aDir := filepath.Join("testdata", "diff", tt.name, "a")
-			bDir := filepath.Join("testdata", "diff", tt.name, "b")
-			aFsys := rwos.DirFS(aDir)
-			bFsys := rwos.DirFS(bDir)
-			aIndex, err := v2.NewIndex(aFsys)
-			require.NoError(t, err)
-			bIndex, err := v2.NewIndex(bFsys)
-			require.NoError(t, err)
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				aDir := filepath.Join("testdata", "diff", tt.name, "a")
+				bDir := filepath.Join("testdata", "diff", tt.name, "b")
+				aFsys := rwos.DirFS(aDir)
+				bFsys := rwos.DirFS(bDir)
+				aIndex, err := v2.NewIndex(aFsys)
+				require.NoError(t, err)
+				bIndex, err := v2.NewIndex(bFsys)
+				require.NoError(t, err)
 
-			err = Validate(ValidateOptions{
-				AdvisoryDocs:     bIndex,
-				BaseAdvisoryDocs: aIndex,
-				Now:              now,
+				err = Validate(context.Background(), ValidateOptions{
+					AdvisoryDocs:     bIndex,
+					BaseAdvisoryDocs: aIndex,
+					Now:              now,
+				})
+				if tt.shouldBeValid && err != nil {
+					t.Errorf("should be valid but got error: %v", err)
+				}
+				if !tt.shouldBeValid && err == nil {
+					t.Error("shouldn't be valid but got no error")
+				}
 			})
-			if tt.shouldBeValid && err != nil {
-				t.Errorf("should be valid but got error: %v", err)
-			}
-			if !tt.shouldBeValid && err == nil {
-				t.Error("shouldn't be valid but got no error")
-			}
-		})
-	}
-}
+		}
+	})
 
-// now establishes a fixed time for testing recency validation, for deterministic test runs.
-var now = time.Unix(1699660800, 0) // Nov 11 2023 00:00:00 UTC
+	t.Run("alias completeness", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			shouldBeValid bool
+		}{
+			{
+				name:          "alias-missing-cve",
+				shouldBeValid: false,
+			},
+			{
+				name:          "alias-missing-ghsa",
+				shouldBeValid: false,
+			},
+			{
+				name:          "alias-not-missing",
+				shouldBeValid: true,
+			},
+		}
+
+		mockAF := &mockAliasFinder{
+			cveByGHSA: map[string]string{
+				"GHSA-2222-2222-2222": "CVE-2222-2222",
+			},
+			ghsasByCVE: map[string][]string{
+				"CVE-2222-2222": {"GHSA-2222-2222-2222"},
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				dir := filepath.Join("testdata", "validate", tt.name)
+				fsys := rwos.DirFS(dir)
+				index, err := v2.NewIndex(fsys)
+				require.NoError(t, err)
+
+				err = Validate(context.Background(), ValidateOptions{
+					AdvisoryDocs: index,
+					AliasFinder:  mockAF,
+				})
+				if tt.shouldBeValid && err != nil {
+					t.Errorf("should be valid but got error: %v", err)
+				}
+				if !tt.shouldBeValid && err == nil {
+					t.Error("shouldn't be valid but got no error")
+				}
+			})
+		}
+	})
+}

--- a/pkg/cli/advisory_alias_discover.go
+++ b/pkg/cli/advisory_alias_discover.go
@@ -99,5 +99,5 @@ func (p *aliasDiscoverParams) addFlagsTo(cmd *cobra.Command) {
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 	addNoDistroDetectionFlag(&p.doNotDetectDistro, cmd)
 
-	cmd.Flags().StringSliceVarP(&p.packages, "package", "p", nil, "packages to operate on")
+	cmd.Flags().StringSliceVarP(&p.packages, flagNamePackage, "p", nil, "packages to operate on")
 }

--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -124,9 +124,15 @@ print an error message that specifies where and how the data is invalid.`,
 
 			af := advisory.NewHTTPAliasFinder(http.DefaultClient)
 
+			selectedPackageSet := make(map[string]struct{})
+			for _, pkg := range p.packages {
+				selectedPackageSet[pkg] = struct{}{}
+			}
+
 			opts := advisory.ValidateOptions{
 				AdvisoryDocs:     advisoriesIndex,
 				BaseAdvisoryDocs: baseAdvisoriesIndex,
+				SelectedPackages: selectedPackageSet,
 				Now:              time.Now(),
 				AliasFinder:      af,
 			}
@@ -156,6 +162,7 @@ type validateParams struct {
 	advisoriesRepoDir              string
 	advisoriesRepoUpstreamHTTPSURL string
 	advisoriesRepoBaseHash         string
+	packages                       []string
 }
 
 const (
@@ -168,6 +175,7 @@ func (p *validateParams) addFlagsTo(cmd *cobra.Command) {
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 	cmd.Flags().StringVar(&p.advisoriesRepoUpstreamHTTPSURL, flagNameAdvisoriesRepoURL, "", "HTTPS URL of the upstream Git remote for the advisories repo")
 	cmd.Flags().StringVar(&p.advisoriesRepoBaseHash, flagNameAdvisoriesRepoBaseHash, "", "commit hash of the upstream repo to which the current state will be compared in the diff")
+	cmd.Flags().StringSliceVarP(&p.packages, flagNamePackage, "p", nil, "packages to validate")
 }
 
 func renderValidationError(err error, depth int) string {

--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -121,13 +122,16 @@ print an error message that specifies where and how the data is invalid.`,
 				return err
 			}
 
+			af := advisory.NewHTTPAliasFinder(http.DefaultClient)
+
 			opts := advisory.ValidateOptions{
 				AdvisoryDocs:     advisoriesIndex,
 				BaseAdvisoryDocs: baseAdvisoriesIndex,
 				Now:              time.Now(),
+				AliasFinder:      af,
 			}
 
-			validationErr := advisory.Validate(opts)
+			validationErr := advisory.Validate(cmd.Context(), opts)
 			if validationErr != nil {
 				fmt.Fprintf(
 					os.Stderr,


### PR DESCRIPTION
This adds a check in `wolfictl adv validate` to make sure that all discoverable aliases have been found and added correctly.

Here's a sample of what failing this check looks like:

```
Auto-detected distro: Wolfi

❌ advisory data is not valid.

alias set completeness validation failure(s):
    minio:
        GHSA-2wrh-6pvc-2jm9:
            "GHSA-2wrh-6pvc-2jm9" should be listed as an alias, and "CVE-2023-3978" should be the advisory ID
        CVE-2023-44487:
            missing GHSA alias "GHSA-qppj-fm5r-hxr3" from set [GHSA-m425-mq94-257g, GHSA-2222-2222-2222]
```

**Note:** One potential issue is that frequent runs of `wolfictl adv validate` now risk hitting a user's rate limit with the GitHub API. @rawlingsj has a suggestion of switching the underlying querying to use GraphQL instead of the Rest API, to batch calls in groups of a 100. Another possible solution is to maintain a local cache of results. Both of these have design tradeoffs, and we should keep these in mind if (or when 😅 ) developers and/or CI runs into rate limit issues!

**Also:** This PR also adds a `-p`/`--package` flag that can be used multiple times to filter validation to inspect the advisory documents for one or more specific packages.