### PR TITLE
Bring in the latest melange to handle `test` configurations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	chainguard.dev/apko v0.12.0
-	chainguard.dev/melange v0.5.4-0.20231201200824-16120a17e2e2
+	chainguard.dev/melange v0.5.4
 	github.com/adrg/xdg v0.4.0
 	github.com/anchore/grype v0.73.4
 	github.com/anchore/syft v0.98.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 chainguard.dev/apko v0.12.0 h1:smG4DL5HMmSsbO6/Buou+GpCWpUW4whnoEWNsoz/6To=
 chainguard.dev/apko v0.12.0/go.mod h1:KNMKxHVteLL3R4lfg0ICV5NaAFY6v/+q7/nYT7B/qug=
-chainguard.dev/melange v0.5.4-0.20231201200824-16120a17e2e2 h1:n0hfNJlOpCK8YA/z/VUuFu3H/RqaI7vXc1kO6R3pc9s=
-chainguard.dev/melange v0.5.4-0.20231201200824-16120a17e2e2/go.mod h1:GXS6H4w+rpM1gp8TZmXVxb7D49Kl2XLJ40llBeDZoaQ=
+chainguard.dev/melange v0.5.4 h1:4f3zaTm3vC60+bkzOsr+bmygwqUGSfNr93hs65Pe+nA=
+chainguard.dev/melange v0.5.4/go.mod h1:T0IYIOos8Nr85YtMWk0OTq2+gxWGmsoEvp90KZZhX+Y=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -218,7 +218,7 @@ func NewPackages(fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
 			Package: &c.Package,
 		}
 		for i := range c.Pipeline {
-			s := &build.PipelineContext{Pipeline: &c.Pipeline[i]}
+			s := &build.PipelineContext{Environment: &pctx.Build.Configuration.Environment, PipelineDirs: []string{pipelineDir}, Pipeline: &c.Pipeline[i]}
 			if err := s.ApplyNeeds(pctx); err != nil {
 				return fmt.Errorf("unable to resolve needs for package %s: %w", name, err)
 			}

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -212,7 +212,7 @@ func NewPackages(fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
 		// .environment.contents.packages so the next block can include those as build deps.
 		pctx := &build.PipelineBuild{
 			Build: &build.Build{
-				PipelineDir:   pipelineDir,
+				PipelineDirs:  []string{pipelineDir},
 				Configuration: *c.Configuration,
 			},
 			Package: &c.Package,


### PR DESCRIPTION
Need to plumb through the latest melange changes because without it things are failing in wolfi-dev/os because it doesn't know about new fields.
https://github.com/wolfi-dev/os/pull/9982
like this:
https://github.com/wolfi-dev/os/actions/runs/7225997373/job/19690633526?pr=9982