### PR TITLE
release: don't bump tags if no changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Check if any changes since last tag
+        id: check
+        run: |
+          git fetch --tags
+          if [ -z "$(git tag --points-at HEAD)" ]; then
+            echo "Nothing points at HEAD, bump a new tag"
+            echo "bump=yes" >> $GITHUB_OUTPUT
+          else
+            echo "A tag already points to head, don't bump"
+            echo "bump=no" >> $GITHUB_OUTPUT
+          fi
       - name: Bump patch version and push tag
         uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 # v6.1
+        if: steps.check.outputs.bump == 'yes'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some releases are redundant, since no changes happen during the intervening time. We should try to avoid these.

This is an attempt to avoid these.

<img width="430" alt="Screenshot 2024-01-19 at 11 28 45 AM" src="https://github.com/wolfi-dev/wolfictl/assets/210737/0711b969-2762-420b-840f-034c1574b2d6">
