### PR TITLE
rules: add check to forbid nolint directive for bad-version

### DIFF
--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -79,6 +79,14 @@ func (l *Linter) Lint(ctx context.Context) (Result, error) {
 			}
 
 			if slices.Contains(namesToPkg[name].NoLint, rule.Name) {
+				// Some rules are not allowed to be disabled.
+				if rule.ForbidNolint {
+					failedRules = append(failedRules, EvalRuleError{
+						Rule:  rule,
+						Error: fmt.Errorf("[%s]: use of #nolint: directive is forbidden for this rule", rule.Name),
+					})
+					continue
+				}
 				log.Debugf("%s: skipping rule %s because file contains #nolint:%s\n", name, rule.Name, rule.Name)
 				continue
 			}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -289,6 +289,8 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Name:        "bad-version",
 			Description: "version is malformed",
 			Severity:    SeverityError,
+			// Bad versioning results in `package file format error` while attempting to install with `apk add`
+			ForbidNolint: true,
 			LintFunc: func(config config.Configuration) error {
 				version := config.Package.Version
 				if err := versions.ValidateWithoutEpoch(version); err != nil {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -168,10 +168,27 @@ func TestLinter_Rules(t *testing.T) {
 				Errors: EvalRuleErrors{
 					{
 						Rule: Rule{
-							Name:     "bad-version",
-							Severity: SeverityError,
+							Name:         "bad-version",
+							Severity:     SeverityError,
+							ForbidNolint: true,
 						},
 						Error: fmt.Errorf("[bad-version]: invalid version 1.0.0rc1, could not parse (ERROR)"),
+					},
+				},
+			},
+		},
+		{
+			file: "bad-version-nolint-forbid.yaml",
+			want: EvalResult{
+				File: "bad-version",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:         "bad-version",
+							Severity:     SeverityError,
+							ForbidNolint: true,
+						},
+						Error: fmt.Errorf("[bad-version]: use of #nolint: directive is forbidden for this rule"),
 					},
 				},
 			},
@@ -330,6 +347,7 @@ func TestLinter_Rules(t *testing.T) {
 				assert.Equal(t, e.Error, tt.want.Errors[i].Error, "Lint(): Error: got = %v, want %v", e.Error, tt.want.Errors[i].Error)
 				assert.Equal(t, e.Rule.Name, tt.want.Errors[i].Rule.Name, "Lint(): Rule.Name: got = %v, want %v", e.Rule.Name, tt.want.Errors[i].Rule.Name)
 				assert.Equal(t, e.Rule.Severity, tt.want.Errors[i].Rule.Severity, "Lint(): Rule.Severity: got = %v, want %v", e.Rule.Severity, tt.want.Errors[i].Rule.Severity)
+				assert.Equal(t, e.Rule.ForbidNolint, tt.want.Errors[i].Rule.ForbidNolint, "Lint(): Rule.ForbidNolint: got = %v, want %v", e.Rule.ForbidNolint, tt.want.Errors[i].Rule.ForbidNolint)
 			}
 		})
 	}

--- a/pkg/lint/testdata/files/bad-version-nolint-forbid.yaml
+++ b/pkg/lint/testdata/files/bad-version-nolint-forbid.yaml
@@ -1,0 +1,16 @@
+#nolint:bad-version
+package:
+  name: bad-version
+  version: 1.0.0rc1
+  epoch: 0
+  description: "a package with a wrong pipeline fetch uri"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+environment:
+  contents:
+    packages:
+      - foo
+      - bar

--- a/pkg/lint/testdata/files/nolint.yaml
+++ b/pkg/lint/testdata/files/nolint.yaml
@@ -1,7 +1,7 @@
-#nolint:bad-version,no-repeated-deps
+#nolint:no-repeated-deps
 package:
   name: nolint
-  version: 1.0.0rc1
+  version: 1.0.0
   epoch: 0
   description: "a package that fails (but skips) two lint checks, and fails (and doesn't skip) one"
   # also no copyright

--- a/pkg/lint/types.go
+++ b/pkg/lint/types.go
@@ -32,6 +32,9 @@ type Rule struct {
 	// Severity is the severity of the rule.
 	Severity Severity
 
+	// ForbidNolint forbids the use of nolint directives for this rule.
+	ForbidNolint bool
+
 	// LintFunc is the function that lints a single configuration.
 	LintFunc Function
 


### PR DESCRIPTION
This PR adds ability to forbid some `nolint:` directives for the rules. For example, we should not allow `nolint:bad-version` since it results in `package file format error` while attempting to install with `apk add`.