### PR TITLE
Add ParsePackageIndexFromJSON

### DIFF
--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -3,6 +3,7 @@ package apk
 import (
 	"archive/tar"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -41,6 +42,18 @@ func (c Context) GetApkPackages() (map[string]*apk.Package, error) {
 	}
 
 	return ParseApkIndex(resp.Body)
+}
+
+func ParsePackageIndexFromJSON(jsonAPKLIndex []byte) (map[string]*apk.Package, error) {
+	var idx apk.APKIndex
+	wolfiPackages := make(map[string]*apk.Package)
+
+	err := json.Unmarshal(jsonAPKLIndex, &idx)
+	if err != nil {
+		return nil, err
+	}
+
+	return getLatestPackagesMap(idx.Packages, wolfiPackages)
 }
 
 func ParseUnpackedApkIndex(indexData io.ReadCloser) (map[string]*apk.Package, error) {

--- a/pkg/apk/apk_test.go
+++ b/pkg/apk/apk_test.go
@@ -40,3 +40,12 @@ func Test_ParseApkIndex(t *testing.T) {
 	assert.Equal(t, "4.33-r0", wolfiPackages["libev-doc"].Version)
 	assert.Equal(t, "0.19.0-r3", wolfiPackages["tini"].Version)
 }
+
+func Test_ParseApkIndexFromJSON(t *testing.T) {
+	f, err := os.ReadFile(filepath.Join("testdata", "APKINDEX.json"))
+	assert.NoError(t, err)
+
+	wolfiPackages, err := ParsePackageIndexFromJSON(f)
+	assert.NoError(t, err)
+	assert.Equal(t, "2201-r0", wolfiPackages["7zip"].Version)
+}

--- a/pkg/apk/testdata/APKINDEX.json
+++ b/pkg/apk/testdata/APKINDEX.json
@@ -1,0 +1,64 @@
+{
+  "Signature": null,
+  "Description": "",
+  "Packages": [
+    {
+      "Name": "7zip",
+      "Version": "22.01-r0",
+      "Arch": "x86_64",
+      "Description": "File archiver with a high compression ratio",
+      "License": "LGPL-2.0-only",
+      "Origin": "7zip",
+      "Maintainer": "",
+      "URL": "",
+      "Checksum": "WmGnNqREp8L34t7rILbINU9sMts=",
+      "Dependencies": [
+        "so:ld-linux-x86-64.so.2",
+        "so:libc.so.6",
+        "so:libgcc_s.so.1",
+        "so:libstdc++.so.6"
+      ],
+      "Provides": [
+        "cmd:7zz=22.01-r0"
+      ],
+      "InstallIf": null,
+      "Size": 1212953,
+      "InstalledSize": 2621828,
+      "ProviderPriority": 0,
+      "BuildTime": "2023-06-16T19:14:10Z",
+      "BuildDate": 1686942850,
+      "RepoCommit": "3034d595991a3a7cabd72895c1a6a723e337e478",
+      "Replaces": null,
+      "DataHash": ""
+    },
+    {
+      "Name": "7zip",
+      "Version": "2201-r0",
+      "Arch": "x86_64",
+      "Description": "File archiver with a high compression ratio",
+      "License": "LGPL-2.0-only",
+      "Origin": "7zip",
+      "Maintainer": "",
+      "URL": "",
+      "Checksum": "CQiy+5tJ5+Oe2hcjaV9iybZ2hgM=",
+      "Dependencies": [
+        "so:ld-linux-x86-64.so.2",
+        "so:libc.so.6",
+        "so:libgcc_s.so.1",
+        "so:libstdc++.so.6"
+      ],
+      "Provides": [
+        "cmd:7zz=2201-r0"
+      ],
+      "InstallIf": null,
+      "Size": 1257476,
+      "InstalledSize": 2617725,
+      "ProviderPriority": 0,
+      "BuildTime": "2023-08-02T01:38:07Z",
+      "BuildDate": 1690940287,
+      "RepoCommit": "7bfb77ab31d2a4d04c0dfa60dd9036d06e267679",
+      "Replaces": null,
+      "DataHash": ""
+    }
+  ]
+}


### PR DESCRIPTION
This add a function to parse an apkIndex in json format
This will be use read the apkindex from gcs instead going to the LoadBalancer