### PR TITLE
use "github.com/knqyf263/go-apk-version" to sort the versions for advisory validate

### DIFF
--- a/pkg/advisory/testdata/validate/fixed-version/mo.advisories.yaml
+++ b/pkg/advisory/testdata/validate/fixed-version/mo.advisories.yaml
@@ -1,0 +1,12 @@
+schema-version: 2.0.1
+
+package:
+  name: mo
+
+advisories:
+  - id: GHSA-2222-2222-2222
+    events:
+      - timestamp: 1970-01-01T00:00:00Z
+        type: fixed
+        data:
+          fixed-version: 1.0.0-r10

--- a/pkg/advisory/validate.go
+++ b/pkg/advisory/validate.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	goapkversion "github.com/knqyf263/go-apk-version"
+
 	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/go-apk/pkg/apk"
@@ -16,7 +18,6 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	"github.com/wolfi-dev/wolfictl/pkg/internal/errorhelpers"
-	"github.com/wolfi-dev/wolfictl/pkg/versions"
 )
 
 type ValidateOptions struct {
@@ -310,11 +311,11 @@ func (opts ValidateOptions) validateFixedVersionIsNotFirstVersionInAPKINDEX(ctx 
 	}
 
 	sort.Slice(packageVersions, func(i, j int) bool {
-		iVer, err := versions.NewVersion(packageVersions[i].Version)
+		iVer, err := goapkversion.NewVersion(packageVersions[i].Version)
 		if err != nil {
 			return true
 		}
-		jVer, err := versions.NewVersion(packageVersions[j].Version)
+		jVer, err := goapkversion.NewVersion(packageVersions[j].Version)
 		if err != nil {
 			return false
 		}

--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -308,6 +308,46 @@ func TestValidate(t *testing.T) {
 								Name:    "ko",
 								Version: "1.0.0-r2",
 							},
+							{
+								Name:    "mo",
+								Version: "1.0.0-r8",
+							},
+							{
+								Name:    "mo",
+								Version: "1.0.0-r9",
+							},
+							{
+								Name:    "mo",
+								Version: "1.0.0-r10",
+							},
+						},
+					},
+					shouldBeValid: true,
+				},
+				{
+					name: "fixed-version-present-and-not-first-missing-rs",
+					apkindex: &apk.APKIndex{
+						Packages: []*apk.Package{
+							{
+								Name:    "ko",
+								Version: "1.0.0-r1",
+							},
+							{
+								Name:    "ko",
+								Version: "1.0.0-r2",
+							},
+							{
+								Name:    "mo",
+								Version: "1.0.0-r8",
+							},
+							{
+								Name:    "mo",
+								Version: "1.0.0-r9",
+							},
+							{
+								Name:    "mo",
+								Version: "1.0.0-r10",
+							},
 						},
 					},
 					shouldBeValid: true,


### PR DESCRIPTION
this changes the sort versions to use the "github.com/knqyf263/go-apk-version" lib

we have an issue in the advisory validation when having package revisions that are missing r0, r1, for example, and have only `r8, r9, r10` for instance that was getting sorted wrong with the `r10` in the first

so we expected `1.0.0-r8, 1.0.0-r9,1.0.0-r10` for example and we were getting `1.0.0-r10, 1.0.0-r8, 1.0.0-r9`


real use case:

before the fix:

```
$ wolfictl adv validate -v --skip-alias
time=2024-03-13T14:51:33.590+01:00 level=INFO msg="detected distro" name=Chainguard
time=2024-03-13T14:51:36.924+01:00 level=INFO msg="validating index diff" diffIsZero=true
time=2024-03-13T14:51:36.924+01:00 level=INFO msg="validating fixed versions"
time=2024-03-13T14:51:36.942+01:00 level=INFO msg="skipping validation of alias set completeness, no alias finder provided"
❌ advisory data is not valid.

fixed version validation failure(s):
    kubernetes-csi-external-attacher-fips-4.3:
        CVE-2023-45289:
            event 2 (type: fixed):
                "4.3.0-r10" is the first version of the package listed in the APKINDEX, so it cannot be used as a fixed-version (consider switching type to "false-positive-determination")
        CVE-2023-45290:
            event 2 (type: fixed):
                "4.3.0-r10" is the first version of the package listed in the APKINDEX, so it cannot be used as a fixed-version (consider switching type to "false-positive-determination")
        CVE-2024-24783:
            event 2 (type: fixed):
                "4.3.0-r10" is the first version of the package listed in the APKINDEX, so it cannot be used as a fixed-version (consider switching type to "false-positive-determination")
        CVE-2024-24784:
            event 2 (type: fixed):
                "4.3.0-r10" is the first version of the package listed in the APKINDEX, so it cannot be used as a fixed-version (consider switching type to "false-positive-determination")
        CVE-2024-24785:
            event 2 (type: fixed):
                "4.3.0-r10" is the first version of the package listed in the APKINDEX, so it cannot be used as a fixed-version (consider switching type to "false-positive-determination")
```


after
```
$ wolfictl adv validate -v --skip-alias
time=2024-03-13T14:50:32.346+01:00 level=INFO msg="detected distro" name=Chainguard
time=2024-03-13T14:50:35.546+01:00 level=INFO msg="validating index diff" diffIsZero=true
time=2024-03-13T14:50:35.546+01:00 level=INFO msg="validating fixed versions"
time=2024-03-13T14:50:35.565+01:00 level=INFO msg="skipping validation of alias set completeness, no alias finder provided"
✅ advisory data is valid.
```