### PR TITLE
feat: fix --flag arg in text command

### DIFF
--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -32,7 +32,8 @@ func cmdText() *cobra.Command {
 			}
 			g, err := dag.NewGraph(pkgs,
 				dag.WithKeys(extraKeys...),
-				dag.WithRepos(extraRepos...))
+				dag.WithRepos(extraRepos...),
+				dag.WithArch(arch))
 			if err != nil {
 				return err
 			}

--- a/pkg/dag/graph.go
+++ b/pkg/dag/graph.go
@@ -80,8 +80,11 @@ func NewGraph(pkgs *Packages, options ...GraphOptions) (*Graph, error) {
 	)
 
 	// TODO: should we repeat across multiple arches? Use c.Package.TargetArchitecture []string
-	var arch = "x86_64"
-	localRepo := pkgs.Repository(arch)
+	if opts.arch == "" {
+		opts.arch = "x86_64"
+	}
+
+	localRepo := pkgs.Repository(opts.arch)
 	localRepoSource := localRepo.Source()
 	localOnlyResolver := apk.NewPkgResolver(context.TODO(), []apk.NamedIndex{localRepo})
 	g.resolvers[localRepoSource] = localOnlyResolver
@@ -97,7 +100,7 @@ func NewGraph(pkgs *Packages, options ...GraphOptions) (*Graph, error) {
 			continue
 		}
 		// add the origin package as its own resolver, so that the subpackage can resolve to it
-		g.resolvers[c.String()] = singlePackageResolver(c, arch)
+		g.resolvers[c.String()] = singlePackageResolver(c, opts.arch)
 		for i := range c.Subpackages {
 			subpkg := pkgs.Config(c.Subpackages[i].Name, false)
 			for _, subpkgVersion := range subpkg {
@@ -120,7 +123,7 @@ func NewGraph(pkgs *Packages, options ...GraphOptions) (*Graph, error) {
 
 	for _, c := range pkgs.Packages() {
 		// add packages from the runtime dependencies
-		resolverKey, err := g.addResolverForRepos(arch,
+		resolverKey, err := g.addResolverForRepos(opts.arch,
 			localRepo,
 			indexes,
 			keys,
@@ -140,7 +143,7 @@ func NewGraph(pkgs *Packages, options ...GraphOptions) (*Graph, error) {
 
 	for _, c := range pkgs.Packages() {
 		// add packages from the buildtime dependencies
-		resolverKey, err := g.addResolverForRepos(arch,
+		resolverKey, err := g.addResolverForRepos(opts.arch,
 			localRepo,
 			indexes,
 			keys,

--- a/pkg/dag/graph_options.go
+++ b/pkg/dag/graph_options.go
@@ -4,6 +4,7 @@ type graphOptions struct {
 	allowUnresolved bool
 	repos           []string
 	keys            []string
+	arch            string
 }
 
 type GraphOptions func(*graphOptions) error
@@ -35,6 +36,14 @@ func WithRepos(repos ...string) GraphOptions {
 func WithKeys(keys ...string) GraphOptions {
 	return func(o *graphOptions) error {
 		o.keys = keys
+		return nil
+	}
+}
+
+// WithArch sets the architecture for which the graph is built.
+func WithArch(arch string) GraphOptions {
+	return func(o *graphOptions) error {
+		o.arch = arch
 		return nil
 	}
 }


### PR DESCRIPTION
The `wolfictl text` command is ignoring `--arch` argument, always running for x86 arch.

```bash
❯ ./../wolfictl/wolfictl text
2023/12/28 01:05:21 Skipping non-melange YAML file: kubeflow-pipelines/metadata-envoy-config.yaml
2023/12/28 01:05:22 Skipping non-melange YAML file: loki/local-config.yaml
2023/12/28 01:05:22 Skipping non-melange YAML file: loki/promtail-local-config.yaml
2023/12/28 01:05:22 Skipping non-melange YAML file: pipelines/bitnami/compat.yaml
2023/12/28 01:05:22 Skipping non-melange YAML file: pipelines/go/bump.yaml
2023/12/28 01:05:22 Skipping non-melange YAML file: pipelines/ruby/unlock-spec.yaml
2023/12/28 01:05:22 [DEBUG] GET https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
2023/12/28 01:05:23 [DEBUG] GET https://packages.wolfi.dev/bootstrap/stage3/x86_64/APKINDEX.tar.gz
^C
❯ ./../wolfictl/wolfictl text --arch aarch64
2023/12/28 01:05:16 Skipping non-melange YAML file: kubeflow-pipelines/metadata-envoy-config.yaml
2023/12/28 01:05:16 Skipping non-melange YAML file: loki/local-config.yaml
2023/12/28 01:05:16 Skipping non-melange YAML file: loki/promtail-local-config.yaml
2023/12/28 01:05:16 Skipping non-melange YAML file: pipelines/bitnami/compat.yaml
2023/12/28 01:05:16 Skipping non-melange YAML file: pipelines/go/bump.yaml
2023/12/28 01:05:16 Skipping non-melange YAML file: pipelines/ruby/unlock-spec.yaml
2023/12/28 01:05:17 [DEBUG] GET https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
2023/12/28 01:05:17 [DEBUG] GET https://packages.wolfi.dev/bootstrap/stage3/x86_64/APKINDEX.tar.gz
^C
```

After this update

```bash
❯ ./../wolfictl/wolfictl text --arch aarch64
2023/12/28 01:07:03 Skipping non-melange YAML file: kubeflow-pipelines/metadata-envoy-config.yaml
2023/12/28 01:07:03 Skipping non-melange YAML file: loki/local-config.yaml
2023/12/28 01:07:03 Skipping non-melange YAML file: loki/promtail-local-config.yaml
2023/12/28 01:07:03 Skipping non-melange YAML file: pipelines/bitnami/compat.yaml
2023/12/28 01:07:03 Skipping non-melange YAML file: pipelines/go/bump.yaml
2023/12/28 01:07:03 Skipping non-melange YAML file: pipelines/ruby/unlock-spec.yaml
2023/12/28 01:07:04 [DEBUG] GET https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
2023/12/28 01:07:05 [DEBUG] GET https://packages.wolfi.dev/bootstrap/stage3/aarch64/APKINDEX.tar.gz
^C
```