### PR TITLE
fix: explicitly do not log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.5
 
 require (
 	chainguard.dev/apko v0.13.4-0.20240116200834-c10dc551b827
-	chainguard.dev/melange v0.5.6-0.20240116222011-34a2130156b4
+	chainguard.dev/melange v0.5.6-0.20240118190540-d50de70a95bd
 	github.com/adrg/xdg v0.4.0
 	github.com/anchore/grype v0.74.0
 	github.com/anchore/syft v0.100.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 chainguard.dev/apko v0.13.4-0.20240116200834-c10dc551b827 h1:O5FUsm7JVXKlWGS2UrgP7A8HlEKoH0fLtuiV6rQ7KEs=
 chainguard.dev/apko v0.13.4-0.20240116200834-c10dc551b827/go.mod h1:6WRsohsp9hXU2J7LTxOmplw28L6fYEcdjZLNR6BiYKU=
-chainguard.dev/melange v0.5.6-0.20240116222011-34a2130156b4 h1:BkDqkZkWbIg7U7nZsBO5J0t0flKVzg7s1D3ZFxSE3PI=
-chainguard.dev/melange v0.5.6-0.20240116222011-34a2130156b4/go.mod h1:3KNCNL1kAcCD+Xrm3JVCdimoitS4M5ZiD6NTm0WNAyY=
+chainguard.dev/melange v0.5.6-0.20240118190540-d50de70a95bd h1:xoRrcT4AGBbUy9hDbENJL2djpKlJZSKfR2fUJmb0e8Q=
+chainguard.dev/melange v0.5.6-0.20240118190540-d50de70a95bd/go.mod h1:3KNCNL1kAcCD+Xrm3JVCdimoitS4M5ZiD6NTm0WNAyY=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"sort"
@@ -18,6 +17,7 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
+	"github.com/wolfi-dev/wolfictl/pkg/internal"
 	"github.com/wolfi-dev/wolfictl/pkg/versions"
 )
 
@@ -190,7 +190,7 @@ func newLogger(verbosity int) *slog.Logger {
 	case verbosity >= 2:
 		h = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
 	default:
-		h = slog.NewTextHandler(io.Discard, nil)
+		return internal.NopLogger()
 	}
 
 	return slog.New(h)

--- a/pkg/configs/build/build.go
+++ b/pkg/configs/build/build.go
@@ -5,8 +5,10 @@ import (
 	"io/fs"
 
 	"chainguard.dev/melange/pkg/config"
+	"github.com/chainguard-dev/clog"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	"github.com/wolfi-dev/wolfictl/pkg/configs/rwfs"
+	"github.com/wolfi-dev/wolfictl/pkg/internal"
 )
 
 func NewIndex(fsys rwfs.FS) (*configs.Index[config.Configuration], error) {
@@ -19,7 +21,7 @@ func NewIndexFromPaths(fsys rwfs.FS, paths ...string) (*configs.Index[config.Con
 
 func newConfigurationDecodeFunc(fsys fs.FS) func(string) (*config.Configuration, error) {
 	return func(path string) (*config.Configuration, error) {
-		ctx := context.Background()
+		ctx := clog.WithLogger(context.Background(), clog.NewLogger(internal.NopLogger()))
 		return config.ParseConfiguration(ctx, path, config.WithFS(fsys))
 	}
 }

--- a/pkg/internal/nop_slogger.go
+++ b/pkg/internal/nop_slogger.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"context"
+	"log/slog"
+)
+
+// NopLogger returns a new slog.Logger that does nothing.
+func NopLogger() *slog.Logger {
+	return slog.New(nopHandler{})
+}
+
+type nopHandler struct{}
+
+func (h nopHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return false
+}
+
+func (h nopHandler) Handle(_ context.Context, _ slog.Record) error {
+	return nil
+}
+
+func (h nopHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h nopHandler) WithGroup(_ string) slog.Handler {
+	return h
+}


### PR DESCRIPTION
To avoid a default logger being used via https://github.com/chainguard-dev/clog, this introduces a no-op logger that does nothing, that can be injected into contexts explicitly to prevent downstream calls from having side effects.

This also updates an existing "no-op" use case in advisory validation with a better one.

This also updates Melange to incorporate this fix: https://github.com/chainguard-dev/melange/pull/936

cc: @imjasonh @jonjohnsonjr 