### PR TITLE
FIx Bug: git-checkout into proper destination

### DIFF
--- a/pkg/update/deps/cleanup.go
+++ b/pkg/update/deps/cleanup.go
@@ -228,7 +228,12 @@ func CleanupGoBumpDeps(doc *yaml.Node, updated *config.Configuration, tidy bool,
 	for i < len(updated.Pipeline) {
 		// TODO(hectorj2f): add support for fetch pipelines
 		if updated.Pipeline[i].Uses == "git-checkout" {
-			err := gitCheckout(&updated.Pipeline[i], tempDir, mutations)
+			destinationDir := tempDir
+			dest := updated.Pipeline[i].With["destination"]
+			if dest != "" {
+				destinationDir = path.Join(tempDir, dest)
+			}
+			err := gitCheckout(&updated.Pipeline[i], destinationDir, mutations)
 			if err != nil {
 				return fmt.Errorf("failed to git checkout the repository: %v", err)
 			}


### PR DESCRIPTION
While checking go/bump pipelines via the function `CleanupGoBumpDeps`
We were not placing the git repository into the desired destination it caused failure when the repo is cloned into a destination repository. with error `error cleaning up go/bump deps: unable to parse the go mod file with error: open /tmp/wolfibump379243584/<specified-destination>/go.mod: no such file or directory`

Example:
- https://github.com/wolfi-dev/os/actions/runs/8200210238/job/22426545029?pr=14379
- https://github.com/wolfi-dev/os/actions/runs/8201144492/job/22429289256?pr=14382
