### PR TITLE
fix(sbom,scan): resync configured catalogers

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -23,18 +23,17 @@ import (
 )
 
 var syftCatalogersEnabled = []string{
-	"apkdb",
-	"binary",
-	"dotnet-deps",
-	"go-module-binary",
+	"apk-db-cataloger",
+	"binary-cataloger",
+	"dotnet-portable-executable-cataloger",
+	"go-module-binary-cataloger",
 	"graalvm-native-image",
-	"java",
-	"javascript-package",
-	"php-composer-installed",
-	"portage",
-	"python-package",
+	"java-archive-cataloger",
+	"javascript-package-cataloger",
+	"php-composer-installed-cataloger",
+	"python-installed-package-cataloger",
 	"r-package-cataloger",
-	"ruby-gemspec",
+	"ruby-installed-gemspec-cataloger",
 }
 
 // Generate creates an SBOM for the given APK file.


### PR DESCRIPTION
There were recent breaking changes in Syft where numerous cataloger names were updated.

This PR resyncs the list of configured catalogers to Syft's catalogers using their latest explicit names, by:
- Starting with all [image catalogers](https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/cataloger.go#L42-L64) (for the sake of parity w/ Syft/Grype image scanning)
- Removing irrelevent catalogers (e.g. debian)
- Removing the SBOM cataloger and other catalogers that shouldn't be in Syft's image cataloger list (like cpp/Conan) — will follow up with them on these cataloger choices
