### PR TITLE
wolfictl text: support nested repo structure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,9 +39,16 @@ jobs:
         with:
           repository: 'wolfi-dev/os'
           path: 'wolfi-os'
-      - run: |
+      - name: Test Wolfi OS repo
+        run: |
           ./wolfictl text -d wolfi-os \
             --type=name \
             --pipeline-dir=wolfi-os/pipelines/ \
             --keyring-append=https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub \
             --repository-append=https://packages.wolfi.dev/bootstrap/stage3
+
+      - name: Test nested repo structure
+        run: |
+          ./wolfictl text -d testdata/text/ | grep foo-0.0.2-r0
+          ./wolfictl text -d testdata/text/ | grep bar-0.0.1-r0
+          ./wolfictl text -d testdata/text/ | grep root-0.0.1-r0

--- a/testdata/text/org/bar/bar.melange.yaml
+++ b/testdata/text/org/bar/bar.melange.yaml
@@ -1,0 +1,4 @@
+package:
+  name: bar
+  version: 0.0.1
+  description: a melange config in the bar org

--- a/testdata/text/org/foo/foo.melange.yaml
+++ b/testdata/text/org/foo/foo.melange.yaml
@@ -1,0 +1,4 @@
+package:
+  name: foo
+  version: 0.0.2
+  description: a melange config in the foo org

--- a/testdata/text/root.yaml
+++ b/testdata/text/root.yaml
@@ -1,0 +1,4 @@
+package:
+  name: root
+  version: 0.0.1
+  description: a melange config in the root


### PR DESCRIPTION
This starts to support cases where the repo containing Melange configs isn't just a flat directory.

It does support the current flat structure:

```
foo.yaml
bar.yaml
baz.yaml
```

...as well as a nested structure like:

```
blah/foo/foo.melange.yaml
blah/bar/bar.melange.yaml
hello/baz/baz.melange.yaml
```

(NB: files must be named like `*.melange.yaml`, otherwise they're ignored -- the directory name is not currently taken into account, but could be)

...and an intermediate stage where the repo may have some files in the flat structure and some in the nested structure:

```
foo.yaml
blah/bar/bar.melange.yaml
baz.yaml
```

The `foo.yaml` does not currently need to describe a package with `name: foo` -- we might add this later. A `foo.melange.yaml` doesn't need to be contained in a directory named `foo/` -- we might add this later.

Our current graph construction logic prevents two packages with the same name _and version_. We might add more validation for this later.

For now this works with the testdata layout added in the PR, and this is enforced in CI.