### PR TITLE
feat(adv): validate package definition existence

### DIFF
--- a/pkg/advisory/testdata/validate/package-existence/advisories/ko.advisories.yaml
+++ b/pkg/advisory/testdata/validate/package-existence/advisories/ko.advisories.yaml
@@ -1,0 +1,10 @@
+schema-version: 2.0.1
+
+package:
+  name: ko
+
+advisories:
+  - id: CVE-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination

--- a/pkg/advisory/testdata/validate/package-existence/advisories/mo.advisories.yaml
+++ b/pkg/advisory/testdata/validate/package-existence/advisories/mo.advisories.yaml
@@ -1,0 +1,10 @@
+schema-version: 2.0.1
+
+package:
+  name: mo
+
+advisories:
+  - id: CVE-3333-3333
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination

--- a/pkg/advisory/testdata/validate/package-existence/distro/ko.yaml
+++ b/pkg/advisory/testdata/validate/package-existence/distro/ko.yaml
@@ -1,0 +1,41 @@
+package:
+  name: ko
+  version: 0.15.1
+  epoch: 0
+  description: Simple, fast container image builder for Go applications.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      destination: ko
+      expected-commit: 2e9e58b187e1092534fbfc9889a04725da4a403d
+      repository: https://github.com/ko-build/ko
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: -w -X github.com/google/ko/pkg/commands.Version=${{package.version}}
+      modroot: ko
+      output: ko
+      packages: .
+      vendor: true
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: ko-build/ko
+    strip-prefix: v


### PR DESCRIPTION
This adds a new check to `wolfictl adv validate` to make sure that the package named in a given advisory document is currently defined in a build configuration in the corresponding distro packages repository (using the local clone of said repository).

Here's an example of failure output for this check:

```
Auto-detected distro: Wolfi

❌ advisory data is not valid.

package existence validation failure(s):
    argo-cd:
        this package is not defined in any distro package configuration
```

**Also:** This PR adds new flags that can turn off specific aspects of validation:

```
      --skip-alias                         skip alias completeness validation
      --skip-diff                          skip diff-based validations
      --skip-existence                     skip package configuration existence validation
```