### PR TITLE
bump deps, use slog and clog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/adrg/xdg v0.4.0
 	github.com/anchore/grype v0.74.0
 	github.com/anchore/syft v0.100.0
+	github.com/chainguard-dev/clog v1.2.3-0.20240116182827-04bee692f7a8
 	github.com/chainguard-dev/go-apk v0.0.0-20240116193855-4c76fbe27ad7
 	github.com/chainguard-dev/yam v0.0.0-20231106172656-25546e2ce3e3
 	github.com/charmbracelet/bubbles v0.17.1
@@ -32,7 +33,6 @@ require (
 	github.com/package-url/packageurl-go v0.1.2
 	github.com/samber/lo v1.39.0
 	github.com/savioxavier/termlink v1.3.0
-	github.com/sirupsen/logrus v1.9.3
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -86,7 +86,6 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar/v2 v2.0.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
-	github.com/chainguard-dev/clog v1.2.3-0.20240116182827-04bee692f7a8 // indirect
 	github.com/chainguard-dev/go-pkgconfig v0.0.0-20230905070237-e8c268e1732e // indirect
 	github.com/chainguard-dev/kontext v0.1.0 // indirect
 	github.com/cli/safeexec v1.0.0 // indirect
@@ -248,6 +247,7 @@ require (
 	github.com/sigstore/cosign/v2 v2.2.1 // indirect
 	github.com/sigstore/rekor v1.3.3 // indirect
 	github.com/sigstore/sigstore v1.7.5 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spdx/tools-golang v0.5.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,16 @@
 module github.com/wolfi-dev/wolfictl
 
-go 1.21.1
+go 1.21.2
+
+toolchain go1.21.5
 
 require (
-	chainguard.dev/apko v0.13.3
-	chainguard.dev/melange v0.5.5
+	chainguard.dev/apko v0.13.4-0.20240116200834-c10dc551b827
+	chainguard.dev/melange v0.5.6-0.20240116222011-34a2130156b4
 	github.com/adrg/xdg v0.4.0
 	github.com/anchore/grype v0.74.0
 	github.com/anchore/syft v0.100.0
-	github.com/chainguard-dev/go-apk v0.0.0-20231218235333-2acefacd5846
+	github.com/chainguard-dev/go-apk v0.0.0-20240116193855-4c76fbe27ad7
 	github.com/chainguard-dev/yam v0.0.0-20231106172656-25546e2ce3e3
 	github.com/charmbracelet/bubbles v0.17.1
 	github.com/charmbracelet/bubbletea v0.25.0
@@ -84,6 +86,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar/v2 v2.0.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
+	github.com/chainguard-dev/clog v1.2.3-0.20240116182827-04bee692f7a8 // indirect
 	github.com/chainguard-dev/go-pkgconfig v0.0.0-20230905070237-e8c268e1732e // indirect
 	github.com/chainguard-dev/kontext v0.1.0 // indirect
 	github.com/cli/safeexec v1.0.0 // indirect
@@ -159,6 +162,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.7.3 // indirect
+	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
@@ -182,7 +186,6 @@ require (
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d // indirect
 	github.com/knqyf263/go-rpmdb v0.0.0-20230301153543-ba94b245509b // indirect
-	github.com/korovkin/limiter v0.0.0-20230307205149-3d4b2b34c99d // indirect
 	github.com/letsencrypt/boulder v0.0.0-20231130210859-6445feb96b98 // indirect
 	github.com/lima-vm/go-qcow2reader v0.1.1 // indirect
 	github.com/lima-vm/lima v0.19.1 // indirect
@@ -276,7 +279,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/build v0.0.0-20231201193718-2d1c9af824e6 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-chainguard.dev/apko v0.13.3 h1:UWejRRhoK8qbdhmBsw0Se8V1hdUrf2K1gC46yZYJsVM=
-chainguard.dev/apko v0.13.3/go.mod h1:gK9AnuqgbHVVdslgOjq5sHDz/n9Pf2ND/rTpm9Vbyb8=
-chainguard.dev/melange v0.5.5 h1:5w2nRu4b39iHHKiOdR4EFMTliltteDbg7FMHTGsfJDg=
-chainguard.dev/melange v0.5.5/go.mod h1:TUlU/BwGkyWHgSpRQDunNuEy6wWFjGaI+uEhikGP80w=
+chainguard.dev/apko v0.13.4-0.20240116200834-c10dc551b827 h1:O5FUsm7JVXKlWGS2UrgP7A8HlEKoH0fLtuiV6rQ7KEs=
+chainguard.dev/apko v0.13.4-0.20240116200834-c10dc551b827/go.mod h1:6WRsohsp9hXU2J7LTxOmplw28L6fYEcdjZLNR6BiYKU=
+chainguard.dev/melange v0.5.6-0.20240116222011-34a2130156b4 h1:BkDqkZkWbIg7U7nZsBO5J0t0flKVzg7s1D3ZFxSE3PI=
+chainguard.dev/melange v0.5.6-0.20240116222011-34a2130156b4/go.mod h1:3KNCNL1kAcCD+Xrm3JVCdimoitS4M5ZiD6NTm0WNAyY=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -301,8 +301,10 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chainguard-dev/go-apk v0.0.0-20231218235333-2acefacd5846 h1:5IIBDHIW3qkVVYtwOK6Lsx/loxl+2lHXisPCKGrwBk8=
-github.com/chainguard-dev/go-apk v0.0.0-20231218235333-2acefacd5846/go.mod h1:y0BbOQALsoi1T2Lt5KmFNn92G+fRFSUuogQI2171HS8=
+github.com/chainguard-dev/clog v1.2.3-0.20240116182827-04bee692f7a8 h1:E2y3L/nM7vRzwyROQgmuB+Egm/d1rHOyip0Bq4AyVow=
+github.com/chainguard-dev/clog v1.2.3-0.20240116182827-04bee692f7a8/go.mod h1:cV516KZWqYc/phZsCNwF36u/KMGS+Gj5Uqeb8Hlp95Y=
+github.com/chainguard-dev/go-apk v0.0.0-20240116193855-4c76fbe27ad7 h1:lzVhpylUJwoA7eQN6X18ZZXPHovjVDDBXwQkg5qFM9k=
+github.com/chainguard-dev/go-apk v0.0.0-20240116193855-4c76fbe27ad7/go.mod h1:OdsmvVJb8RNVcTVQ7x07L319LLeiRaRnnsmj8qBBgb4=
 github.com/chainguard-dev/go-pkgconfig v0.0.0-20230905070237-e8c268e1732e h1:MiWG71ge3/KiR2fW9R8MFHck4NbCtuwD6NpOXcZQ1qo=
 github.com/chainguard-dev/go-pkgconfig v0.0.0-20230905070237-e8c268e1732e/go.mod h1:obzGv2cx3tkRgkLQADSPaRl3OEsYmyfSv7t2Wu60tZw=
 github.com/chainguard-dev/kontext v0.1.0 h1:GFnDRZiqa+anUi7tzZMECXr0nwt4Eo/zMzTQPLRXUIs=
@@ -786,8 +788,6 @@ github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d/go.mod h1:
 github.com/knqyf263/go-rpmdb v0.0.0-20230301153543-ba94b245509b h1:boYyvL3tbUuKcMN029mpCl7oYYJ7yIXujLj+fiW4Alc=
 github.com/knqyf263/go-rpmdb v0.0.0-20230301153543-ba94b245509b/go.mod h1:9LQcoMCMQ9vrF7HcDtXfvqGO4+ddxFQ8+YF/0CVGDww=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/korovkin/limiter v0.0.0-20230307205149-3d4b2b34c99d h1:7CfsXfFpCG1wrUpuyOzG8+vpL1ZqH2goz23wZ9pboGE=
-github.com/korovkin/limiter v0.0.0-20230307205149-3d4b2b34c99d/go.mod h1:3NeYeWwAOTnDChps1fD7YGD/uWzp+tqmShgjhhMIHDM=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -1103,6 +1103,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
@@ -1214,8 +1215,6 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
-golang.org/x/build v0.0.0-20231201193718-2d1c9af824e6 h1:KPswmKUijLSQWhbhSDk0oTAoFe7izYWSV6/kIC74dMY=
-golang.org/x/build v0.0.0-20231201193718-2d1c9af824e6/go.mod h1:dYD00ZPoQHK4GMm3QX05aTutZAk8hP43zHq62Wmljdk=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
+	"log"
+
 	"github.com/wolfi-dev/wolfictl/pkg/cli"
 )
 

--- a/pkg/advisory/validate.go
+++ b/pkg/advisory/validate.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"chainguard.dev/melange/pkg/config"
+	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/go-apk/pkg/apk"
+	"github.com/saferwall/pe/log"
 	"github.com/samber/lo"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
@@ -55,13 +56,10 @@ type ValidateOptions struct {
 	// validating the advisories. This gets computed dynamically using APKIndex
 	// before validation happens.
 	apkIndexPackageMap map[string][]*apk.Package
-
-	// Logger is the logger to use during validation. A logger must always be
-	// provided.
-	Logger *slog.Logger
 }
 
 func Validate(ctx context.Context, opts ValidateOptions) error {
+	log := clog.FromContext(ctx)
 	opts.distroPackageMap = opts.createDistroPackageMap()
 	opts.apkIndexPackageMap = opts.createAPKIndexPackageMap()
 
@@ -86,19 +84,19 @@ func Validate(ctx context.Context, opts ValidateOptions) error {
 		diff := IndexDiff(opts.BaseAdvisoryDocs, opts.AdvisoryDocs)
 		errs = append(errs, opts.validateIndexDiff(diff))
 	} else {
-		opts.Logger.Info("skipping validation of index diff, no comparison basis provided")
+		log.Info("skipping validation of index diff, no comparison basis provided")
 	}
 
 	if opts.APKIndex != nil {
-		errs = append(errs, opts.validateFixedVersions())
+		errs = append(errs, opts.validateFixedVersions(ctx))
 	} else {
-		opts.Logger.Info("skipping validation of fixed versions, no APKINDEX provided")
+		log.Info("skipping validation of fixed versions, no APKINDEX provided")
 	}
 
 	if opts.AliasFinder != nil {
 		errs = append(errs, opts.validateAliasSetCompleteness(ctx))
 	} else {
-		opts.Logger.Info("skipping validation of alias set completeness, no alias finder provided")
+		log.Info("skipping validation of alias set completeness, no alias finder provided")
 	}
 
 	return errors.Join(errs...)
@@ -134,24 +132,25 @@ func (opts ValidateOptions) createAPKIndexPackageMap() map[string][]*apk.Package
 	return pkgMap
 }
 
-func (opts ValidateOptions) validateFixedVersions() error {
+func (opts ValidateOptions) validateFixedVersions(ctx context.Context) error {
+	log := clog.FromContext(ctx)
 	if opts.APKIndex == nil {
 		// Not enough input information to drive this validation check.
-		opts.Logger.Warn("not validating fixed versions, no APKINDEX provided")
+		log.Warn("not validating fixed versions, no APKINDEX provided")
 		return nil
 	}
 
 	var errs []error
 
 	documents := opts.AdvisoryDocs.Select().Configurations()
-	opts.Logger.Debug(
+	log.Debug(
 		"validating fixed versions",
 		"indexPackageCount",
 		len(opts.APKIndex.Packages),
 		"documentCount",
 		len(documents),
 	)
-	opts.Logger.Info("validating fixed versions")
+	log.Info("validating fixed versions")
 	for i := range documents {
 		doc := documents[i]
 
@@ -164,7 +163,7 @@ func (opts ValidateOptions) validateFixedVersions() error {
 
 		var docErrs []error
 
-		opts.Logger.Debug(
+		log.Debug(
 			"checking advisories",
 			"documentName",
 			doc.Name(),
@@ -175,7 +174,7 @@ func (opts ValidateOptions) validateFixedVersions() error {
 			adv := doc.Advisories[i]
 			var advErrs []error
 
-			opts.Logger.Debug("checking events", "advisory", adv.ID, "eventCount", len(adv.Events))
+			log.Debug("checking events", "advisory", adv.ID, "eventCount", len(adv.Events))
 			for i := range adv.Events {
 				event := adv.Events[i]
 
@@ -255,10 +254,10 @@ func (opts ValidateOptions) validateBuildConfigurationOrAPKIndexEntryExistence(p
 }
 
 func (opts ValidateOptions) validatePackageVersionExistsInAPKINDEX(pkgName, version string) error {
-	opts.Logger.Debug("validating package version existence in APKINDEX", "package", pkgName, "version", version)
+	log.Debug("validating package version existence in APKINDEX", "package", pkgName, "version", version)
 	if opts.APKIndex == nil {
 		// Not enough input information to drive this validation check.
-		opts.Logger.Warn("not validating package version existence, no APKINDEX provided")
+		log.Warn("not validating package version existence, no APKINDEX provided")
 		return nil
 	}
 
@@ -275,7 +274,7 @@ func (opts ValidateOptions) validatePackageVersionExistsInAPKINDEX(pkgName, vers
 
 	for _, pkg := range opts.apkIndexPackageMap[pkgName] {
 		if pkg.Version == version {
-			opts.Logger.Debug(
+			log.Debug(
 				"package version found in APKINDEX",
 				"package",
 				pkgName,
@@ -292,7 +291,7 @@ func (opts ValidateOptions) validatePackageVersionExistsInAPKINDEX(pkgName, vers
 func (opts ValidateOptions) validateFixedVersionIsNotFirstVersionInAPKINDEX(pkgName, version string) error {
 	if opts.APKIndex == nil {
 		// Not enough input information to drive this validation check.
-		opts.Logger.Warn("not validating fixed version is not first version, no APKINDEX provided")
+		log.Warn("not validating fixed version is not first version, no APKINDEX provided")
 		return nil
 	}
 
@@ -339,7 +338,7 @@ func (opts ValidateOptions) validateFixedVersionIsNotFirstVersionInAPKINDEX(pkgN
 }
 
 func (opts ValidateOptions) validateAliasSetCompleteness(ctx context.Context) error {
-	opts.Logger.Info("validating alias set completeness")
+	log.Info("validating alias set completeness")
 
 	var errs []error
 
@@ -392,7 +391,7 @@ func (opts ValidateOptions) validateAliasSetCompleteness(ctx context.Context) er
 }
 
 func (opts ValidateOptions) validateIndexDiff(diff IndexDiffResult) error {
-	opts.Logger.Info("validating index diff", "diffIsZero", diff.IsZero())
+	log.Info("validating index diff", "diffIsZero", diff.IsZero())
 
 	var errs []error
 

--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -2,8 +2,6 @@ package advisory
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,8 +13,6 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/configs/build"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 )
-
-var testLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 func TestValidate(t *testing.T) {
 	// The diff validation tests use the test fixtures for advisory.IndexDiff.
@@ -79,7 +75,6 @@ func TestValidate(t *testing.T) {
 					AdvisoryDocs:     bIndex,
 					BaseAdvisoryDocs: aIndex,
 					Now:              now,
-					Logger:           testLogger,
 				})
 				if tt.shouldBeValid && err != nil {
 					t.Errorf("should be valid but got error: %v", err)
@@ -202,7 +197,6 @@ func TestValidate(t *testing.T) {
 						Now:                   now,
 						PackageConfigurations: tt.packageCfgsFunc(t),
 						APKIndex:              tt.apkindex,
-						Logger:                testLogger,
 					})
 					if tt.shouldBeValid && err != nil {
 						t.Errorf("should be valid but got error: %v", err)
@@ -253,7 +247,6 @@ func TestValidate(t *testing.T) {
 				err = Validate(context.Background(), ValidateOptions{
 					AdvisoryDocs: index,
 					AliasFinder:  mockAF,
-					Logger:       testLogger,
 				})
 				if tt.shouldBeValid && err != nil {
 					t.Errorf("should be valid but got error: %v", err)
@@ -331,7 +324,6 @@ func TestValidate(t *testing.T) {
 					err = Validate(context.Background(), ValidateOptions{
 						AdvisoryDocs: index,
 						APKIndex:     tt.apkindex,
-						Logger:       testLogger,
 					})
 					if tt.shouldBeValid && err != nil {
 						t.Errorf("should be valid but got error: %v", err)

--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -45,14 +45,14 @@ func SetupUpdate() (*update.Options, lint.EvalRuleErrors) {
 }
 
 // CheckUpdates will use the melange update config to get the latest versions and validate fetch and git-checkout pipelines
-func (o CheckUpdateOptions) CheckUpdates(files []string) error {
+func (o CheckUpdateOptions) CheckUpdates(ctx context.Context, files []string) error {
 	updateOpts, checkErrors := SetupUpdate()
 
 	changedPackages := GetPackagesToUpdate(files)
 
-	validateUpdateConfig(changedPackages, &checkErrors)
+	validateUpdateConfig(ctx, changedPackages, &checkErrors)
 
-	latestVersions, err := updateOpts.GetLatestVersions(o.Dir, changedPackages)
+	latestVersions, err := updateOpts.GetLatestVersions(ctx, o.Dir, changedPackages)
 	if err != nil {
 		addCheckError(&checkErrors, err)
 	}
@@ -60,11 +60,11 @@ func (o CheckUpdateOptions) CheckUpdates(files []string) error {
 	handleErrorMessages(updateOpts, &checkErrors)
 
 	if o.OverrideVersion == "" {
-		o.checkForLatestVersions(latestVersions, &checkErrors)
+		o.checkForLatestVersions(ctx, latestVersions, &checkErrors)
 	}
 
 	if len(checkErrors) == 0 {
-		err := o.processUpdates(latestVersions, &checkErrors)
+		err := o.processUpdates(ctx, latestVersions, &checkErrors)
 		if err != nil {
 			addCheckError(&checkErrors, err)
 		}
@@ -76,7 +76,7 @@ func (o CheckUpdateOptions) CheckUpdates(files []string) error {
 const yamlExtension = ".yaml"
 
 // validates update configuration
-func validateUpdateConfig(files []string, checkErrors *lint.EvalRuleErrors) {
+func validateUpdateConfig(ctx context.Context, files []string, checkErrors *lint.EvalRuleErrors) {
 	for _, file := range files {
 		// skip hidden files
 		if strings.HasPrefix(file, ".") {
@@ -112,7 +112,7 @@ func validateUpdateConfig(files []string, checkErrors *lint.EvalRuleErrors) {
 		}
 
 		// now make sure update config is configured
-		c, err := config.ParseConfiguration(file)
+		c, err := config.ParseConfiguration(ctx, file)
 		if err != nil {
 			addCheckError(checkErrors, fmt.Errorf("failed to parse %s: %w", file, err))
 			continue
@@ -161,9 +161,9 @@ func handleErrorMessages(updateOpts *update.Options, checkErrors *lint.EvalRuleE
 }
 
 // check if the current package.version is the latest according to the update config
-func (o CheckUpdateOptions) checkForLatestVersions(latestVersions map[string]update.NewVersionResults, checkErrors *lint.EvalRuleErrors) {
+func (o CheckUpdateOptions) checkForLatestVersions(ctx context.Context, latestVersions map[string]update.NewVersionResults, checkErrors *lint.EvalRuleErrors) {
 	for k, v := range latestVersions {
-		c, err := config.ParseConfiguration(filepath.Join(o.Dir, k+yamlExtension))
+		c, err := config.ParseConfiguration(ctx, filepath.Join(o.Dir, k+yamlExtension))
 		if err != nil {
 			addCheckError(checkErrors, err)
 			continue
@@ -186,7 +186,7 @@ func (o CheckUpdateOptions) checkForLatestVersions(latestVersions map[string]upd
 }
 
 // iterate over slice of packages, optionally override the package.version and verify fetch + git-checkout work with latest versions
-func (o CheckUpdateOptions) processUpdates(latestVersions map[string]update.NewVersionResults, checkErrors *lint.EvalRuleErrors) error {
+func (o CheckUpdateOptions) processUpdates(ctx context.Context, latestVersions map[string]update.NewVersionResults, checkErrors *lint.EvalRuleErrors) error {
 	tempDir, err := os.MkdirTemp("", "wolfictl")
 	if err != nil {
 		return err
@@ -197,7 +197,7 @@ func (o CheckUpdateOptions) processUpdates(latestVersions map[string]update.NewV
 	for packageName, newVersion := range latestVersions {
 		srcConfigFile := filepath.Join(o.Dir, packageName+yamlExtension)
 
-		dryRunConfig, err := config.ParseConfiguration(srcConfigFile)
+		dryRunConfig, err := config.ParseConfiguration(ctx, srcConfigFile)
 		if err != nil {
 			return err
 		}
@@ -215,13 +215,13 @@ func (o CheckUpdateOptions) processUpdates(latestVersions map[string]update.NewV
 		}
 
 		// melange bump will modify the modified copy of the melange config
-		err = melange.Bump(tmpConfigFile, newVersion.Version, newVersion.Commit)
+		err = melange.Bump(ctx, tmpConfigFile, newVersion.Version, newVersion.Commit)
 		if err != nil {
 			addCheckError(checkErrors, fmt.Errorf("package %s: failed to validate update config, melange bump: %w", packageName, err))
 			continue
 		}
 
-		updated, err := config.ParseConfiguration(tmpConfigFile)
+		updated, err := config.ParseConfiguration(ctx, tmpConfigFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/checks/update_test.go
+++ b/pkg/checks/update_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,7 @@ import (
 )
 
 func TestProcessUpdatesGitCheckout(t *testing.T) {
+	ctx := context.Background()
 	checkErrors := make(lint.EvalRuleErrors, 0)
 
 	newVersion := "9.8.7"
@@ -51,12 +53,13 @@ func TestProcessUpdatesGitCheckout(t *testing.T) {
 		Logger: log.New(log.Writer(), "test: ", log.LstdFlags|log.Lmsgprefix),
 	}
 
-	err = o.processUpdates(latestVersions, &checkErrors)
+	err = o.processUpdates(ctx, latestVersions, &checkErrors)
 	assert.NoError(t, err)
 	assert.Len(t, checkErrors, 0)
 }
 
 func TestProcessUpdatesFetch(t *testing.T) {
+	ctx := context.Background()
 	checkErrors := make(lint.EvalRuleErrors, 0)
 
 	newVersion := "9.8.7"
@@ -90,7 +93,7 @@ func TestProcessUpdatesFetch(t *testing.T) {
 		Logger: log.New(log.Writer(), "test: ", log.LstdFlags|log.Lmsgprefix),
 	}
 
-	err = o.processUpdates(latestVersions, &checkErrors)
+	err = o.processUpdates(ctx, latestVersions, &checkErrors)
 	assert.NoError(t, err)
 	assert.Len(t, checkErrors, 0)
 }
@@ -138,6 +141,7 @@ func createTestRepo(t *testing.T, dir, tag string) string {
 }
 
 func TestUpdateKeyExists(t *testing.T) {
+	ctx := context.Background()
 	dir := t.TempDir()
 	// create a temporary file with an update key
 	yamlData := []byte("package:\n  name: cheese\n  version: 1\nupdate:\n  manual: true\n")
@@ -149,7 +153,7 @@ func TestUpdateKeyExists(t *testing.T) {
 
 	checkErrors := make(lint.EvalRuleErrors, 0)
 	// check update key exists
-	validateUpdateConfig([]string{fileContainsUpdate}, &checkErrors)
+	validateUpdateConfig(ctx, []string{fileContainsUpdate}, &checkErrors)
 
 	assert.Empty(t, checkErrors)
 
@@ -165,6 +169,6 @@ func TestUpdateKeyExists(t *testing.T) {
 	}
 
 	// check the update key does not exist
-	validateUpdateConfig([]string{fileNoContainsUpdate}, &checkErrors)
+	validateUpdateConfig(ctx, []string{fileNoContainsUpdate}, &checkErrors)
 	assert.NotEmpty(t, checkErrors)
 }

--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"chainguard.dev/melange/pkg/config"
+	"github.com/chainguard-dev/clog"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
@@ -27,7 +28,7 @@ func cmdAdvisoryValidate() *cobra.Command {
 		Short: "Validate the state of advisory data",
 		Long: `Validate the state of the advisory data.
 
-This command examines all advisory documents to check the validity of the data. 
+This command examines all advisory documents to check the validity of the data.
 
 It looks for issues like:
 
@@ -58,7 +59,7 @@ specify the following flags:
 
 More information about these flags is shown in the documentation for each flag.
 
-If any issues are found in the advisory data, the command will exit 1, and will 
+If any issues are found in the advisory data, the command will exit 1, and will
 print an error message that specifies where and how the data is invalid.`,
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
@@ -69,7 +70,8 @@ print an error message that specifies where and how the data is invalid.`,
 			var packagesRepoDir string
 			var apkRepositoryURL string
 
-			logger := newLogger(p.verbosity)
+			logger := clog.NewLogger(newLogger(p.verbosity))
+			ctx := clog.WithLogger(cmd.Context(), logger)
 
 			if p.doNotDetectDistro {
 				logger.Debug("distro auto-detection disabled")
@@ -194,10 +196,9 @@ print an error message that specifies where and how the data is invalid.`,
 				AliasFinder:           af,
 				PackageConfigurations: packageConfigurationsIndex,
 				APKIndex:              apkIndex,
-				Logger:                logger,
 			}
 
-			validationErr := advisory.Validate(cmd.Context(), opts)
+			validationErr := advisory.Validate(ctx, opts)
 			if validationErr != nil {
 				fmt.Fprintf(
 					os.Stderr,

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -14,7 +14,6 @@ import (
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 
@@ -37,6 +36,7 @@ func cmdBuild() *cobra.Command {
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			log := clog.FromContext(ctx)
 
 			if jobs == 0 {
 				jobs = runtime.GOMAXPROCS(0)
@@ -66,7 +66,7 @@ func cmdBuild() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			g, err := dag.NewGraph(pkgs,
+			g, err := dag.NewGraph(ctx, pkgs,
 				dag.WithKeys(extraKeys...),
 				dag.WithRepos(extraRepos...))
 			if err != nil {
@@ -154,6 +154,7 @@ type task struct {
 }
 
 func (t *task) start(ctx context.Context) {
+	log := clog.FromContext(ctx).With("pkg", t.pkg)
 	log.Infof("task %q waiting on %q", t.pkg, maps.Keys(t.deps))
 
 	defer close(t.done) // signal that we're done, one way or another.

--- a/pkg/cli/bump.go
+++ b/pkg/cli/bump.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,6 +79,7 @@ modifying anything in the filesystem.
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			if len(args) == 0 {
 				cmd.Help() //nolint:errcheck
 				return fmt.Errorf("not enough arguments")
@@ -107,7 +109,7 @@ modifying anything in the filesystem.
 			}
 
 			for _, f := range files {
-				if err := bumpEpoch(opts, f); err != nil {
+				if err := bumpEpoch(ctx, opts, f); err != nil {
 					return err
 				}
 			}
@@ -122,8 +124,8 @@ modifying anything in the filesystem.
 	return cmd
 }
 
-func bumpEpoch(opts bumpOptions, path string) error {
-	cfg, err := config.ParseConfiguration(path)
+func bumpEpoch(ctx context.Context, opts bumpOptions, path string) error {
+	cfg, err := config.ParseConfiguration(ctx, path)
 	if err != nil {
 		return fmt.Errorf("unable to parse configuration at %q: %w", path, err)
 	}

--- a/pkg/cli/check_update.go
+++ b/pkg/cli/check_update.go
@@ -20,7 +20,7 @@ func CheckUpdate() *cobra.Command {
 		SilenceErrors:     true,
 		Short:             "Check Wolfi update configs",
 		RunE: func(cmd *cobra.Command, files []string) error {
-			return o.CheckUpdates(files)
+			return o.CheckUpdates(cmd.Context(), files)
 		},
 	}
 

--- a/pkg/cli/dot.go
+++ b/pkg/cli/dot.go
@@ -46,11 +46,12 @@ Open browser to explore crane's deps recursively, only showing a minimum subgrap
   wolfictl dot --web -R -S crane
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			if pipelineDir == "" {
 				pipelineDir = filepath.Join(dir, "pipelines")
 			}
 
-			pkgs, err := dag.NewPackages(os.DirFS(dir), dir, pipelineDir)
+			pkgs, err := dag.NewPackages(ctx, os.DirFS(dir), dir, pipelineDir)
 			if err != nil {
 				return fmt.Errorf("NewPackages: %w", err)
 			}

--- a/pkg/cli/dot.go
+++ b/pkg/cli/dot.go
@@ -56,7 +56,7 @@ Open browser to explore crane's deps recursively, only showing a minimum subgrap
 				return fmt.Errorf("NewPackages: %w", err)
 			}
 
-			g, err := dag.NewGraph(pkgs,
+			g, err := dag.NewGraph(ctx, pkgs,
 				dag.WithKeys(extraKeys...),
 				dag.WithRepos(extraRepos...),
 			)

--- a/pkg/cli/lint.go
+++ b/pkg/cli/lint.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ func cmdLint() *cobra.Command {
 			// args[0] can be used to get the path to the file to lint or `.` to lint the current directory
 			// what if given yaml is not Melange yaml?
 			o.args = args
-			return o.LintCmd()
+			return o.LintCmd(cmd.Context())
 		},
 	}
 	cmd.Flags().BoolVarP(&o.verbose, "verbose", "v", false, "verbose output")
@@ -38,7 +39,7 @@ func cmdLint() *cobra.Command {
 	return cmd
 }
 
-func (o lintOptions) LintCmd() error {
+func (o lintOptions) LintCmd(ctx context.Context) error {
 	linter := lint.New(o.makeLintOptions()...)
 
 	// If the list flag is set, print the list of available rules and exit.
@@ -48,7 +49,7 @@ func (o lintOptions) LintCmd() error {
 	}
 
 	// Run the linter.
-	result, err := linter.Lint()
+	result, err := linter.Lint(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -20,13 +20,14 @@ func cmdText() *cobra.Command {
 		Short: "Print a sorted list of downstream dependent packages",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 			if pipelineDir == "" {
 				pipelineDir = filepath.Join(dir, "pipelines")
 			}
 
 			arch := types.ParseArchitecture(arch).ToAPK()
 
-			pkgs, err := dag.NewPackages(os.DirFS(dir), dir, pipelineDir)
+			pkgs, err := dag.NewPackages(ctx, os.DirFS(dir), dir, pipelineDir)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -31,7 +31,7 @@ func cmdText() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			g, err := dag.NewGraph(pkgs,
+			g, err := dag.NewGraph(ctx, pkgs,
 				dag.WithKeys(extraKeys...),
 				dag.WithRepos(extraRepos...),
 				dag.WithArch(arch))

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -55,7 +55,7 @@ func cmdUpdate() *cobra.Command {
 	return cmd
 }
 
-func (o options) UpdateCmd(_ context.Context, repoURI string) error {
+func (o options) UpdateCmd(ctx context.Context, repoURI string) error {
 	updateContext := update.New()
 
 	if !o.dryRun {
@@ -79,7 +79,7 @@ func (o options) UpdateCmd(_ context.Context, repoURI string) error {
 	updateContext.IssueLabels = o.issueLabels
 	updateContext.MaxRetries = o.maxRetries
 	updateContext.PkgPath = o.pkgPath
-	if err := updateContext.Update(); err != nil {
+	if err := updateContext.Update(ctx); err != nil {
 		return fmt.Errorf("creating updates: %w", err)
 	}
 

--- a/pkg/cli/update_package.go
+++ b/pkg/cli/update_package.go
@@ -22,7 +22,7 @@ func Package() *cobra.Command {
 			}
 
 			o.PackageName = args[0]
-			return o.UpdatePackageCmd()
+			return o.UpdatePackageCmd(cmd.Context())
 		},
 	}
 

--- a/pkg/configs/build/build.go
+++ b/pkg/configs/build/build.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"io/fs"
 
 	"chainguard.dev/melange/pkg/config"
@@ -18,6 +19,7 @@ func NewIndexFromPaths(fsys rwfs.FS, paths ...string) (*configs.Index[config.Con
 
 func newConfigurationDecodeFunc(fsys fs.FS) func(string) (*config.Configuration, error) {
 	return func(path string) (*config.Configuration, error) {
-		return config.ParseConfiguration(path, config.WithFS(fsys))
+		ctx := context.Background()
+		return config.ParseConfiguration(ctx, path, config.WithFS(fsys))
 	}
 }

--- a/pkg/configs/index_test.go
+++ b/pkg/configs/index_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"context"
 	"testing"
 
 	"chainguard.dev/melange/pkg/config"
@@ -10,10 +11,11 @@ import (
 )
 
 func TestNewIndex(t *testing.T) {
+	ctx := context.Background()
 	fsys := rwos.DirFS("testdata/index-1")
 
 	index, err := NewIndex[config.Configuration](fsys, func(path string) (*config.Configuration, error) {
-		return config.ParseConfiguration(path, config.WithFS(fsys))
+		return config.ParseConfiguration(ctx, path, config.WithFS(fsys))
 	})
 	require.NoError(t, err)
 

--- a/pkg/dag/graph_test.go
+++ b/pkg/dag/graph_test.go
@@ -1,6 +1,7 @@
 package dag
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,13 +17,14 @@ const (
 
 func TestNewGraph(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
+		ctx := context.Background()
 		var (
 			testDir = "testdata/basic"
 		)
 		t.Run("allowed dangling", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
+			pkgs, err := NewPackages(ctx, os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
-			graph, err := NewGraph(pkgs, WithAllowUnresolved())
+			graph, err := NewGraph(ctx, pkgs, WithAllowUnresolved())
 			require.NoError(t, err)
 			amap, err := graph.Graph.AdjacencyMap()
 			require.NoError(t, err)
@@ -51,9 +53,9 @@ func TestNewGraph(t *testing.T) {
 			}
 		})
 		t.Run("has expected tree", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
+			pkgs, err := NewPackages(ctx, os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
-			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
+			graph, err := NewGraph(ctx, pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
 			amap, err := graph.Graph.AdjacencyMap()
 			require.NoError(t, err)
@@ -87,17 +89,18 @@ func TestNewGraph(t *testing.T) {
 		})
 	})
 	t.Run("complex", func(t *testing.T) {
+		ctx := context.Background()
 		var testDir = "testdata/complex"
 		t.Run("allowed dangling", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
+			pkgs, err := NewPackages(ctx, os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
-			_, err = NewGraph(pkgs, WithAllowUnresolved())
+			_, err = NewGraph(ctx, pkgs, WithAllowUnresolved())
 			require.NoError(t, err)
 		})
 		t.Run("external dependencies only", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
+			pkgs, err := NewPackages(ctx, os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
-			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
+			graph, err := NewGraph(ctx, pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
 			amap, err := graph.Graph.AdjacencyMap()
 			require.NoError(t, err)
@@ -130,9 +133,9 @@ func TestNewGraph(t *testing.T) {
 			}
 		})
 		t.Run("internal and external dependencies", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
+			pkgs, err := NewPackages(ctx, os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
-			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
+			graph, err := NewGraph(ctx, pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
 			amap, err := graph.Graph.AdjacencyMap()
 			require.NoError(t, err)
@@ -176,9 +179,9 @@ func TestNewGraph(t *testing.T) {
 		})
 
 		t.Run("internal dependencies numbered", func(t *testing.T) {
-			pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
+			pkgs, err := NewPackages(ctx, os.DirFS(testDir), testDir, "")
 			require.NoError(t, err)
-			graph, err := NewGraph(pkgs, WithRepos(packageRepo), WithKeys(key))
+			graph, err := NewGraph(ctx, pkgs, WithRepos(packageRepo), WithKeys(key))
 			require.NoError(t, err)
 			amap, err := graph.Graph.AdjacencyMap()
 			require.NoError(t, err)
@@ -226,6 +229,7 @@ func TestNewGraph(t *testing.T) {
 		})
 	})
 	t.Run("resolve cycle", func(t *testing.T) {
+		ctx := context.Background()
 		var (
 			testDir          = "testdata/cycle"
 			cyclePackageRepo = filepath.Join(testDir, "packages")
@@ -237,9 +241,9 @@ func TestNewGraph(t *testing.T) {
 				"d": {"a:1.3.5-r1@local"},
 			}
 		)
-		pkgs, err := NewPackages(os.DirFS(testDir), testDir, "")
+		pkgs, err := NewPackages(ctx, os.DirFS(testDir), testDir, "")
 		require.NoError(t, err)
-		graph, err := NewGraph(pkgs, WithRepos(cyclePackageRepo), WithKeys(cycleKey))
+		graph, err := NewGraph(ctx, pkgs, WithRepos(cyclePackageRepo), WithKeys(cycleKey))
 		require.NoError(t, err)
 		amap, err := graph.Graph.AdjacencyMap()
 		require.NoError(t, err)

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -1,6 +1,7 @@
 package dag
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"log"
@@ -126,7 +127,7 @@ func (p *Packages) addProvides(c *Configuration, provides []string) error {
 //
 // The repetition of the path is necessary because of how the upstream parser in melange
 // requires the full path to the directory to be passed in.
-func NewPackages(fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
+func NewPackages(ctx context.Context, fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
 	pkgs := &Packages{
 		configs:  make(map[string][]*Configuration),
 		packages: make(map[string][]*Configuration),
@@ -164,7 +165,7 @@ func NewPackages(fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
 		}
 
 		p := filepath.Join(dirPath, path)
-		buildc, err := config.ParseConfiguration(p)
+		buildc, err := config.ParseConfiguration(ctx, p)
 		if err != nil {
 			return err
 		}
@@ -219,7 +220,7 @@ func NewPackages(fsys fs.FS, dirPath, pipelineDir string) (*Packages, error) {
 		}
 		for i := range c.Pipeline {
 			s := &build.PipelineContext{Environment: &pctx.Build.Configuration.Environment, PipelineDirs: []string{pipelineDir}, Pipeline: &c.Pipeline[i]}
-			if err := s.ApplyNeeds(pctx); err != nil {
+			if err := s.ApplyNeeds(ctx, pctx); err != nil {
 				return fmt.Errorf("unable to resolve needs for package %s: %w", name, err)
 			}
 			c.Environment.Contents.Packages = pctx.Build.Configuration.Environment.Contents.Packages

--- a/pkg/dag/packages_test.go
+++ b/pkg/dag/packages_test.go
@@ -1,6 +1,7 @@
 package dag
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,8 +13,9 @@ import (
 
 func TestNewPackages(t *testing.T) {
 	// for now, just a simple test that the loaded info is correct
+	ctx := context.Background()
 	testdir := "testdata/complex"
-	pkgs, err := NewPackages(os.DirFS(testdir), testdir, "")
+	pkgs, err := NewPackages(ctx, os.DirFS(testdir), testdir, "")
 	require.NoError(t, err)
 
 	// should have named packages that match what is in the files and *not* the filenames

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -35,10 +36,10 @@ func New(opts ...Option) *Linter {
 }
 
 // Lint evaluates all rules and returns the result.
-func (l *Linter) Lint() (Result, error) {
+func (l *Linter) Lint(ctx context.Context) (Result, error) {
 	rules := AllRules(l)
 
-	namesToPkg, err := melange.ReadAllPackagesFromRepo(l.options.Path)
+	namesToPkg, err := melange.ReadAllPackagesFromRepo(ctx, l.options.Path)
 	if err != nil {
 		return Result{}, err
 	}

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -89,8 +90,9 @@ func TestLinter_Dir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
 			l := newTestLinterWithDir(tt.path)
-			got, err := l.Lint()
+			got, err := l.Lint(ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Lint() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -307,8 +308,9 @@ func TestLinter_Rules(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.file, func(t *testing.T) {
+			ctx := context.Background()
 			l := newTestLinterWithFile(tt.file)
-			got, err := l.Lint()
+			got, err := l.Lint(ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Lint() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/melange/melange_test.go
+++ b/pkg/melange/melange_test.go
@@ -1,6 +1,7 @@
 package melange
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -9,7 +10,8 @@ import (
 
 // make sure apko yaml files are skipped and no errors
 func TestMelange_readPackageConfigsNotSubFolders(t *testing.T) {
-	packages, err := ReadPackageConfigs([]string{}, filepath.Join("testdata", "melange_dir"))
+	ctx := context.Background()
+	packages, err := ReadPackageConfigs(ctx, []string{}, filepath.Join("testdata", "melange_dir"))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(packages))
 }

--- a/pkg/update/package.go
+++ b/pkg/update/package.go
@@ -66,7 +66,7 @@ func NewPackageOptions() PackageOptions {
 	return options
 }
 
-func (o *PackageOptions) UpdatePackageCmd() error {
+func (o *PackageOptions) UpdatePackageCmd(ctx context.Context) error {
 	// clone the melange config git repo into a temp folder so we can work with it
 	tempDir, err := os.MkdirTemp("", "wolfictl")
 	if err != nil {
@@ -92,7 +92,7 @@ func (o *PackageOptions) UpdatePackageCmd() error {
 	}
 
 	// first, let's get the melange package(s) from the target git repo, that we want to check for updates
-	o.PackageConfig, err = melange.ReadPackageConfigs([]string{o.PackageName}, tempDir)
+	o.PackageConfig, err = melange.ReadPackageConfigs(ctx, []string{o.PackageName}, tempDir)
 	if err != nil {
 		return fmt.Errorf("failed to get package config for package name %s: %w", o.PackageName, err)
 	}
@@ -124,7 +124,7 @@ func (o *PackageOptions) UpdatePackageCmd() error {
 	nvr := NewVersionResults{
 		Version: v,
 	}
-	errorMessage, err := uo.updateGitPackage(repo, o.PackageName, nvr, ref)
+	errorMessage, err := uo.updateGitPackage(ctx, repo, o.PackageName, nvr, ref)
 	if err != nil {
 		return fmt.Errorf("failed to update package in git repository: %w", err)
 	}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -53,13 +54,14 @@ func TestMonitorService_updatePackagesGitRepository(t *testing.T) {
 		DefaultBranch: "master",
 	}
 
-	o.PackageConfigs, err = melange.ReadAllPackagesFromRepo(filepath.Join(dir, "melange"))
+	ctx := context.Background()
+	o.PackageConfigs, err = melange.ReadAllPackagesFromRepo(ctx, filepath.Join(dir, "melange"))
 	assert.NoError(t, err)
 
 	// fake a new version available
 	newVersion := map[string]NewVersionResults{"cheese": {Version: "1.5.10"}}
 	errorMessages := make(map[string]string)
-	err = o.updatePackagesGitRepository(r, newVersion)
+	err = o.updatePackagesGitRepository(ctx, r, newVersion)
 	assert.NoError(t, err)
 	assert.Empty(t, errorMessages)
 


### PR DESCRIPTION
This picks up recent changes to apko, melange and go-apk to use `log/slog` structured logging, and `github.com/chainguard-dev/clog` to pass around a logger with the context.

By standardizing on this form, if we move any part of this code to run in a cloud service, we can have those structured logs also get slurped into GCP logs in the standard way using https://github.com/imjasonh/gcpslog