### PR TITLE
fix(adv): skip alias validation by default

### DIFF
--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -249,7 +249,7 @@ func (p *validateParams) addFlagsTo(cmd *cobra.Command) {
 	addDistroDirFlag(&p.packagesRepoDir, cmd)
 	cmd.Flags().StringSliceVarP(&p.packages, flagNamePackage, "p", nil, "packages to validate")
 	cmd.Flags().BoolVar(&p.skipDiffValidation, flagNameSkipDiffValidation, false, "skip diff-based validations")
-	cmd.Flags().BoolVar(&p.skipAliasCompletenessValidation, flagNameSkipAliasCompleteness, false, "skip alias completeness validation")
+	cmd.Flags().BoolVar(&p.skipAliasCompletenessValidation, flagNameSkipAliasCompleteness, true, "skip alias completeness validation")
 	cmd.Flags().BoolVar(&p.skipPackageExistenceValidation, flagNameSkipPackageExistence, false, "skip package configuration existence validation")
 	addPackageRepoURLFlag(&p.packageRepositoryURL, cmd)
 }


### PR DESCRIPTION
Today the alias validation makes many calls to the GitHub API. This works for some people, if they're authenticated, but can also result in rate limiting from the API, particularly if no subset of packages is selected on the command line (i.e. with `-p`).

In the future, an implementation is possible that avoids these API calls altogether by querying a local cache of GitHub's data.

But for now, to avoid toil, we'll default this check to off. It can be re-enabled by using `--skip-alias=false`.

cc: @mamccorm 