### PR TITLE
cleanup: improve perf when cloning git repos

### DIFF
--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -317,6 +317,7 @@ func (o *CheckUpdateOptions) updateGoBumpDeps(updated *config.Configuration, dir
 	if err != nil {
 		return fmt.Errorf("error unmarshalling YAML: %v", err)
 	}
+	// NOTE: By default, we set tidy to false because we don´t want to compile the go project during updates.
 	tidy := false
 	if err := deps.CleanupGoBumpDeps(&doc, updated, tidy, mutations); err != nil {
 		return err

--- a/pkg/update/deps/cleanup.go
+++ b/pkg/update/deps/cleanup.go
@@ -44,8 +44,7 @@ func gitCheckout(p *config.Pipeline, dir string, mutations map[string]string) er
 		URL:               repoValue,
 		ReferenceName:     plumbing.ReferenceName(fmt.Sprintf("refs/tags/%s", evaluatedTag)),
 		Progress:          os.Stdout,
-		RecurseSubmodules: 1,
-		ShallowSubmodules: true,
+		RecurseSubmodules: git.NoRecurseSubmodules,
 		Depth:             1,
 		Auth:              wgit.GetGitAuth(),
 	}

--- a/pkg/update/deps/cleanup_test.go
+++ b/pkg/update/deps/cleanup_test.go
@@ -80,7 +80,7 @@ func TestCleanupDeps(t *testing.T) {
 			err = yaml.Unmarshal(yamlContent, &doc)
 			require.NoError(t, err)
 
-			err = CleanupGoBumpDeps(&doc, updated, true, mutations)
+			err = CleanupGoBumpDeps(&doc, updated, false, mutations)
 			if tc.expectedErr && err == nil {
 				t.Errorf("expected error")
 			} else if err != nil && !tc.expectedErr {

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -480,6 +480,7 @@ func (o *Options) updateGoBumpDeps(updated *config.Configuration, dir, filename 
 	if err != nil {
 		return fmt.Errorf("error unmarshalling YAML: %v", err)
 	}
+	// NOTE: By default, we set tidy to false because we don´t want to compile the go project during updates.
 	tidy := false
 	if err := deps.CleanupGoBumpDeps(&doc, updated, tidy, mutations); err != nil {
 		return err


### PR DESCRIPTION
We disable the submodule recursion because we are just interested on the current module when looking for `go.mod` files. If this doesn't improve the performance, we could even attempt fetch the `go.mod` file itself although this could get more complicated when we don't know the location of the go.mod file.