### PR TITLE
fix: base existence check on diff conditions

### DIFF
--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -5,13 +5,18 @@ import (
 	"path/filepath"
 	"testing"
 
+	"chainguard.dev/melange/pkg/config"
+	"github.com/chainguard-dev/go-apk/pkg/apk"
 	"github.com/stretchr/testify/require"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	"github.com/wolfi-dev/wolfictl/pkg/configs/build"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 )
 
 func TestValidate(t *testing.T) {
+	// The diff validation tests use the test fixtures for advisory.IndexDiff.
+
 	t.Run("diff", func(t *testing.T) {
 		cases := []struct {
 			name          string
@@ -79,6 +84,110 @@ func TestValidate(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("with existence conditions", func(t *testing.T) {
+			cases := []struct {
+				name            string
+				subcase         string
+				packageCfgsFunc func(t *testing.T) *configs.Index[config.Configuration]
+				apkindex        *apk.APKIndex
+				shouldBeValid   bool
+			}{
+				{
+					name:            "added-document", // these must be in distro
+					subcase:         "package in APKINDEX but not distro",
+					packageCfgsFunc: distroWithNothing,
+					apkindex: &apk.APKIndex{
+						Packages: []*apk.Package{
+							{
+								Name: "ko",
+							},
+						},
+					},
+					shouldBeValid: false,
+				},
+				{
+					name:            "added-document",
+					subcase:         "package in distro and APKINDEX",
+					packageCfgsFunc: distroWithKo,
+					apkindex: &apk.APKIndex{
+						Packages: []*apk.Package{
+							{
+								Name: "ko",
+							},
+						},
+					},
+					shouldBeValid: true,
+				},
+				{
+					name:            "added-document",
+					subcase:         "package not in distro or APKINDEX",
+					packageCfgsFunc: distroWithNothing,
+					apkindex:        &apk.APKIndex{},
+					shouldBeValid:   false,
+				},
+				{
+					name:            "added-advisory", // i.e. "modified-document", can be just in APKINDEX
+					subcase:         "package in APKINDEX but not distro",
+					packageCfgsFunc: distroWithNothing,
+					apkindex: &apk.APKIndex{
+						Packages: []*apk.Package{
+							{
+								Name: "ko",
+							},
+						},
+					},
+					shouldBeValid: true,
+				},
+				{
+					name:            "added-advisory",
+					subcase:         "package in distro and APKINDEX",
+					packageCfgsFunc: distroWithKo,
+					apkindex: &apk.APKIndex{
+						Packages: []*apk.Package{
+							{
+								Name: "ko",
+							},
+						},
+					},
+					shouldBeValid: true,
+				},
+				{
+					name:            "added-advisory",
+					subcase:         "package not in distro or APKINDEX",
+					packageCfgsFunc: distroWithNothing,
+					apkindex:        &apk.APKIndex{},
+					shouldBeValid:   false,
+				},
+			}
+
+			for _, tt := range cases {
+				t.Run(tt.name+" -- "+tt.subcase, func(t *testing.T) {
+					aDir := filepath.Join("testdata", "diff", tt.name, "a")
+					bDir := filepath.Join("testdata", "diff", tt.name, "b")
+					aFsys := rwos.DirFS(aDir)
+					bFsys := rwos.DirFS(bDir)
+					aIndex, err := v2.NewIndex(aFsys)
+					require.NoError(t, err)
+					bIndex, err := v2.NewIndex(bFsys)
+					require.NoError(t, err)
+
+					err = Validate(context.Background(), ValidateOptions{
+						AdvisoryDocs:          bIndex,
+						BaseAdvisoryDocs:      aIndex,
+						Now:                   now,
+						PackageConfigurations: tt.packageCfgsFunc(t),
+						APKIndex:              tt.apkindex,
+					})
+					if tt.shouldBeValid && err != nil {
+						t.Errorf("should be valid but got error: %v", err)
+					}
+					if !tt.shouldBeValid && err == nil {
+						t.Error("shouldn't be valid but got no error")
+					}
+				})
+			}
+		})
 	})
 
 	t.Run("alias completeness", func(t *testing.T) {
@@ -129,44 +238,18 @@ func TestValidate(t *testing.T) {
 			})
 		}
 	})
+}
 
