### PR TITLE
update/cleanup: few improvements and more tests

### DIFF
--- a/pkg/update/deps/cleanup_test.go
+++ b/pkg/update/deps/cleanup_test.go
@@ -38,6 +38,12 @@ func TestCleanupDeps(t *testing.T) {
 	}, {
 		name:     "cleanup gobump and update another go/bump",
 		filename: "config-6",
+	}, {
+		name:     "go.mod require and replace conflicting to different version of the same grpc version",
+		filename: "config-7",
+	}, {
+		name:     "upgrade gorm version in replaces with a newer version in go.mod in a replace block",
+		filename: "config-8",
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/update/deps/testdata/config-7.yaml
+++ b/pkg/update/deps/testdata/config-7.yaml
@@ -1,0 +1,43 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: kubescape
+  version: 3.0.3
+  epoch: 3
+  description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
+  copyright:
+    - license: Apache-2.0 AND MIT
+  dependencies:
+    runtime:
+      - build-base
+      - go
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubescape/kubescape.git
+      tag: v${{package.version}}
+      expected-commit: 4e4a642673b49c26b615c14ae88c7aaf2d5f51c6
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: go/bump
+    with:
+      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
+      replaces: sigs.k8s.io/kustomize/kyaml=sigs.k8s.io/kustomize/kyaml@v0.14.1 k8s.io/kube-openapi=k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f github.com/google/gnostic=github.com/google/gnostic@v0.5.7-v3refs k8s.io/client-go=k8s.io/client-go@v0.27.4 k8s.io/api=k8s.io/api@v0.27.4 google.golang.org/grpc=google.golang.org/grpc@v1.58.3
+      go-version: "1.21"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubescape/kubescape
+    strip-prefix: v

--- a/pkg/update/deps/testdata/config-7_expected.yaml
+++ b/pkg/update/deps/testdata/config-7_expected.yaml
@@ -1,0 +1,43 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: kubescape
+  version: 3.0.3
+  epoch: 3
+  description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
+  copyright:
+    - license: Apache-2.0 AND MIT
+  dependencies:
+    runtime:
+      - build-base
+      - go
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubescape/kubescape.git
+      tag: v${{package.version}}
+      expected-commit: 4e4a642673b49c26b615c14ae88c7aaf2d5f51c6
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: go/bump
+    with:
+      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
+      replaces: sigs.k8s.io/kustomize/kyaml=sigs.k8s.io/kustomize/kyaml@v0.14.1 k8s.io/kube-openapi=k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f github.com/google/gnostic=github.com/google/gnostic@v0.5.7-v3refs k8s.io/client-go=k8s.io/client-go@v0.27.4 k8s.io/api=k8s.io/api@v0.27.4 google.golang.org/grpc=google.golang.org/grpc@v1.58.3
+      go-version: "1.21"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubescape/kubescape
+    strip-prefix: v

--- a/pkg/update/deps/testdata/config-8.yaml
+++ b/pkg/update/deps/testdata/config-8.yaml
@@ -1,0 +1,43 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: kubescape
+  version: 3.0.3
+  epoch: 3
+  description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
+  copyright:
+    - license: Apache-2.0 AND MIT
+  dependencies:
+    runtime:
+      - build-base
+      - go
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubescape/kubescape.git
+      tag: v${{package.version}}
+      expected-commit: 4e4a642673b49c26b615c14ae88c7aaf2d5f51c6
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: go/bump
+    with:
+      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
+      replaces: google.golang.org/grpc=google.golang.org/grpc@v1.58.4 gorm.io/gorm=gorm.io/gorm@v1.1.1
+      go-version: "1.21"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubescape/kubescape
+    strip-prefix: v

--- a/pkg/update/deps/testdata/config-8_expected.yaml
+++ b/pkg/update/deps/testdata/config-8_expected.yaml
@@ -1,0 +1,43 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: kubescape
+  version: 3.0.3
+  epoch: 3
+  description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
+  copyright:
+    - license: Apache-2.0 AND MIT
+  dependencies:
+    runtime:
+      - build-base
+      - go
+
+environment:
+  contents:
+    packages:
+      - gitlab-cng-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubescape/kubescape.git
+      tag: v${{package.version}}
+      expected-commit: 4e4a642673b49c26b615c14ae88c7aaf2d5f51c6
+
+  - runs: |
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: go/bump
+    with:
+      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
+      replaces: google.golang.org/grpc=google.golang.org/grpc@v1.58.4
+      go-version: "1.21"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubescape/kubescape
+    strip-prefix: v


### PR DESCRIPTION
The code is getting rid off the dependencies in `gobump.replaces` whenever there is a greater version in the go.mod require OR replace blocks.

I've added more tests to cover some missing use cases.

I delete the removed dependency from the maps to avoid removing it again once it has been already removed (this was a potential bug).