### PR TITLE
Add filter-prefix support for 'wolfictl check update'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -309,3 +309,5 @@ require (
 )
 
 replace golang.org/x/vuln => github.com/luhring/golang-vuln v1.0.2-0.20231029212121-c364fd4725dc
+
+replace chainguard.dev/melange => github.com/smoser/melange v0.0.0-20240312132843-ec4906396e26

--- a/go.sum
+++ b/go.sum
@@ -1019,6 +1019,8 @@ github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/smoser/melange v0.0.0-20240312132843-ec4906396e26 h1:khf1as/3rjQ/TJS7XYq5f3KKIip69tzMuNbxbMiFXQI=
+github.com/smoser/melange v0.0.0-20240312132843-ec4906396e26/go.mod h1:qg4YiiegjRcD/LH/NpvimDGkb1qlhCu1seTytSbxpoY=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/update/githubReleases.go
+++ b/pkg/update/githubReleases.go
@@ -600,6 +600,13 @@ func (o GitHubReleaseOptions) prepareVersion(nameHash, v, id string) (string, er
 		return "", fmt.Errorf("no github update config found for package %s", id)
 	}
 
+	if c.Update.FilterPrefix != "" {
+		// if the version did not match the prefix then ignore it.
+		if !strings.HasPrefix(v, c.Update.FilterPrefix) {
+			return "", nil
+		}
+	}
+
 	// the github graphql query filter matches any occurrence, we want to make that more strict and remove any tags that do not START with the filter
 	// deprecated: todo: ajayk remove this once we have migrated over to TagFilterPrefix
 	if ghm.TagFilter != "" {

--- a/pkg/update/releaseMonitor.go
+++ b/pkg/update/releaseMonitor.go
@@ -103,6 +103,13 @@ ReleaseMonitorPackagesLoop:
 			}
 		}
 
+		if p.Config.Update.FilterPrefix != "" {
+			// if the version did not match the prefix then ignore it.
+			if !strings.HasPrefix(latestVersion, p.Config.Update.FilterPrefix) {
+				break ReleaseMonitorPackagesLoop
+			}
+		}
+
 		// replace any nonstandard version separators
 		if p.Config.Update.VersionSeparator != "" {
 			latestVersion = strings.ReplaceAll(latestVersion, p.Config.Update.VersionSeparator, ".")


### PR DESCRIPTION
This relies on
https://github.com/chainguard-dev/melange/pull/1083

And allows adding an "include prefix" for update checks.