### PR TITLE
lint: detect IDN homograph attacks

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -97,6 +97,22 @@ func TestLinter_Rules(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			file: "idn-homograph-attack.yaml",
+			want: EvalResult{
+				File: "idn-homograph-attack",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "valid-pipeline-fetch-uri",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[valid-pipeline-fetch-uri]: uri hostname \"downloads.xⅰph.org\" is invalid (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			file: "wrong-pipeline-fetch-digest.yaml",
 			want: EvalResult{
 				File: "wrong-pipeline-fetch-digest",

--- a/pkg/lint/testdata/files/idn-homograph-attack.yaml
+++ b/pkg/lint/testdata/files/idn-homograph-attack.yaml
@@ -1,0 +1,16 @@
+package:
+  name: idn-homograph-attack
+  version: 1.0.0
+  epoch: 0
+  description: "a package with an IDN homograph attack"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://downloads.xⅰph.org/releases/cdparanoia/cdparanoia-III-${{package.version}}.src.tgz
+      expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269


### PR DESCRIPTION
This detects if a fetch URL uses IDN lookalike domains such as `xⅰph.org` instead of 
 `xiph.org`.

For more context, see https://en.wikipedia.org/wiki/IDN_homograph_attack
