### PR TITLE
Revert "make invalid SPDX identifier an error"

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -397,7 +397,7 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 		{
 			Name:        "valid-spdx-license",
 			Description: "every package should have a valid SPDX license",
-			Severity:    SeverityError,
+			Severity:    SeverityWarning, // TODO(jason): Make this an error.
 			LintFunc: func(config config.Configuration) error {
 				for _, c := range config.Package.Copyright {
 					if c.License == "" {


### PR DESCRIPTION
Reverts wolfi-dev/wolfictl#581