### PR TITLE
feat(adv): v2.0.2 schema

### DIFF
--- a/pkg/advisory/diff_test.go
+++ b/pkg/advisory/diff_test.go
@@ -33,7 +33,7 @@ func TestIndexDiff(t *testing.T) {
 			expectedDiffResult: IndexDiffResult{
 				Added: []v2.Document{
 					{
-						SchemaVersion: v2.SchemaVersion,
+						SchemaVersion: "2.0.1",
 						Package: v2.Package{
 							Name: "ko",
 						},
@@ -57,7 +57,7 @@ func TestIndexDiff(t *testing.T) {
 			expectedDiffResult: IndexDiffResult{
 				Removed: []v2.Document{
 					{
-						SchemaVersion: v2.SchemaVersion,
+						SchemaVersion: "2.0.1",
 						Package: v2.Package{
 							Name: "ko",
 						},

--- a/pkg/configs/advisory/SCHEMA_VERSIONS.md
+++ b/pkg/configs/advisory/SCHEMA_VERSIONS.md
@@ -88,6 +88,9 @@ Log the new schema version in this document, at the top of the section [Version 
 `(vNext goes here)`
 - (list what was changed)
 
+`v2.0.2`
+- Added a new detection type "scan/v1", which corresponds to a new type for the detection event's "data" field. This introduces the notion of "type" values being versioned (e.g. with "/v1").
+
 `v2.0.1`
 - Added new event type "pending-upstream-fix", with a required "note" data field.
 

--- a/pkg/configs/advisory/v2/detection.go
+++ b/pkg/configs/advisory/v2/detection.go
@@ -14,6 +14,7 @@ import (
 const (
 	DetectionTypeManual = "manual"
 	DetectionTypeNVDAPI = "nvdapi"
+	DetectionTypeScanV1 = "scan/v1"
 )
 
 var (
@@ -21,6 +22,7 @@ var (
 	DetectionTypes = []string{
 		DetectionTypeManual,
 		DetectionTypeNVDAPI,
+		DetectionTypeScanV1,
 	}
 )
 
@@ -59,6 +61,9 @@ func (d Detection) validateData() error {
 
 	case DetectionTypeNVDAPI:
 		return validateTypedDetectionData[DetectionNVDAPI](d.Data)
+
+	case DetectionTypeScanV1:
+		return validateTypedDetectionData[DetectionScanV1](d.Data)
 	}
 
 	return nil
@@ -99,6 +104,13 @@ func (d *Detection) UnmarshalYAML(v *yaml.Node) error {
 		}
 		d.Data = data
 
+	case DetectionTypeScanV1:
+		var data DetectionScanV1
+		if err := partial.Data.Decode(&data); err != nil {
+			return err
+		}
+		d.Data = data
+
 	default:
 		// TODO: log at warn level: unrecognized type
 	}
@@ -123,4 +135,52 @@ func (d DetectionNVDAPI) Validate() error {
 			errorhelpers.LabelError("cpeFound", vuln.ValidateCPE(d.CPEFound)),
 		),
 	)
+}
+
+var (
+	DetectionScannerGrype = "grype"
+)
+
+var DetectionScanners = []string{
+	DetectionScannerGrype,
+}
+
+// DetectionScanV1 is the data associated with DetectionTypeScanV1.
+type DetectionScanV1 struct {
+	SubpackageName    string `yaml:"subpackageName"`
+	ComponentID       string `yaml:"componentID"` // TODO: consider namespacing this ID using the SBOM tool+format
+	ComponentName     string `yaml:"componentName"`
+	ComponentVersion  string `yaml:"componentVersion"`
+	ComponentType     string `yaml:"componentType"`
+	ComponentLocation string `yaml:"componentLocation"`
+	Scanner           string `yaml:"scanner"` // TODO: it'd be nice for the scanner value to be automatically versioned
+}
+
+// Validate returns an error if the DetectionScanV1 data is invalid.
+func (d DetectionScanV1) Validate() error {
+	// TODO: Should SubpackageName be required, and it's set to the origin package
+	// 	sometimes? Or should an empty value imply this was a scan of an origin
+	// 	package?
+
+	return errorhelpers.LabelError("scan/v1 detection data",
+		errors.Join(
+			errorhelpers.LabelError("componentID", validateNotEmpty(d.ComponentID)),
+			errorhelpers.LabelError("componentName", validateNotEmpty(d.ComponentName)),
+			errorhelpers.LabelError("componentVersion", validateNotEmpty(d.ComponentVersion)),
+			errorhelpers.LabelError("componentType", validateNotEmpty(d.ComponentType)),
+			errorhelpers.LabelError("componentLocation", validateNotEmpty(d.ComponentLocation)),
+			errorhelpers.LabelError("scanner", validateDetectionScanner(d.Scanner)),
+		),
+	)
+}
+
+func validateDetectionScanner(scanner string) error {
+	if !slices.Contains(DetectionScanners, scanner) {
+		return fmt.Errorf("value is %q but must be one of [%v]", scanner, strings.Join(
+			DetectionScanners,
+			", ",
+		))
+	}
+
+	return nil
 }

--- a/pkg/configs/advisory/v2/detection.go
+++ b/pkg/configs/advisory/v2/detection.go
@@ -158,12 +158,9 @@ type DetectionScanV1 struct {
 
 // Validate returns an error if the DetectionScanV1 data is invalid.
 func (d DetectionScanV1) Validate() error {
-	// TODO: Should SubpackageName be required, and it's set to the origin package
-	// 	sometimes? Or should an empty value imply this was a scan of an origin
-	// 	package?
-
 	return errorhelpers.LabelError("scan/v1 detection data",
 		errors.Join(
+			errorhelpers.LabelError("subpackageName", validateNotEmpty(d.SubpackageName)),
 			errorhelpers.LabelError("componentID", validateNotEmpty(d.ComponentID)),
 			errorhelpers.LabelError("componentName", validateNotEmpty(d.ComponentName)),
 			errorhelpers.LabelError("componentVersion", validateNotEmpty(d.ComponentVersion)),

--- a/pkg/configs/advisory/v2/detection_test.go
+++ b/pkg/configs/advisory/v2/detection_test.go
@@ -62,6 +62,38 @@ func TestDetection_Validate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "scan/v1",
+			detection: Detection{
+				Type: DetectionTypeScanV1,
+				Data: DetectionScanV1{
+					SubpackageName:    "crane-docs",
+					ComponentID:       "fe8053a3adedc5d0",
+					ComponentName:     "github.com/docker/distribution",
+					ComponentVersion:  "v2.8.1+incompatible",
+					ComponentType:     "go-module",
+					ComponentLocation: "/usr/bin/crane",
+					Scanner:           "grype",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "scan/v1 missing required fields",
+			detection: Detection{
+				Type: DetectionTypeScanV1,
+				Data: DetectionScanV1{
+					SubpackageName:    "",
+					ComponentID:       "fe8053a3adedc5d0",
+					ComponentName:     "github.com/docker/distribution",
+					ComponentVersion:  "",
+					ComponentType:     "go-module",
+					ComponentLocation: "",
+					Scanner:           "",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/configs/advisory/v2/document.go
+++ b/pkg/configs/advisory/v2/document.go
@@ -15,7 +15,7 @@ import (
 // Wolfictl can only operate on documents that use a schema version that is
 // equal to or earlier than this version and that is not earlier than this
 // version's MAJOR number.
-const SchemaVersion = "2.0.1"
+const SchemaVersion = "2.0.2"
 
 type Document struct {
 	SchemaVersion string     `yaml:"schema-version"`
@@ -159,4 +159,12 @@ func (advs Advisories) Less(i, j int) bool {
 
 func (advs Advisories) Swap(i, j int) {
 	advs[i], advs[j] = advs[j], advs[i]
+}
+
+func validateNotEmpty(s string) error {
+	if s == "" {
+		return fmt.Errorf("must not be empty")
+	}
+
+	return nil
 }

--- a/pkg/configs/advisory/v2/document_test.go
+++ b/pkg/configs/advisory/v2/document_test.go
@@ -148,6 +148,22 @@ func TestDocument_full_coverage(t *testing.T) {
 					},
 					{
 						Timestamp: testTime,
+						Type:      EventTypeDetection,
+						Data: Detection{
+							Type: DetectionTypeScanV1,
+							Data: DetectionScanV1{
+								SubpackageName:    "test-sub",
+								ComponentID:       "fe8053a3adedc5d0",
+								ComponentName:     "github.com/docker/distribution",
+								ComponentVersion:  "v2.8.1+incompatible",
+								ComponentType:     "go-module",
+								ComponentLocation: "/usr/bin/crane",
+								Scanner:           "grype",
+							},
+						},
+					},
+					{
+						Timestamp: testTime,
 						Type:      EventTypeTruePositiveDetermination,
 						Data: TruePositiveDetermination{
 							Note: "Something something true positive.",
@@ -242,7 +258,7 @@ func TestDocument_full_coverage(t *testing.T) {
 		},
 	}
 
-	f, err := os.Open("testdata/full.advisories.yaml")
+	f, err := os.Open("testdata/full.advisories.yaml") // Note: Keep this document using the latest schema.
 	require.NoError(t, err)
 
 	t.Run("decode", func(t *testing.T) {

--- a/pkg/configs/advisory/v2/testdata/full.advisories.yaml
+++ b/pkg/configs/advisory/v2/testdata/full.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: full
@@ -20,6 +20,18 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:*:tinyxml:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:tinyxml_project:tinyxml:*:*:*:*:*:*:*:*
+      - timestamp: 2000-01-01T00:00:00Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: test-sub
+            componentID: fe8053a3adedc5d0
+            componentName: github.com/docker/distribution
+            componentVersion: v2.8.1+incompatible
+            componentType: go-module
+            componentLocation: /usr/bin/crane
+            scanner: grype
       - timestamp: 2000-01-01T00:00:00Z
         type: true-positive-determination
         data:


### PR DESCRIPTION
This PR adds a new non-breaking ("addition") advisory schema update: **v2.0.2**.

This adds support for capturing valuable information from a vulnerability scan into an advisory's **detection** event(s).

This also tests out the idea of "versioned" types in the advisory schema, here by introducing a new detection type of `scan/v1`. This is intended to allow us to iterate on the data shape such that multiple versions of this detection type can coexist in a single advisory data set, and newer detections can always take advantage of the latest data structure available.

The hope is that by adding this library support, we can begin automatically generating advisory data using vulnerability scans, such that we're not losing the insightful data found at scan-time as we encode the detection into our advisory data store.

**Note:** This PR doesn't add any actual exercising of the new schema yet. At some point relatively soon, it'd be neat to add an option to wolfictl's scanning to immediately record net-new vulnerabilities using this new detection type.

cc: @rawlingsj @cpanato @pdeslaur 