### PR TITLE
go.mod: precise replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -308,4 +308,4 @@ require (
 	modernc.org/sqlite v1.29.2 // indirect
 )
 
-replace golang.org/x/vuln => github.com/luhring/golang-vuln v1.0.2-0.20231029212121-c364fd4725dc
+replace golang.org/x/vuln v1.0.1 => github.com/luhring/golang-vuln v1.0.2-0.20231029212121-c364fd4725dc


### PR DESCRIPTION
Use exact version in replace.

The hope here is to resolve this warning:

```
go: downloading github.com/wolfi-dev/wolfictl v0.15.4
go: github.com/wolfi-dev/wolfictl@v0.15.4 (in github.com/wolfi-dev/wolfictl@v0.15.4):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.

```