### PR TITLE
feat: new command "scan-source"

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -27,6 +27,7 @@ func New() *cobra.Command {
 		cmdLs(),
 		cmdSBOM(),
 		cmdScan(),
+		cmdScanSource(),
 		cmdUpdate(),
 		cmdVEX(),
 		cmdWithdraw(),

--- a/pkg/cli/scan-source.go
+++ b/pkg/cli/scan-source.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/configs/build"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+	"github.com/wolfi-dev/wolfictl/pkg/scan"
+)
+
+func cmdScanSource() *cobra.Command {
+	p := &scanSourceParams{}
+	cmd := &cobra.Command{
+		Use:           "scan-source",
+		Short:         "Scan a package's source code for vulnerabilities",
+		Args:          cobra.MinimumNArgs(1),
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger := newLogger(p.verbosity)
+
+			distroDir := p.distroDir
+			if distroDir == "" {
+				distroDir = "."
+			}
+
+			fsys := rwos.DirFS(distroDir)
+			index, err := build.NewIndex(fsys)
+			if err != nil {
+				return fmt.Errorf("failed to create index of package configurations: %w", err)
+			}
+
+			first, err := index.Select().WhereName(args[0]).First()
+			if err != nil {
+				return fmt.Errorf("failed to find configuration for package %q: %w", args[0], err)
+			}
+			cfg := first.Configuration()
+
+			logger.Info("scanning source code used in melange configuration", "package", cfg.Name())
+
+			scanResults, err := scan.Sources(cmd.Context(), logger, cfg)
+			if err != nil {
+				return fmt.Errorf("failed to scan sources for %q: %w", cfg.Name(), err)
+			}
+
+			for _, r := range scanResults {
+				fmt.Print(r)
+			}
+
+			return nil
+		},
+	}
+
+	p.addFlagsTo(cmd)
+	return cmd
+}
+
+type scanSourceParams struct {
+	distroDir string
+	verbosity int
+}
+
+func (p *scanSourceParams) addFlagsTo(cmd *cobra.Command) {
+	addDistroDirFlag(&p.distroDir, cmd)
+	addVerboseFlag(&p.verbosity, cmd)
+}

--- a/pkg/scan/source.go
+++ b/pkg/scan/source.go
@@ -1,0 +1,131 @@
+package scan
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"chainguard.dev/melange/pkg/config"
+	"github.com/wolfi-dev/wolfictl/pkg/git"
+	"golang.org/x/vuln/pkg/vulncheck"
+)
+
+func Sources(ctx context.Context, logger *slog.Logger, cfg *config.Configuration) ([]SourceResult, error) {
+	// TODO: handle "fetch" pipelines
+
+	const gitCheckoutPipelineName = "git-checkout"
+
+	var targets []gitCloneTarget
+	for i := range cfg.Pipeline {
+		step := cfg.Pipeline[i]
+
+		if step.Uses != gitCheckoutPipelineName {
+			continue
+		}
+
+		// TODO: Ideally there's an elegant way to do this by leaning on Melange's code,
+		//  but that code is pretty messy at the moment. I would've expected these
+		//  substitutions that don't depend on runtime information to be done at parse
+		//  time, but they're not.
+		step.With["tag"] = strings.ReplaceAll(step.With["tag"], config.SubstitutionPackageVersion, cfg.Package.Version)
+
+		t := gitCloneTarget{
+			url: step.With["repository"],
+			tag: step.With["tag"],
+		}
+		targets = append(targets, t)
+
+		logger.Debug(
+			"found git checkout step",
+			"stepIndex",
+			i,
+			"repository",
+			t.url,
+			"tag",
+			t.tag,
+		)
+	}
+
+	logger.Debug("finished finding git checkout steps", "total", len(targets))
+
+	var results []SourceResult
+	for _, t := range targets {
+		r, err := t.cloneAndRunGovulncheckSourceScan(ctx, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, SourceResult{
+			Name:            cfg.Name(),
+			GitRepository:   t,
+			VulncheckResult: r,
+		})
+	}
+
+	return results, nil
+}
+
+type gitCloneTarget struct {
+	url string
+	tag string
+}
+
+func (t gitCloneTarget) cloneAndRunGovulncheckSourceScan(ctx context.Context, logger *slog.Logger) (*vulncheck.Result, error) {
+	logger.Debug("beginning git clone", "url", t.url, "tag", t.tag)
+	tempDir, err := git.TempCloneTag(t.url, t.tag, false)
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to clone repo %q: %w", t.url, err)
+	}
+	logger.Debug("finished git clone", "url", t.url, "tag", t.tag)
+
+	logger.Debug("beginning govulncheck source scan", "repo", t.url, "tag", t.tag, "tempDir", tempDir)
+	result, err := runGovulncheckSource(ctx, tempDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to run govulncheck on %q: %w", t.url, err)
+	}
+	logger.Debug("finished govulncheck source scan", "target", t)
+
+	return result, nil
+}
+
+// SourceResult is the result of scanning a package's source code for
+// vulnerabilities using govulncheck.
+type SourceResult struct {
+	// The Name of the package described in the Melange configuration.
+	Name string
+
+	// GitRepository describes the repository that was scanned.
+	GitRepository gitCloneTarget
+
+	// VulncheckResult is the result of running govulncheck on the repository.
+	VulncheckResult *vulncheck.Result
+}
+
+// String returns a human-readable representation of the result.
+func (r SourceResult) String() string {
+	s := fmt.Sprintf(
+		"%s %s %s\n",
+		r.Name,
+		r.GitRepository.url,
+		r.GitRepository.tag,
+	)
+
+	if len(r.VulncheckResult.Vulns) == 0 {
+		s += "  No vulnerabilities found\n"
+		return s
+	}
+
+	for _, v := range r.VulncheckResult.Vulns {
+		s += fmt.Sprintf(
+			"  %s %s %s\n",
+			v.OSV.ID,
+			v.ImportSink.String(),
+			v.Symbol,
+		)
+	}
+
+	return s
+}


### PR DESCRIPTION
Adds a new experimental command to start letting us do source code scans of our distro packages. The goal here is to both:

1. find vulnerabilities that are otherwise obscured by our build process and thus not detectable in package/image scans
2. realize false positives via analyses like the call graph analysis in `govulncheck` that otherwise appear to be true positives in simple binary scans.

```shell
wolfictl scan-source [-d path/to/distro/dir] [-v] package
```

<img width="1840" alt="image" src="https://github.com/wolfi-dev/wolfictl/assets/5199289/bb37d9d3-d4eb-44d6-aff2-e6a25dd65c5f">

For now, this just uses `govulncheck`, wired in as a library. But in subsequent iterations we can add Grype or other scanners that will help surface findings in raw source code.

To finish this first iteration, there's a handful of tasks left to do:

- [ ] Support `fetch` pipelines (currently this just supports `git-checkout` pipelines)
- [ ] Consider using breakpoints or something similar to allow Melange pipeline configurations to specify the optimal scan point (it may be further into the pipeline than just after retrieving the upstream source code, particular if code or dependencies are modified)
- [ ] Tests
- [ ] Docs

