### PR TITLE
fix(scan): CPE matching for OpenJDK packages

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
@@ -155,6 +156,23 @@ func generateCPEs(p pkg.Package) []cpe.CPE {
 	dictionaryCPE, ok := cpegen.DictionaryFind(p)
 	if ok {
 		return []cpe.CPE{dictionaryCPE}
+	}
+
+	// TODO: This is a workaround for Syft not coming up with this CPE for OpenJDK
+	// 	packages. Some thought would be needed on the "right" way to implement this
+	// 	upstream, but it's more obvious how we can address this in wolfictl for our
+	// 	purposes.
+	//
+	//  Potentially related: https://github.com/anchore/syft/issues/2422
+	if strings.HasPrefix(p.Name, "openjdk-") {
+		return []cpe.CPE{
+			{
+				Part:    "a",
+				Vendor:  "oracle",
+				Product: "jdk",
+				Version: p.Version,
+			},
+		}
 	}
 
 	return cpegen.Generate(p)


### PR DESCRIPTION
Syft and Grype don't seem to be handling OpenJDK properly, such that **we miss valid vulnerability matches** (i.e. false negatives) in our `openjdk-*` APKs when using Syft and Grype in `wolfictl` to scan the APK.

This PR implements a potentially viable workaround that lets us discover these vulnerabilities after all.

### Before

```console
$ wolfictl scan --disable-sbom-cache =(curl -sS https://packages.wolfi.dev/os/aarch64/openjdk-21-21.0.1-r0.apk)
🔎 Scanning "/tmp/zshp5wsUm"
✅ No vulnerabilities found
```

### After

```console
$ wolfictl scan --disable-sbom-cache =(curl -sS https://packages.wolfi.dev/os/aarch64/openjdk-21-21.0.1-r0.apk)
🔎 Scanning "/tmp/zshryD2h3"
└── 📄 /.PKGINFO
        📦 openjdk-21 21.0.1-r0 (apk)
            High CVE-2024-20918
            Medium CVE-2024-20926
            High CVE-2024-20952
```