### PR TITLE
cleanup: skip if go/bump pipeline was not found

### DIFF
--- a/pkg/checks/update.go
+++ b/pkg/checks/update.go
@@ -241,7 +241,7 @@ func (o CheckUpdateOptions) processUpdates(ctx context.Context, latestVersions m
 		}
 
 		// Skip any processing for definitions with a single pipeline
-		if len(updated.Pipeline) > 1 {
+		if len(updated.Pipeline) > 1 && deps.ContainsGoBumpPipeline(updated) {
 			if err := o.updateGoBumpDeps(updated, o.Dir, packageName, mutations); err != nil {
 				return fmt.Errorf("error cleaning up go/bump deps: %v", err)
 			}

--- a/pkg/update/deps/cleanup.go
+++ b/pkg/update/deps/cleanup.go
@@ -198,6 +198,17 @@ func cleanupGoBumpPipelineDeps(p *config.Pipeline, tempDir string, tidy bool) er
 	return nil
 }
 
+// ContainsGoBumpPipeline checks whether there is a gobump in the wolfi package definition.
+// If so, we will attempt to clean the unnecessary dependencies.
+func ContainsGoBumpPipeline(updated *config.Configuration) bool {
+	for i := range updated.Pipeline {
+		if updated.Pipeline[i].Uses == "go/bump" {
+			return true
+		}
+	}
+	return false
+}
+
 func CleanupGoBumpDeps(doc *yaml.Node, updated *config.Configuration, tidy bool, mutations map[string]string) error {
 	tempDir, err := os.MkdirTemp("", "wolfibump")
 	if err != nil {

--- a/pkg/update/deps/cleanup_test.go
+++ b/pkg/update/deps/cleanup_test.go
@@ -112,3 +112,61 @@ func copyFile(t *testing.T, src, dst string) {
 		t.Fatal(err)
 	}
 }
+
+func TestContainsGoBump(t *testing.T) {
+	testcases := []struct {
+		name           string
+		filename       string
+		containsGoBump bool
+	}{{
+		name:           "update existing go/bump",
+		filename:       "config-1",
+		containsGoBump: true,
+	}, {
+		name:           "add go/bump",
+		filename:       "config-2",
+		containsGoBump: true,
+	}, {
+		name:           "add go/bump before go mod tidy",
+		filename:       "config-3",
+		containsGoBump: true,
+	}, {
+		name:           "cleanup gobump, empty deps",
+		filename:       "config-4",
+		containsGoBump: true,
+	}, {
+		name:           "cleanup gobump, empty replaces",
+		filename:       "config-5",
+		containsGoBump: true,
+	}, {
+		name:           "cleanup gobump and update another go/bump",
+		filename:       "config-6",
+		containsGoBump: true,
+	}, {
+		name:           "go.mod require and replace conflicting to different version of the same grpc version",
+		filename:       "config-7",
+		containsGoBump: true,
+	}, {
+		name:           "upgrade gorm version in replaces with a newer version in go.mod in a replace block",
+		filename:       "config-8",
+		containsGoBump: true,
+	}, {
+		name:           "no go/bump in the pipelines",
+		filename:       "config-9",
+		containsGoBump: false,
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := "testdata"
+			filename := fmt.Sprintf("%s.yaml", tc.filename)
+
+			// now make sure update config is configured
+			updated, err := config.ParseConfiguration(context.Background(), filepath.Join(dir, filename))
+			require.NoError(t, err)
+			exists := ContainsGoBumpPipeline(updated)
+			if tc.containsGoBump != exists {
+				t.Errorf("unexpected value for contains go/bump: got %v and expected %v", exists, tc.containsGoBump)
+			}
+		})
+	}
+}

--- a/pkg/update/deps/testdata/config-9.yaml
+++ b/pkg/update/deps/testdata/config-9.yaml
@@ -1,0 +1,33 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: nogobump
+  version: 3.0.3
+  epoch: 3
+  description: blah.
+  copyright:
+    - license: Apache-2.0 AND MIT
+  dependencies:
+    runtime:
+      - build-base
+      - go
+
+environment:
+  contents:
+    packages:
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/wrong/repo.git
+      tag: v${{package.version}}
+      expected-commit: 4e4a642673b49c26b615c14ae88c7aaf2d5f51c6
+
+  - runs: |
+      make coffee "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: strip
+
+update:
+  enabled: false

--- a/pkg/update/deps/testdata/config-9_expected.yaml
+++ b/pkg/update/deps/testdata/config-9_expected.yaml
@@ -1,0 +1,33 @@
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: nogobump
+  version: 3.0.3
+  epoch: 3
+  description: blah.
+  copyright:
+    - license: Apache-2.0 AND MIT
+  dependencies:
+    runtime:
+      - build-base
+      - go
+
+environment:
+  contents:
+    packages:
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/wrong/repo.git
+      tag: v${{package.version}}
+      expected-commit: 4e4a642673b49c26b615c14ae88c7aaf2d5f51c6
+
+  - runs: |
+      make coffee "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - uses: strip
+
+update:
+  enabled: false

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -434,7 +434,7 @@ func (o *Options) updateGitPackage(ctx context.Context, repo *git.Repository, pa
 	}
 
 	// Skip any processing for definitions with a single pipeline
-	if len(updated.Pipeline) > 1 {
+	if len(updated.Pipeline) > 1 && deps.ContainsGoBumpPipeline(updated) {
 		if err := o.updateGoBumpDeps(updated, root, pc.Filename, mutations); err != nil {
 			return fmt.Sprintf("error cleaning up go/bump deps: %v", err), nil
 		}


### PR DESCRIPTION
We now check in advance before cloning any repo if the package definition contains a go-bump pipeline to attempt cleaning unused deps.