-	t.Run("package existence", func(t *testing.T) {
-		cases := []struct {
-			name          string
-			packageSet    map[string]struct{}
-			shouldBeValid bool
-		}{
-			{
-				name:          "package-exists",
-				packageSet:    map[string]struct{}{"ko": {}},
-				shouldBeValid: true,
-			},
-			{
-				name:          "package-does-not-exist",
-				packageSet:    map[string]struct{}{"mo": {}},
-				shouldBeValid: false,
-			},
-		}
+func distroWithKo(t *testing.T) *configs.Index[config.Configuration] {
+	fsys := rwos.DirFS(filepath.Join("testdata", "validate", "package-existence", "distro"))
+	index, err := build.NewIndex(fsys)
+	require.NoError(t, err)
+	return index
+}
 
-		advIndex, err := v2.NewIndex(rwos.DirFS(filepath.Join("testdata", "validate", "package-existence", "advisories")))
-		require.NoError(t, err)
-		packageIndex, err := build.NewIndex(rwos.DirFS(filepath.Join("testdata", "validate", "package-existence", "distro")))
-		require.NoError(t, err)
-
-		for _, tt := range cases {
-			t.Run(tt.name, func(t *testing.T) {
-				err = Validate(context.Background(), ValidateOptions{
-					AdvisoryDocs:          advIndex,
-					SelectedPackages:      tt.packageSet,
-					PackageConfigurations: packageIndex,
-				})
-				if tt.shouldBeValid && err != nil {
-					t.Errorf("should be valid but got error: %v", err)
-				}
-				if !tt.shouldBeValid && err == nil {
-					t.Error("shouldn't be valid but got no error")
-				}
-			})
-		}
-	})
+func distroWithNothing(t *testing.T) *configs.Index[config.Configuration] {
+	fsys := rwos.DirFS(filepath.Join("testdata", "validate", "package-existence", "distro-empty"))
+	index, err := build.NewIndex(fsys)
+	require.NoError(t, err)
+	return index
 }

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -145,6 +145,7 @@ const (
 	flagNameAdvisoriesRepoDir = "advisories-repo-dir"
 	flagNameNoPrompt          = "no-prompt"
 	flagNameNoDistroDetection = "no-distro-detection"
+	flagNamePackageRepoURL    = "package-repo-url"
 )
 
 func addPackageFlag(val *string, cmd *cobra.Command) {
@@ -169,6 +170,10 @@ func addNoPromptFlag(val *bool, cmd *cobra.Command) {
 
 func addNoDistroDetectionFlag(val *bool, cmd *cobra.Command) {
 	cmd.Flags().BoolVar(val, flagNameNoDistroDetection, false, "do not attempt to auto-detect the distro")
+}
+
+func addPackageRepoURLFlag(val *string, cmd *cobra.Command) {
+	cmd.Flags().StringVarP(val, flagNamePackageRepoURL, "r", "", "URL of the APK package repository")
 }
 
 func newAllowedFixedVersionsFunc(apkindexes []*apk.APKIndex, buildCfgs *configs.Index[config.Configuration]) func(packageName string) []string {

--- a/pkg/cli/advisory_create.go
+++ b/pkg/cli/advisory_create.go
@@ -187,5 +187,5 @@ func (p *createParams) addFlagsTo(cmd *cobra.Command) {
 	addDistroDirFlag(&p.distroRepoDir, cmd)
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 	cmd.Flags().StringSliceVar(&p.archs, "arch", []string{"x86_64", "aarch64"}, "package architectures to find published versions for")
-	cmd.Flags().StringVarP(&p.packageRepositoryURL, "package-repo-url", "r", "", "URL of the APK package repository")
+	addPackageRepoURLFlag(&p.packageRepositoryURL, cmd)
 }

--- a/pkg/cli/advisory_update.go
+++ b/pkg/cli/advisory_update.go
@@ -182,5 +182,5 @@ func (p *updateParams) addFlagsTo(cmd *cobra.Command) {
 	addDistroDirFlag(&p.distroRepoDir, cmd)
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 	cmd.Flags().StringSliceVar(&p.archs, "arch", []string{"x86_64", "aarch64"}, "package architectures to find published versions for")
-	cmd.Flags().StringVarP(&p.packageRepositoryURL, "package-repo-url", "r", "", "URL of the APK package repository")
+	addPackageRepoURLFlag(&p.packageRepositoryURL, cmd)
 }


### PR DESCRIPTION
This updates the validation check implemented in #494. Rather than require all advisory documents to describe packages currently defined in the distro, the rules are now as follows:

- Net new advisory documents must refer to packages currently defined in the distro
- Modified advisory documents must refer to packages either currently defined in the distro, or that exist in the distro's APKINDEX (such as because they were _formerly_ defined in the distro)
- There are no package existence requirements for advisory documents being removed