### PR TITLE
wolfictl update: fix panic when dropping bumps

### DIFF
--- a/pkg/update/deps/cleanup.go
+++ b/pkg/update/deps/cleanup.go
@@ -140,8 +140,10 @@ func cleanupGoBumpPipelineDeps(p *config.Pipeline, tempDir string, tidy bool) er
 				if semver.IsValid(pkgRequireVersions[replace.New.Path]) {
 					if semver.Compare(replace.New.Version, pkgRequireVersions[replace.New.Path]) >= 0 {
 						idx := slices.Index(deps, fmt.Sprintf("%s=%s@%s", replace.New.Path, replace.New.Path, pkgRequireVersions[replace.New.Path]))
-						deps = append(deps[:idx], deps[idx+1:]...)
-						delete(pkgRequireVersions, replace.New.Path)
+						if idx != -1 { // Check if the index is valid before attempting to slice
+							deps = append(deps[:idx], deps[idx+1:]...)
+							delete(pkgRequireVersions, replace.New.Path)
+						}
 					}
 				}
 			}
@@ -151,8 +153,10 @@ func cleanupGoBumpPipelineDeps(p *config.Pipeline, tempDir string, tidy bool) er
 					if semver.Compare(replace.New.Version, pkgReplaceVersions[replace.New.Path]) > 0 {
 						// TODO(hectorj2f): Assume that the source is the same
 						idx := slices.Index(replaces, fmt.Sprintf("%s=%s@%s", replace.New.Path, replace.New.Path, pkgReplaceVersions[replace.New.Path]))
-						replaces = append(replaces[:idx], replaces[idx+1:]...)
-						delete(pkgReplaceVersions, replace.New.Path)
+						if idx != -1 { // Check if the index is valid before attempting to slice
+							replaces = append(replaces[:idx], replaces[idx+1:]...)
+							delete(pkgReplaceVersions, replace.New.Path)
+						}
 					}
 				}
 			}
@@ -165,8 +169,10 @@ func cleanupGoBumpPipelineDeps(p *config.Pipeline, tempDir string, tidy bool) er
 				if semver.IsValid(pkgRequireVersions[require.Mod.Path]) {
 					if semver.Compare(require.Mod.Version, pkgRequireVersions[require.Mod.Path]) >= 0 {
 						idx := slices.Index(deps, fmt.Sprintf("%s@%s", require.Mod.Path, pkgRequireVersions[require.Mod.Path]))
-						deps = append(deps[:idx], deps[idx+1:]...)
-						delete(pkgRequireVersions, require.Mod.Path)
+						if idx != -1 { // Check if the index is valid before attempting to slice
+							deps = append(deps[:idx], deps[idx+1:]...)
+							delete(pkgRequireVersions, require.Mod.Path)
+						}
 					}
 				}
 			}
@@ -176,8 +182,10 @@ func cleanupGoBumpPipelineDeps(p *config.Pipeline, tempDir string, tidy bool) er
 					if semver.Compare(require.Mod.Version, pkgReplaceVersions[require.Mod.Path]) > 0 {
 						// TODO(hectorj2f): Assume that the source is the same
 						idx := slices.Index(replaces, fmt.Sprintf("%s=%s@%s", require.Mod.Path, require.Mod.Path, pkgReplaceVersions[require.Mod.Path]))
-						replaces = append(replaces[:idx], replaces[idx+1:]...)
-						delete(pkgReplaceVersions, require.Mod.Path)
+						if idx != -1 { // Check if the index is valid before attempting to slice
+							replaces = append(replaces[:idx], replaces[idx+1:]...)
+							delete(pkgReplaceVersions, require.Mod.Path)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes the wolfi bot update job which is currently failing https://github.com/wolfi-dev/os/actions/runs/8108959477/job/22163187753

```
2024/03/01 09:16:05 INFO checking the pipeline: { go/bump map[deps:golang.org/x/net@v0.17.0]  [] map[] {[]}   {0}  map[]}
panic: runtime error: slice bounds out of range [:-1]

goroutine 1 [running]:
github.com/wolfi-dev/wolfictl/pkg/update/deps.cleanupGoBumpPipelineDeps(0xc002b809b8, {0xc00f3c0a20, 0x18}, 0x0)
	github.com/wolfi-dev/wolfictl/pkg/update/deps/cleanup.go:143 +0x1c7e
```