### PR TITLE
Don't validate grype DB by hash

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -34,9 +34,10 @@ const (
 var grypeDBDir = path.Join(xdg.CacheHome, "wolfictl", "grype", "db")
 
 var grypeDBConfig = db.Config{
-	DBRootDir:           grypeDBDir,
-	ListingURL:          grypeDBListingURL,
-	ValidateByHashOnGet: true,
+	DBRootDir:  grypeDBDir,
+	ListingURL: grypeDBListingURL,
+	// TODO(https://github.com/wolfi-dev/wolfictl/issues/520): Set this to true.
+	ValidateByHashOnGet: false,
 	ValidateAge:         true,
 	MaxAllowedBuiltAge:  24 * time.Hour,
 }


### PR DESCRIPTION
This is very expensive and we do it for every APK that gets scanned.

We should consider re-enabling this if we initialize the DB once per invocation instead of per APK.

X-ref: https://github.com/wolfi-dev/wolfictl/issues/520