### PR TITLE
Advisory validation: start detecting duplicate IDs being used

### DIFF
--- a/pkg/advisory/diff.go
+++ b/pkg/advisory/diff.go
@@ -111,7 +111,7 @@ func documentDiff(a, b v2.Document) DocumentDiffResult {
 		advA, _ := a.Advisories.Get(id)
 		advB, _ := b.Advisories.Get(id)
 
-		diff := diff(advA, advB)
+		diff := advisoryDiff(advA, advB)
 		if !diff.IsZero() {
 			result.Modified = append(result.Modified, diff)
 		}
@@ -120,10 +120,10 @@ func documentDiff(a, b v2.Document) DocumentDiffResult {
 	return result
 }
 
-// diff takes two advisories and if they are different, returns a DiffResult
+// advisoryDiff takes two advisories and if they are different, returns a DiffResult
 // wrapping the two advisories; otherwise if they are the same, it returns a
 // zero-value DiffResult.
-func diff(a, b v2.Advisory) DiffResult {
+func advisoryDiff(a, b v2.Advisory) DiffResult {
 	if reflect.DeepEqual(a, b) {
 		return DiffResult{}
 	}

--- a/pkg/advisory/testdata/validate/duplicate-advisory-by-id-and-alias/ko.advisories.yaml
+++ b/pkg/advisory/testdata/validate/duplicate-advisory-by-id-and-alias/ko.advisories.yaml
@@ -1,0 +1,19 @@
+schema-version: 2.0.1
+
+package:
+  name: ko
+
+advisories:
+  - id: GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination
+
+  - id: CVE-2022-2222
+    aliases:
+      - GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: fixed
+        data:
+          fixed-version: 1.0.0-r3

--- a/pkg/advisory/testdata/validate/duplicate-advisory-by-id/ko.advisories.yaml
+++ b/pkg/advisory/testdata/validate/duplicate-advisory-by-id/ko.advisories.yaml
@@ -1,0 +1,17 @@
+schema-version: 2.0.1
+
+package:
+  name: ko
+
+advisories:
+  - id: GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination
+
+  - id: GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: fixed
+        data:
+          fixed-version: 1.0.0-r3

--- a/pkg/advisory/testdata/validate/no-duplicates/ko.advisories.yaml
+++ b/pkg/advisory/testdata/validate/no-duplicates/ko.advisories.yaml
@@ -1,0 +1,17 @@
+schema-version: 2.0.1
+
+package:
+  name: ko
+
+advisories:
+  - id: GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: true-positive-determination
+
+  - id: GHSA-3333-3333-3333
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: fixed
+        data:
+          fixed-version: 1.0.0-r3

--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -335,6 +335,45 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("duplicate advisories", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			shouldBeValid bool
+		}{
+			{
+				name:          "duplicate-advisory-by-id",
+				shouldBeValid: false,
+			},
+			{
+				name:          "duplicate-advisory-by-id-and-alias",
+				shouldBeValid: false,
+			},
+			{
+				name:          "no-duplicates",
+				shouldBeValid: true,
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				dir := filepath.Join("testdata", "validate", tt.name)
+				fsys := rwos.DirFS(dir)
+				index, err := v2.NewIndex(fsys)
+				require.NoError(t, err)
+
+				err = Validate(context.Background(), ValidateOptions{
+					AdvisoryDocs: index,
+				})
+				if tt.shouldBeValid && err != nil {
+					t.Errorf("should be valid but got error: %v", err)
+				}
+				if !tt.shouldBeValid && err == nil {
+					t.Error("shouldn't be valid but got no error")
+				}
+			})
+		}
+	})
 }
 
 func distroWithKo(t *testing.T) *configs.Index[config.Configuration] {

--- a/pkg/configs/advisory/v2/document.go
+++ b/pkg/configs/advisory/v2/document.go
@@ -97,12 +97,32 @@ func (advs Advisories) Validate() error {
 		return fmt.Errorf("this file should not exist if there are no advisories recorded")
 	}
 
+	seenIDs := make(map[string]bool)
+	for _, adv := range advs {
+		if _, ok := seenIDs[adv.ID]; ok {
+			return fmt.Errorf("%s: %w", adv.ID, ErrAdvisoryIDDuplicated)
+		}
+		seenIDs[adv.ID] = true
+
+		for _, alias := range adv.Aliases {
+			if _, ok := seenIDs[alias]; ok {
+				return fmt.Errorf("%s: %w", alias, ErrAdvisoryIDDuplicatedAsAlias)
+			}
+			seenIDs[alias] = true
+		}
+	}
+
 	return errorhelpers.LabelError("advisories",
 		errors.Join(lo.Map(advs, func(adv Advisory, _ int) error {
 			return adv.Validate()
 		})...),
 	)
 }
+
+var (
+	ErrAdvisoryIDDuplicated        = errors.New("advisory ID is not unique")
+	ErrAdvisoryIDDuplicatedAsAlias = errors.New("advisory ID duplicates an alias ID in the same document")
+)
 
 // Get returns the advisory with the given ID. If such an advisory does not
 // exist, the second return value will be false; otherwise it will be true.


### PR DESCRIPTION
This will catch when both IDs and aliases are reused when they shouldn't be.

Example output:

```console
❌ advisory data is not valid.

basic validation failure(s):
    kube-state-metrics-2.6:
        advisories:
            CVE-2023-3978: advisory ID is not unique
            GHSA-2wrh-6pvc-2jm9: advisory alias is not unique
    metrics-server-fips:
        advisories:
            GHSA-45x7-px36-x8w8: advisory ID is not unique
```