### PR TITLE
wolfibot: go bump removals - use error messages that generate issues …

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -425,14 +425,14 @@ func (o *Options) updateGitPackage(ctx context.Context, repo *git.Repository, pa
 	// Skip any processing for definitions with a single pipeline
 	if len(updated.Pipeline) > 1 {
 		if err := o.updateGoBumpDeps(updated, pc.Dir, packageName, mutations); err != nil {
-			return "", fmt.Errorf("error cleaning up go/bump deps: %v", err)
+			return fmt.Sprintf("error cleaning up go/bump deps: %v", err), nil
 		}
 	}
 
 	// Run yam formatter
 	err = yam.FormatConfigurationFile(pc.Dir, pc.Filename)
 	if err != nil {
-		return "", fmt.Errorf("failed to format configuration file: %v", err)
+		return fmt.Sprintf("failed to format configuration file: %v", err), nil
 	}
 
 	_, err = worktree.Add(fileRelPath)


### PR DESCRIPTION
…rather than return errors that stop the automation

If we return an error then the bot will retry and then fail.  Instead we can return error messages that allow the bot to carry on to the next package update and will create issues for any error messages.