### PR TITLE
update source data for apk sbom to include apk name and version instead of the path

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -82,7 +82,7 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 				ID: distroID,
 			},
 		},
-		Source: getDeterministicSourceDescription(src, inputFilePath),
+		Source: getDeterministicSourceDescription(src, inputFilePath, apkPackage.Name, apkPackage.Version),
 		Descriptor: sbom.Descriptor{
 			Name: "wolfictl",
 		},
@@ -91,11 +91,12 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 	return &s, nil
 }
 
-func getDeterministicSourceDescription(src *source.DirectorySource, inputFilePath string) source.Description {
+func getDeterministicSourceDescription(src *source.DirectorySource, inputFilePath, apkName, apkVersion string) source.Description {
 	description := src.Describe()
 
 	description.ID = "(redacted for determinism)"
-	description.Name = inputFilePath
+	description.Name = apkName
+	description.Version = apkVersion
 	metadata := source.DirectorySourceMetadata{
 		Path: inputFilePath,
 	}


### PR DESCRIPTION
before we have this in the source section

```
    "source": {
        "id": "(redacted for determinism)",
        "name": "os/x86_64/argo-cd-2.8-2.8.7-r5.apk",
        "version": "",
        "type": "directory",
        "metadata": {
            "path": "os/x86_64/argo-cd-2.8-2.8.7-r5.apk"
        }
    },
```

after the change we will have

```
    "source": {
        "id": "(redacted for determinism)",
        "name": "conftest",
        "version": "0.47.0-r2",
        "type": "directory",
        "metadata": {
            "path": "/Users/cpanato/Downloads/conftest-0.47.0-r2.apk"
        }
    },
```

this will help in the cve automation to check the version of an apk sbom