### PR TITLE
chore: add a new advisory filter set

### DIFF
--- a/docs/cmd/wolfictl_scan.md
+++ b/docs/cmd/wolfictl_scan.md
@@ -47,6 +47,9 @@ filtering. The following sets of advisories are available:
 - "all": Filter out all vulnerabilities that are referenced from any advisory
   in the advisories repository.
 
+- "concluded": Only filter out all vulnerabilities that have been fixed, or those
+  where no change is planned to fix the vulnerability.
+
 ## AUTO-TRIAGING
 
 Wolfictl now supports auto-triaging vulnerabilities found in Go binaries using
@@ -111,7 +114,7 @@ wolfictl scan package1 package2 --remote
 
 ```
   -a, --advisories-repo-dir strings   local directory for advisory data
-  -f, --advisory-filter string        exclude vulnerability matches that are referenced from the specified set of advisories (resolved|all)
+  -f, --advisory-filter string        exclude vulnerability matches that are referenced from the specified set of advisories (resolved|all|concluded)
       --build-log                     treat input as a package build log file (or a directory that contains a packages.log file)
       --disable-sbom-cache            don't use the SBOM cache
       --distro string                 distro to use during vulnerability matching (default "wolfi")

--- a/docs/man/man1/wolfictl-scan.1
+++ b/docs/man/man1/wolfictl-scan.1
@@ -69,6 +69,11 @@ distro.
 .PP
 "all": Filter out all vulnerabilities that are referenced from any advisory
 in the advisories repository.
+.IP \(bu 2
+
+.PP
+"concluded": Only filter out all vulnerabilities that have been fixed, or those
+where no change is planned to fix the vulnerability.
 
 .RE
 
@@ -130,7 +135,7 @@ found and the \-\-require\-zero flag is specified.
 
 .PP
 \fB\-f\fP, \fB\-\-advisory\-filter\fP=""
-    exclude vulnerability matches that are referenced from the specified set of advisories (resolved|all)
+    exclude vulnerability matches that are referenced from the specified set of advisories (resolved|all|concluded)
 
 .PP
 \fB\-\-build\-log\fP[=false]

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -80,6 +80,9 @@ filtering. The following sets of advisories are available:
 - "all": Filter out all vulnerabilities that are referenced from any advisory
   in the advisories repository.
 
+- "concluded": Only filter out all vulnerabilities that have been fixed, or those
+  where no change is planned to fix the vulnerability.
+
 ## AUTO-TRIAGING
 
 Wolfictl now supports auto-triaging vulnerabilities found in Go binaries using

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -12,9 +12,10 @@ import (
 const (
 	AdvisoriesSetResolved = "resolved"
 	AdvisoriesSetAll      = "all"
+	AdvisoriesSetPending  = "pending"
 )
 
-var ValidAdvisoriesSets = []string{AdvisoriesSetResolved, AdvisoriesSetAll}
+var ValidAdvisoriesSets = []string{AdvisoriesSetResolved, AdvisoriesSetAll, AdvisoriesSetPending}
 
 // FilterWithAdvisories filters the findings in the result based on the advisories for the target APK.
 func FilterWithAdvisories(result Result, advisoryDocIndices []*configs.Index[v2.Document], advisoryFilterSet string) ([]Finding, error) {
@@ -47,6 +48,9 @@ func FilterWithAdvisories(result Result, advisoryDocIndices []*configs.Index[v2.
 
 		case AdvisoriesSetResolved:
 			filteredFindings = filterFindingsWithResolvedAdvisories(filteredFindings, packageAdvisories, result.TargetAPK.Version)
+
+		case AdvisoriesSetPending:
+			filteredFindings = filterFindingsWithPendingAdvisories(filteredFindings, packageAdvisories, result.TargetAPK.Version)
 
 		default:
 			return nil, fmt.Errorf("unknown advisory filter set: %s", advisoryFilterSet)
@@ -95,6 +99,29 @@ func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories 
 			}
 
 			if adv.ResolvedAtVersion(currentPackageVersion) {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
+func filterFindingsWithPendingAdvisories(findings []Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []Finding {
+	return lo.Filter(findings, func(finding Finding, _ int) bool {
+		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
+		if ok && adv.PendingAtVersion(currentPackageVersion) {
+			return false
+		}
+
+		// Also check any listed aliases
+		for _, alias := range finding.Vulnerability.Aliases {
+			adv, ok := packageAdvisories.GetByVulnerability(alias)
+			if !ok {
+				continue
+			}
+
+			if adv.PendingAtVersion(currentPackageVersion) {
 				return false
 			}
 		}

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -268,6 +268,87 @@ func TestFilterWithAdvisories(t *testing.T) {
 				},
 			},
 			errAssertion: assert.NoError,
+		}, {
+			name: "use concluded advisory filter",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "0.13.0-r2",
+				},
+				Findings: []Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-2023-1234",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-1999-11111",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-2000-22222",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-2003-55555",
+						},
+					},
+				},
+			},
+			advisoryIndicesGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:     "concluded",
+			expectedFindings: []Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-2023-1234",
+					},
+				},
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-1999-11111",
+					},
+				},
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-2003-55555",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
+		},
+		{
+			name: "use concluded advisory filter with a newer version",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "0.13.0-r30",
+				},
+				Findings: []Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-1999-11111",
+						},
+					},
+				},
+			},
+			advisoryIndicesGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:     "concluded",
+			expectedFindings: []Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-1999-11111",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
 		},
 	}
 


### PR DESCRIPTION
As part of a discussion in https://chainguard-dev.slack.com/archives/C0636FTRFED/p1705946151427929, we decided to add a new filter type so we can filter the advisory data to remediate certain CVE types such as true-positive, pending-upstream-fix and not-fixed...