### PR TITLE
feat: cleanup gobump deps/replaces or even remove the pipeline if not needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f
 	github.com/openvex/go-vex v0.2.5
 	github.com/package-url/packageurl-go v0.1.2
+	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.39.0
 	github.com/savioxavier/termlink v1.3.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
@@ -41,12 +42,14 @@ require (
 	github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0
 	go.lsp.dev/uri v0.3.0
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e
+	golang.org/x/mod v0.14.0
 	golang.org/x/oauth2 v0.16.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 	golang.org/x/time v0.5.0
 	golang.org/x/vuln v1.0.1
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/apimachinery v0.28.4
 	sigs.k8s.io/release-utils v0.7.7
 )
 
@@ -228,7 +231,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e // indirect
@@ -280,7 +282,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect
@@ -300,7 +301,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/gorm v1.25.5 // indirect
 	k8s.io/api v0.28.4 // indirect
-	k8s.io/apimachinery v0.28.4 // indirect
 	k8s.io/client-go v0.28.4 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231129212854-f0671cc7e66a // indirect

--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -20,8 +20,6 @@ import (
 	"chainguard.dev/melange/pkg/util"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	wolfibuild "github.com/wolfi-dev/wolfictl/pkg/configs/build"
-	rwfsOS "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 	"github.com/wolfi-dev/wolfictl/pkg/lint"
 	"github.com/wolfi-dev/wolfictl/pkg/melange"
 	"github.com/wolfi-dev/wolfictl/pkg/update"
@@ -242,26 +240,11 @@ func (o CheckUpdateOptions) processUpdates(ctx context.Context, latestVersions m
 			return err
 		}
 
-		fsys := rwfsOS.DirFS(tempDir)
-		index, err := wolfibuild.NewIndexFromPaths(fsys, []string{packageName + yamlExtension}...)
-		if err != nil {
-			return err
-		}
-		s := index.Select().WhereName(packageName)
-		pipelineSectionUpdater := wolfibuild.NewPipelineSectionUpdater(func(cfg config.Configuration) ([]config.Pipeline, error) {
-			tidy := false
-			err := deps.CleanupGoBumpDeps(updated, tidy, mutations)
-			if err != nil {
-				return updated.Pipeline, err
+		// Skip any processing for definitions with a single pipeline
+		if len(updated.Pipeline) > 1 {
+			if err := o.updateGoBumpDeps(updated, o.Dir, packageName, mutations); err != nil {
+				return fmt.Errorf("error cleaning up go/bump deps: %v", err)
 			}
-			return updated.Pipeline, nil
-		})
-		if err != nil {
-			return err
-		}
-		err = s.Update(pipelineSectionUpdater)
-		if err != nil {
-			return err
 		}
 
 		// if manual update is expected then let's not try to validate pipelines
@@ -321,6 +304,34 @@ func (o CheckUpdateOptions) verifyFetch(p *config.Pipeline, m map[string]string)
 	o.Logger.Println(color.GreenString("fetch was successful"))
 
 	return os.RemoveAll(filename)
+}
+
+func (o *CheckUpdateOptions) updateGoBumpDeps(updated *config.Configuration, dir, packageName string, mutations map[string]string) error {
+	filename := fmt.Sprintf("%s.yaml", packageName)
+	yamlContent, err := os.ReadFile(filepath.Join(dir, filename))
+	if err != nil {
+		return err
+	}
+	var doc yaml.Node
+	err = yaml.Unmarshal(yamlContent, &doc)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling YAML: %v", err)
+	}
+	tidy := false
+	if err := deps.CleanupGoBumpDeps(&doc, updated, tidy, mutations); err != nil {
+		return err
+	}
+
+	modifiedYAML, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("error marshaling YAML: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, filename), modifiedYAML, 0o600); err != nil {
+		return fmt.Errorf("failed to write configuration file: %v", err)
+	}
+
+	return nil
 }
 
 func (o CheckUpdateOptions) verifyGitCheckout(p *config.Pipeline, m map[string]string) error {

--- a/pkg/update/deps/cleanup.go
+++ b/pkg/update/deps/cleanup.go
@@ -1,0 +1,228 @@
+package deps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/util"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"golang.org/x/exp/slices"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+)
+
+func gitCheckout(p *config.Pipeline, dir string, mutations map[string]string) error {
+	repoValue := p.With["repository"]
+	if repoValue == "" {
+		return fmt.Errorf("no repository to checkout")
+	}
+
+	tagValue := p.With["tag"]
+	if tagValue == "" {
+		return fmt.Errorf("no tag to checkout")
+	}
+
+	// evaluate var substitutions
+	evaluatedTag, err := util.MutateStringFromMap(mutations, tagValue)
+	if err != nil {
+		return err
+	}
+
+	cloneOpts := &git.CloneOptions{
+		URL:               repoValue,
+		ReferenceName:     plumbing.ReferenceName(fmt.Sprintf("refs/tags/%s", evaluatedTag)),
+		Progress:          os.Stdout,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+		RemoteName:        "origin",
+		Depth:             1,
+	}
+
+	log.Printf("cloning sources from %s tag %s into a temporary directory '%s', this may take a while", repoValue, dir, evaluatedTag)
+
+	r, err := git.PlainClone(dir, false, cloneOpts)
+	if err != nil {
+		return fmt.Errorf("failed to clone %s ref %s with error: %v", repoValue, evaluatedTag, err)
+	}
+	if r == nil {
+		return fmt.Errorf("clone is empty %s ref %s", repoValue, evaluatedTag)
+	}
+	log.Println("git-checkout was successful")
+
+	return nil
+}
+
+func cleanupGoBumpPipelineDeps(p *config.Pipeline, tempDir string, tidy bool) error {
+	modroot := ""
+	if _, ok := p.With["modroot"]; ok {
+		modroot = p.With["modroot"]
+	}
+	goVersion := ""
+	if _, ok := p.With["go-version"]; ok {
+		goVersion = p.With["go-version"]
+	}
+	if tidy {
+		output, err := goModTidy(path.Join(tempDir, modroot), goVersion)
+		if err != nil {
+			return fmt.Errorf("failed to run 'go mod tidy': %v with output: %v", err, output)
+		}
+	}
+	// Read the entire go.mod one more time into memory and check that all the version constraints are met.
+	modpath := path.Join(tempDir, modroot, "go.mod")
+	modFile, err := parseGoModfile(modpath)
+	if err != nil {
+		return fmt.Errorf("unable to parse the go mod file with error: %v", err)
+	}
+
+	replaces := []string{}
+	deps := []string{}
+	if len(p.With["replaces"]) > 0 {
+		replaces = strings.Split(p.With["replaces"], " ")
+	}
+	pkgReplaceVersions := map[string]string{}
+	for _, pkg := range replaces {
+		replacePkg := strings.Split(pkg, "=")
+		parts := strings.Split(replacePkg[1], "@")
+		pkgReplaceVersions[parts[0]] = parts[1]
+	}
+
+	if len(p.With["deps"]) > 0 {
+		deps = strings.Split(p.With["deps"], " ")
+	}
+
+	pkgRequireVersions := map[string]string{}
+	for _, pkg := range deps {
+		parts := strings.Split(pkg, "@")
+		pkgRequireVersions[parts[0]] = parts[1]
+	}
+
+	// Detect if the list of packages contain any replace statement
+	for _, replace := range modFile.Replace {
+		if replace != nil {
+			if _, ok := pkgRequireVersions[replace.New.Path]; ok {
+				if semver.IsValid(pkgRequireVersions[replace.New.Path]) {
+					if semver.Compare(replace.New.Version, pkgRequireVersions[replace.New.Path]) >= 0 {
+						idx := slices.Index(deps, fmt.Sprintf("%s=%s@%s", replace.New.Path, replace.New.Path, pkgRequireVersions[replace.New.Path]))
+						deps = append(deps[:idx], deps[idx+1:]...)
+					}
+				}
+			}
+			if _, ok := pkgReplaceVersions[replace.New.Path]; ok {
+				if semver.IsValid(pkgReplaceVersions[replace.New.Path]) {
+					if semver.Compare(replace.New.Version, pkgReplaceVersions[replace.New.Path]) >= 0 {
+						// TODO(hectorj2f): Assume that the source is the same
+						idx := slices.Index(replaces, fmt.Sprintf("%s=%s@%s", replace.New.Path, replace.New.Path, pkgReplaceVersions[replace.New.Path]))
+						replaces = append(replaces[:idx], replaces[idx+1:]...)
+					}
+				}
+			}
+		}
+	}
+	// Detect if the list of packages contain any require statement for the package
+	for _, require := range modFile.Require {
+		if require != nil {
+			if _, ok := pkgRequireVersions[require.Mod.Path]; ok {
+				if semver.IsValid(pkgRequireVersions[require.Mod.Path]) {
+					if semver.Compare(require.Mod.Version, pkgRequireVersions[require.Mod.Path]) >= 0 {
+						idx := slices.Index(deps, fmt.Sprintf("%s@%s", require.Mod.Path, pkgRequireVersions[require.Mod.Path]))
+						deps = append(deps[:idx], deps[idx+1:]...)
+					}
+				}
+			}
+			if _, ok := pkgReplaceVersions[require.Mod.Path]; ok {
+				if semver.IsValid(pkgReplaceVersions[require.Mod.Path]) {
+					if semver.Compare(require.Mod.Version, pkgReplaceVersions[require.Mod.Path]) >= 0 {
+						// TODO(hectorj2f): Assume that the source is the same
+						idx := slices.Index(replaces, fmt.Sprintf("%s=%s@%s", require.Mod.Path, require.Mod.Path, pkgReplaceVersions[require.Mod.Path]))
+						replaces = append(replaces[:idx], replaces[idx+1:]...)
+					}
+				}
+			}
+		}
+	}
+	if len(pkgRequireVersions) > 0 {
+		p.With["deps"] = strings.TrimSpace(strings.Join(deps, " "))
+	}
+
+	if len(pkgReplaceVersions) > 0 {
+		p.With["replaces"] = strings.TrimSpace(strings.Join(replaces, " "))
+	}
+
+	log.Printf("New [deps]: %v\n", p.With["deps"])
+	log.Printf("New [replaces]: %v\n", p.With["replaces"])
+
+	return nil
+}
+
+func CleanupGoBumpDeps(updated *config.Configuration, tidy bool, mutations map[string]string) error {
+	tempDir, err := os.MkdirTemp("", "wolfibump")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary folder to clone package configs into: %w", err)
+	}
+	checkedOut := false
+	for i := range updated.Pipeline {
+		// TODO(hectorj2f): add support for fetch pipelines
+		if updated.Pipeline[i].Uses == "git-checkout" {
+			err := gitCheckout(&updated.Pipeline[i], tempDir, mutations)
+			if err != nil {
+				return fmt.Errorf("failed to git checkout the repository: %v", err)
+			}
+			checkedOut = true
+		}
+		if checkedOut && updated.Pipeline[i].Uses == "go/bump" {
+			// get the go/bump pipeline
+			if err := cleanupGoBumpPipelineDeps(&updated.Pipeline[i], tempDir, tidy); err != nil {
+				return err
+			}
+			if updated.Pipeline[i].With["deps"] == "" && updated.Pipeline[i].With["replaces"] == "" {
+				log.Printf("deleting the pipeline: %v", updated.Pipeline[i])
+				updated.Pipeline = slices.Delete(updated.Pipeline, i, (i + 1))
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseGoModfile(file string) (*modfile.File, error) {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	mod, err := modfile.Parse("go.mod", content, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return mod, nil
+}
+
+func goModTidy(modroot, goVersion string) (string, error) {
+	if goVersion == "" {
+		cmd := exec.Command("go", "env", "GOVERSION")
+		cmd.Stderr = os.Stderr
+		out, err := cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("%v: %w", cmd, err)
+		}
+		goVersion = strings.TrimPrefix(strings.TrimSpace(string(out)), "go")
+
+		v := versionutil.MustParseGeneric(goVersion)
+		goVersion = fmt.Sprintf("%d.%d", v.Major(), v.Minor())
+
+		log.Printf("Running go mod tidy with go version '%s' ...\n", goVersion)
+	}
+
+	cmd := exec.Command("go", "mod", "tidy", "-go", goVersion)
+	cmd.Dir = modroot
+	if bytes, err := cmd.CombinedOutput(); err != nil {
+		return strings.TrimSpace(string(bytes)), err
+	}
+	return "", nil
+}

--- a/pkg/update/deps/cleanup_test.go
+++ b/pkg/update/deps/cleanup_test.go
@@ -1,0 +1,194 @@
+package deps
+
+import (
+	"testing"
+
+	"chainguard.dev/melange/pkg/config"
+)
+
+func TestFixedDepsList(t *testing.T) {
+	testcases := []struct {
+		name                 string
+		cfg                  *config.Configuration
+		wantDeps             string
+		wantReplaces         string
+		removeGoBumpPipeline bool
+	}{{
+		name:     "remove the old crypto dependency",
+		wantDeps: "github.com/pkg/errors@v10.10.10",
+		cfg: &config.Configuration{
+			Pipeline: []config.Pipeline{
+				{
+					Uses: "git-checkout",
+					With: map[string]string{
+						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
+						"tag":             "v16.7.3",
+						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
+					},
+				},
+				{
+					Uses: "go/bump",
+					With: map[string]string{
+						"deps": "golang.org/x/crypto@v0.14.0 github.com/pkg/errors@v10.10.10",
+					},
+				},
+			},
+			Subpackages: []config.Subpackage{{
+				Name: "cats",
+				Pipeline: []config.Pipeline{{
+					Runs: "cats are angry",
+				}},
+			}},
+		},
+	}, {
+		name:     "cleanup deps",
+		wantDeps: "",
+		cfg: &config.Configuration{
+			Pipeline: []config.Pipeline{
+				{
+					Uses: "git-checkout",
+					With: map[string]string{
+						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
+						"tag":             "v16.7.3",
+						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
+					},
+				},
+				{
+					Uses: "go/bump",
+					With: map[string]string{
+						"deps":     "golang.org/x/crypto@v0.14.0",
+						"replaces": "github.com/namsral/flag=github.com/namsral/flag@v100.100.100",
+					},
+				},
+			},
+			Subpackages: []config.Subpackage{{
+				Name: "cats",
+				Pipeline: []config.Pipeline{{
+					Runs: "cats are angry",
+				}},
+			}},
+		},
+	}, {
+		name:         "cleanup replaces",
+		wantDeps:     "github.com/pkg/errors@v10.10.10",
+		wantReplaces: "github.com/namsral/flag=github.com/namsral/flag@v100.100.100",
+		cfg: &config.Configuration{
+			Pipeline: []config.Pipeline{
+				{
+					Uses: "git-checkout",
+					With: map[string]string{
+						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
+						"tag":             "v16.7.3",
+						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
+					},
+				},
+				{
+					Uses: "go/bump",
+					With: map[string]string{
+						"deps":     "github.com/pkg/errors@v10.10.10",
+						"replaces": "golang.org/x/crypto=golang.org/x/crypto@v0.14.0 github.com/namsral/flag=github.com/namsral/flag@v100.100.100",
+					},
+				},
+			},
+			Subpackages: []config.Subpackage{{
+				Name: "cats",
+				Pipeline: []config.Pipeline{{
+					Runs: "cats are angry",
+				}},
+			}},
+		},
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CleanupGoBumpDeps(tc.cfg, false, map[string]string{})
+			if err != nil {
+				t.Fatalf("failed to cleanup go bump deps: %v", err)
+			}
+			if tc.cfg.Pipeline[1].With["deps"] != tc.wantDeps {
+				t.Errorf("expect '%s', got '%s'", tc.wantDeps, tc.cfg.Pipeline[1].With["deps"])
+			}
+			if tc.wantReplaces != "" {
+				if tc.cfg.Pipeline[1].With["replaces"] != tc.wantReplaces {
+					t.Errorf("expect replaces '%s', got '%s'", tc.wantReplaces, tc.cfg.Pipeline[1].With["replaces"])
+				}
+			}
+		})
+	}
+}
+
+func TestRemovalGoBumpPipeline(t *testing.T) {
+	testcases := []struct {
+		name                 string
+		cfg                  *config.Configuration
+		removeGoBumpPipeline bool
+	}{{
+		name:                 "cleanup gobump, empty deps",
+		removeGoBumpPipeline: true,
+		cfg: &config.Configuration{
+			Pipeline: []config.Pipeline{
+				{
+					Uses: "git-checkout",
+					With: map[string]string{
+						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
+						"tag":             "v16.7.3",
+						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
+					},
+				},
+				{
+					Uses: "go/bump",
+					With: map[string]string{
+						"deps": "golang.org/x/crypto@v0.14.0",
+					},
+				},
+			},
+			Subpackages: []config.Subpackage{{
+				Name: "cats",
+				Pipeline: []config.Pipeline{{
+					Runs: "cats are angry",
+				}},
+			}},
+		},
+	}, {
+		name:                 "cleanup gobump, empty replaces",
+		removeGoBumpPipeline: true,
+		cfg: &config.Configuration{
+			Pipeline: []config.Pipeline{
+				{
+					Uses: "git-checkout",
+					With: map[string]string{
+						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
+						"tag":             "v16.7.3",
+						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
+					},
+				},
+				{
+					Uses: "go/bump",
+					With: map[string]string{
+						"replaces": "golang.org/x/crypto=golang.org/x/crypto@v0.14.0",
+					},
+				},
+			},
+			Subpackages: []config.Subpackage{{
+				Name: "cats",
+				Pipeline: []config.Pipeline{{
+					Runs: "cats are angry",
+				}},
+			}},
+		},
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			length := len(tc.cfg.Pipeline)
+			mutatations := map[string]string{}
+			err := CleanupGoBumpDeps(tc.cfg, false, mutatations)
+			if err != nil {
+				t.Fatalf("failed to cleanup go bump deps: %v", err)
+			}
+			if tc.removeGoBumpPipeline {
+				if len(tc.cfg.Pipeline) != (length - 1) {
+					t.Errorf("expected the configuration to remove the go/bump pipeline: %v", tc.cfg)
+				}
+			}
+		})
+	}
+}

--- a/pkg/update/deps/cleanup_test.go
+++ b/pkg/update/deps/cleanup_test.go
@@ -35,6 +35,9 @@ func TestCleanupDeps(t *testing.T) {
 	}, {
 		name:     "cleanup gobump, empty replaces",
 		filename: "config-5",
+	}, {
+		name:     "cleanup gobump and update another go/bump",
+		filename: "config-6",
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -89,7 +92,7 @@ func TestCleanupDeps(t *testing.T) {
 			require.NoError(t, err)
 
 			if diff := cmp.Diff(string(modifiedYAMLContent), string(expectedYAMLContent)); diff != "" {
-				t.Errorf("unexpected file modification results (-want, +got):\n%s\n GOTL %s", diff, string(modifiedYAMLContent))
+				t.Errorf("unexpected file modification results (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/update/deps/cleanup_test.go
+++ b/pkg/update/deps/cleanup_test.go
@@ -1,194 +1,103 @@
 package deps
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
+	melangebuild "chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
-func TestFixedDepsList(t *testing.T) {
+func TestCleanupDeps(t *testing.T) {
 	testcases := []struct {
-		name                 string
-		cfg                  *config.Configuration
-		wantDeps             string
-		wantReplaces         string
-		removeGoBumpPipeline bool
+		name        string
+		filename    string
+		expectedErr bool
 	}{{
-		name:     "remove the old crypto dependency",
-		wantDeps: "github.com/pkg/errors@v10.10.10",
-		cfg: &config.Configuration{
-			Pipeline: []config.Pipeline{
-				{
-					Uses: "git-checkout",
-					With: map[string]string{
-						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
-						"tag":             "v16.7.3",
-						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
-					},
-				},
-				{
-					Uses: "go/bump",
-					With: map[string]string{
-						"deps": "golang.org/x/crypto@v0.14.0 github.com/pkg/errors@v10.10.10",
-					},
-				},
-			},
-			Subpackages: []config.Subpackage{{
-				Name: "cats",
-				Pipeline: []config.Pipeline{{
-					Runs: "cats are angry",
-				}},
-			}},
-		},
+		name:     "update existing go/bump",
+		filename: "config-1",
 	}, {
-		name:     "cleanup deps",
-		wantDeps: "",
-		cfg: &config.Configuration{
-			Pipeline: []config.Pipeline{
-				{
-					Uses: "git-checkout",
-					With: map[string]string{
-						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
-						"tag":             "v16.7.3",
-						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
-					},
-				},
-				{
-					Uses: "go/bump",
-					With: map[string]string{
-						"deps":     "golang.org/x/crypto@v0.14.0",
-						"replaces": "github.com/namsral/flag=github.com/namsral/flag@v100.100.100",
-					},
-				},
-			},
-			Subpackages: []config.Subpackage{{
-				Name: "cats",
-				Pipeline: []config.Pipeline{{
-					Runs: "cats are angry",
-				}},
-			}},
-		},
+		name:     "add go/bump",
+		filename: "config-2",
 	}, {
-		name:         "cleanup replaces",
-		wantDeps:     "github.com/pkg/errors@v10.10.10",
-		wantReplaces: "github.com/namsral/flag=github.com/namsral/flag@v100.100.100",
-		cfg: &config.Configuration{
-			Pipeline: []config.Pipeline{
-				{
-					Uses: "git-checkout",
-					With: map[string]string{
-						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
-						"tag":             "v16.7.3",
-						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
-					},
-				},
-				{
-					Uses: "go/bump",
-					With: map[string]string{
-						"deps":     "github.com/pkg/errors@v10.10.10",
-						"replaces": "golang.org/x/crypto=golang.org/x/crypto@v0.14.0 github.com/namsral/flag=github.com/namsral/flag@v100.100.100",
-					},
-				},
-			},
-			Subpackages: []config.Subpackage{{
-				Name: "cats",
-				Pipeline: []config.Pipeline{{
-					Runs: "cats are angry",
-				}},
-			}},
-		},
+		name:     "add go/bump before go mod tidy",
+		filename: "config-3",
+	}, {
+		name:     "cleanup gobump, empty deps",
+		filename: "config-4",
+	}, {
+		name:     "cleanup gobump, empty replaces",
+		filename: "config-5",
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CleanupGoBumpDeps(tc.cfg, false, map[string]string{})
-			if err != nil {
-				t.Fatalf("failed to cleanup go bump deps: %v", err)
+			dir := "testdata"
+			tempDir := t.TempDir()
+			filename := fmt.Sprintf("%s.yaml", tc.filename)
+
+			copyFile(t, filepath.Join(dir, filename), tempDir)
+
+			yamlContent, err := os.ReadFile(filepath.Join(tempDir, filename))
+			require.NoError(t, err)
+
+			expectedYAMLContent, err := os.ReadFile(filepath.Join(dir, tc.filename+"_expected.yaml"))
+			require.NoError(t, err)
+
+			// now make sure update config is configured
+			updated, err := config.ParseConfiguration(context.Background(), filepath.Join(dir, filename))
+			require.NoError(t, err)
+
+			pctx := &melangebuild.PipelineBuild{
+				Build: &melangebuild.Build{
+					Configuration: *updated,
+				},
+				Package: &updated.Package,
 			}
-			if tc.cfg.Pipeline[1].With["deps"] != tc.wantDeps {
-				t.Errorf("expect '%s', got '%s'", tc.wantDeps, tc.cfg.Pipeline[1].With["deps"])
+
+			// get a map of variable mutations we can substitute vars in URLs
+			mutations, err := melangebuild.MutateWith(pctx, map[string]string{})
+			require.NoError(t, err)
+
+			var doc yaml.Node
+			err = yaml.Unmarshal(yamlContent, &doc)
+			require.NoError(t, err)
+
+			err = CleanupGoBumpDeps(&doc, updated, true, mutations)
+			if tc.expectedErr && err == nil {
+				t.Errorf("expected error")
+			} else if err != nil && !tc.expectedErr {
+				t.Fatal(err)
 			}
-			if tc.wantReplaces != "" {
-				if tc.cfg.Pipeline[1].With["replaces"] != tc.wantReplaces {
-					t.Errorf("expect replaces '%s', got '%s'", tc.wantReplaces, tc.cfg.Pipeline[1].With["replaces"])
-				}
+			modifiedYAML, err := yaml.Marshal(&doc)
+			require.NoError(t, err)
+
+			if err := os.WriteFile(filepath.Join(tempDir, filename), modifiedYAML, 0o600); err != nil {
+				t.Errorf("failed to write file: %v", err)
+			}
+
+			err = formatConfigurationFile(tempDir, filename)
+			require.NoError(t, err)
+
+			modifiedYAMLContent, err := os.ReadFile(filepath.Join(tempDir, filename))
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(string(modifiedYAMLContent), string(expectedYAMLContent)); diff != "" {
+				t.Errorf("unexpected file modification results (-want, +got):\n%s\n GOTL %s", diff, string(modifiedYAMLContent))
 			}
 		})
 	}
 }
-
-func TestRemovalGoBumpPipeline(t *testing.T) {
-	testcases := []struct {
-		name                 string
-		cfg                  *config.Configuration
-		removeGoBumpPipeline bool
-	}{{
-		name:                 "cleanup gobump, empty deps",
-		removeGoBumpPipeline: true,
-		cfg: &config.Configuration{
-			Pipeline: []config.Pipeline{
-				{
-					Uses: "git-checkout",
-					With: map[string]string{
-						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
-						"tag":             "v16.7.3",
-						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
-					},
-				},
-				{
-					Uses: "go/bump",
-					With: map[string]string{
-						"deps": "golang.org/x/crypto@v0.14.0",
-					},
-				},
-			},
-			Subpackages: []config.Subpackage{{
-				Name: "cats",
-				Pipeline: []config.Pipeline{{
-					Runs: "cats are angry",
-				}},
-			}},
-		},
-	}, {
-		name:                 "cleanup gobump, empty replaces",
-		removeGoBumpPipeline: true,
-		cfg: &config.Configuration{
-			Pipeline: []config.Pipeline{
-				{
-					Uses: "git-checkout",
-					With: map[string]string{
-						"repository":      "https://gitlab.com/gitlab-org/gitlab-pages.git",
-						"tag":             "v16.7.3",
-						"expected-commit": "135ee38d50c2973c4a6c559b19b417af29465648",
-					},
-				},
-				{
-					Uses: "go/bump",
-					With: map[string]string{
-						"replaces": "golang.org/x/crypto=golang.org/x/crypto@v0.14.0",
-					},
-				},
-			},
-			Subpackages: []config.Subpackage{{
-				Name: "cats",
-				Pipeline: []config.Pipeline{{
-					Runs: "cats are angry",
-				}},
-			}},
-		},
-	}}
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			length := len(tc.cfg.Pipeline)
-			mutatations := map[string]string{}
-			err := CleanupGoBumpDeps(tc.cfg, false, mutatations)
-			if err != nil {
-				t.Fatalf("failed to cleanup go bump deps: %v", err)
-			}
-			if tc.removeGoBumpPipeline {
-				if len(tc.cfg.Pipeline) != (length - 1) {
-					t.Errorf("expected the configuration to remove the go/bump pipeline: %v", tc.cfg)
-				}
-			}
-		})
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	_, err := exec.Command("cp", "-r", src, dst).Output()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/update/deps/testdata/config-1.yaml
+++ b/pkg/update/deps/testdata/config-1.yaml
@@ -1,0 +1,46 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.14.0 github.com/pkg/errors@v10.10.10
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-1_expected.yaml
+++ b/pkg/update/deps/testdata/config-1_expected.yaml
@@ -1,0 +1,46 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      deps: github.com/pkg/errors@v10.10.10
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-2.yaml
+++ b/pkg/update/deps/testdata/config-2.yaml
@@ -1,0 +1,47 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.14.0
+      replaces: github.com/namsral/flag=github.com/namsral/flag@v100.100.100
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-2_expected.yaml
+++ b/pkg/update/deps/testdata/config-2_expected.yaml
@@ -1,0 +1,46 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      replaces: github.com/namsral/flag=github.com/namsral/flag@v100.100.100
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-3.yaml
+++ b/pkg/update/deps/testdata/config-3.yaml
@@ -1,0 +1,47 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      deps: github.com/pkg/errors@v10.10.10
+      replaces: golang.org/x/crypto=golang.org/x/crypto@v0.14.0 github.com/namsral/flag=github.com/namsral/flag@v100.100.100
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-3_expected.yaml
+++ b/pkg/update/deps/testdata/config-3_expected.yaml
@@ -1,0 +1,47 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      deps: github.com/pkg/errors@v10.10.10
+      replaces: github.com/namsral/flag=github.com/namsral/flag@v100.100.100
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-4.yaml
+++ b/pkg/update/deps/testdata/config-4.yaml
@@ -1,0 +1,46 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.14.0
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-4_expected.yaml
+++ b/pkg/update/deps/testdata/config-4_expected.yaml
@@ -1,0 +1,42 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-5.yaml
+++ b/pkg/update/deps/testdata/config-5.yaml
@@ -1,0 +1,46 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      replaces: golang.org/x/crypto=golang.org/x/crypto@v0.14.0
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-5_expected.yaml
+++ b/pkg/update/deps/testdata/config-5_expected.yaml
@@ -1,0 +1,42 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-6.yaml
+++ b/pkg/update/deps/testdata/config-6.yaml
@@ -1,0 +1,51 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - uses: go/bump
+    with:
+      replaces: golang.org/x/crypto=golang.org/x/crypto@v0.14.0
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: go/bump
+    with:
+      deps: github.com/pkg/errors@v10.10.10
+      replaces: golang.org/x/crypto=golang.org/x/crypto@v0.14.0 github.com/namsral/flag=github.com/namsral/flag@v100.100.100
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037

--- a/pkg/update/deps/testdata/config-6_expected.yaml
+++ b/pkg/update/deps/testdata/config-6_expected.yaml
@@ -1,0 +1,47 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-pages
+  version: 16.7.3
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: 135ee38d50c2973c4a6c559b19b417af29465648
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: go/bump
+    with:
+      deps: github.com/pkg/errors@v10.10.10
+      replaces: github.com/namsral/flag=github.com/namsral/flag@v100.100.100
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10037


### PR DESCRIPTION
I’ve coded over the weekend an extension to our `wolfictl update package` command to cleanup go/bump dependencies or even to remove that pipeline if it is not needed anymore. 

This feature reuses the changes to update a package (new tag, repo, ...) and pulls the repository/tag looking for a go.mod file. Once it finds the go.mod file, it verifies whether the go/bump deps can be removed from the list based on the existing deps included in this new version of the package. 

**This feature will help us to keep our Wolfi definitions clean without manual intervention.**

NOTE: this feat only supports package updates where we use `git-checkout` pipelines.

I share here a [PR](https://github.com/hectorj2f/os/pull/31/files) where the `go/bump` dep is removed because the upstream new version of the package already includes that dependency.

This feature doesn't use the locks files or rebase mechanism yet, as suggested in a different proposal.