### PR TITLE
fix(adv): error decoding future enum values

### DIFF
--- a/pkg/configs/advisory/v2/detection.go
+++ b/pkg/configs/advisory/v2/detection.go
@@ -100,7 +100,7 @@ func (d *Detection) UnmarshalYAML(v *yaml.Node) error {
 		d.Data = data
 
 	default:
-		return fmt.Errorf("invalid detection type %q, must be one of [%s]", partial.Type, strings.Join(DetectionTypes, ", "))
+		// TODO: log at warn level: unrecognized type
 	}
 
 	// Copy the data from the partial detection.

--- a/pkg/configs/advisory/v2/document_test.go
+++ b/pkg/configs/advisory/v2/document_test.go
@@ -289,3 +289,12 @@ func TestDocument_full_coverage(t *testing.T) {
 		}
 	})
 }
+
+func TestDocument_DecodeFutureNonBreakingSchema(t *testing.T) {
+	f, err := os.Open("testdata/future.advisories.yaml")
+	require.NoError(t, err)
+
+	var doc Document
+	err = yaml.NewDecoder(f).Decode(&doc)
+	assert.NoError(t, err)
+}

--- a/pkg/configs/advisory/v2/event.go
+++ b/pkg/configs/advisory/v2/event.go
@@ -96,7 +96,12 @@ func (e *Event) UnmarshalYAML(v *yaml.Node) error {
 		event, err = decodeTypedEventData[PendingUpstreamFix](eventData)
 
 	default:
-		return fmt.Errorf("unrecognized event type %q, must be one of [%s]", eventData.Type, strings.Join(EventTypes, ", "))
+		// TODO: log at warn level: unrecognized event type
+
+		event = Event{
+			Timestamp: pe.Timestamp,
+			Type:      pe.Type,
+		}
 	}
 
 	if err != nil {

--- a/pkg/configs/advisory/v2/testdata/future.advisories.yaml
+++ b/pkg/configs/advisory/v2/testdata/future.advisories.yaml
@@ -1,0 +1,30 @@
+schema-version: 2.0.99999
+
+package:
+  name: future
+
+advisories:
+  - id: CVE-2000-0001
+    aliases:
+      - GHSA-xxxx-xxxx-xxx9
+      - GO-2000-0001
+      - DSA-2000-0001
+    events:
+      - timestamp: 2000-01-01T00:00:00Z
+        type: future-event-type
+        data:
+          peanut-butter: jelly
+      - timestamp: 2000-01-01T00:00:00Z
+        type: detection
+        data:
+          type: future-detection-type
+          data:
+            butterflies:
+              - unicorns
+              - rainbows
+      - timestamp: 2000-01-01T00:00:00Z
+        type: false-positive-determination
+        data:
+          type: future-false-positive-type
+          note: Something something false positive.
+


### PR DESCRIPTION
In various parts of the advisory schema, during decoding, we had been requiring that enum values are known to wolfictl, so that we knew which data structure to use to parse the corresponding `Data  interface{}` field.

This causes a problem where non-breaking future schema changes trigger breakages in the current version of wolfictl during decoding.

This PR adds a test (which fails before making the rest of the changes in this PR) to assert that future enum values don't result in an error on decoding.

Thanks to @pdeslaur for finding this!

cc: @rawlingsj 