### PR TITLE
feat(adv): add logging to validation

### DIFF
--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -2,6 +2,8 @@ package advisory
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,6 +15,8 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/configs/build"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 )
+
+var testLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 func TestValidate(t *testing.T) {
 	// The diff validation tests use the test fixtures for advisory.IndexDiff.
@@ -75,6 +79,7 @@ func TestValidate(t *testing.T) {
 					AdvisoryDocs:     bIndex,
 					BaseAdvisoryDocs: aIndex,
 					Now:              now,
+					Logger:           testLogger,
 				})
 				if tt.shouldBeValid && err != nil {
 					t.Errorf("should be valid but got error: %v", err)
@@ -197,6 +202,7 @@ func TestValidate(t *testing.T) {
 						Now:                   now,
 						PackageConfigurations: tt.packageCfgsFunc(t),
 						APKIndex:              tt.apkindex,
+						Logger:                testLogger,
 					})
 					if tt.shouldBeValid && err != nil {
 						t.Errorf("should be valid but got error: %v", err)
@@ -247,6 +253,7 @@ func TestValidate(t *testing.T) {
 				err = Validate(context.Background(), ValidateOptions{
 					AdvisoryDocs: index,
 					AliasFinder:  mockAF,
+					Logger:       testLogger,
 				})
 				if tt.shouldBeValid && err != nil {
 					t.Errorf("should be valid but got error: %v", err)
@@ -324,6 +331,7 @@ func TestValidate(t *testing.T) {
 					err = Validate(context.Background(), ValidateOptions{
 						AdvisoryDocs: index,
 						APKIndex:     tt.apkindex,
+						Logger:       testLogger,
 					})
 					if tt.shouldBeValid && err != nil {
 						t.Errorf("should be valid but got error: %v", err)

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"sort"
 	"strings"
@@ -174,6 +176,24 @@ func addNoDistroDetectionFlag(val *bool, cmd *cobra.Command) {
 
 func addPackageRepoURLFlag(val *string, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(val, flagNamePackageRepoURL, "r", "", "URL of the APK package repository")
+}
+
+func addVerboseFlag(val *int, cmd *cobra.Command) {
+	cmd.Flags().CountVarP(val, "verbose", "v", "logging verbosity (v = info, vv = debug, default is none)")
+}
+
+func newLogger(verbosity int) *slog.Logger {
+	var h slog.Handler
+	switch {
+	case verbosity == 1:
+		h = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})
+	case verbosity >= 2:
+		h = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
+	default:
+		h = slog.NewTextHandler(io.Discard, nil)
+	}
+
+	return slog.New(h)
 }
 
 func newAllowedFixedVersionsFunc(apkindexes []*apk.APKIndex, buildCfgs *configs.Index[config.Configuration]) func(packageName string) []string {


### PR DESCRIPTION
Adds (structured) logging to the advisory code, starting here with the validation functionality.

This logging is off by default, but CLI users can turn on info-level logs with `-v`, and debug-level logs with `-vv`.

Library users can customize the `*slog.Logger` they provide to the `advisory.ValidateOptions` struct however they like.

Example:

```console
$ w adv validate --skip-alias -vv
time=2024-01-09T11:19:39.253-05:00 level=DEBUG msg="distro auto-detection enabled"
time=2024-01-09T11:19:40.418-05:00 level=INFO msg="detected distro" name=Wolfi
time=2024-01-09T11:19:40.418-05:00 level=DEBUG msg="local distro properties" packagesRepoDir=/Users/dan/code/wolfi-os advisoriesRepoDir=/Users/dan/code/wolfi-advisories advisoriesRepoForkPoint=6635d8bf071aef86c5665c14ea803e7c9a939a47
time=2024-01-09T11:19:41.174-05:00 level=DEBUG msg="cloned upstream advisories repo for comparison" dir=/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/wolfictl-git-clone-3669894489
time=2024-01-09T11:19:42.683-05:00 level=INFO msg="validating index diff" diffIsZero=true
time=2024-01-09T11:19:42.683-05:00 level=INFO msg="validating fixed versions" indexPackageCount=34933
time=2024-01-09T11:19:42.737-05:00 level=INFO msg="skipping validation of alias set completeness, no alias finder provided"
✅ advisory data is valid.
```