### PR TITLE
fix(sbom,scan): exclude SBOM cataloging

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -61,6 +61,8 @@ func Generate(inputFilePath string, f io.Reader, distroID string) (*sbom.SBOM, e
 	cfg := syft.DefaultCreateSBOMConfig().WithCatalogerSelection(
 		pkgcataloging.NewSelectionRequest().WithDefaults(
 			pkgcataloging.ImageTag,
+		).WithRemovals(
+			"sbom",
 		),
 	)
 


### PR DESCRIPTION
Don't catalog APK packages from SBOMs in the APKs, just use `.PKGINFO`.

(Soon we'll add integration tests to ensure we're getting consistent results from Syft and Grype.)