### PR TITLE
build: Add span with package name

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -430,6 +430,8 @@ func (t *task) build(ctx context.Context) error {
 		}
 	}()
 
+	fctx, span := otel.Tracer("wolfictl").Start(fctx, t.pkg)
+	defer span.End()
 	if err := bc.BuildPackage(fctx); err != nil {
 		return fmt.Errorf("building package (see %q for logs): %w", logfile, err)
 	}


### PR DESCRIPTION
This lets us see at a glance what order packages were built in.