### PR TITLE
advisory: Don't filter fixed advisories affecting non-apk from scan results

### DIFF
--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -78,7 +78,7 @@ func (adv Advisory) Resolved() bool {
 // ResolvedAtVersion returns true if the advisory indicates that the
 // vulnerability does not affect the distro package at the given package
 // version, or that no further investigation is planned.
-func (adv Advisory) ResolvedAtVersion(version string, packageType string) bool {
+func (adv Advisory) ResolvedAtVersion(version, packageType string) bool {
 	if len(adv.Events) == 0 {
 		return false
 	}
@@ -101,7 +101,7 @@ func (adv Advisory) ResolvedAtVersion(version string, packageType string) bool {
 // ConcludedAtVersion returns true if the advisory indicates that the
 // vulnerability has been solved, or those where no change is
 // expected to fix the CVE in the upstream code.
-func (adv Advisory) ConcludedAtVersion(version string, packageType string) bool {
+func (adv Advisory) ConcludedAtVersion(version, packageType string) bool {
 	if len(adv.Events) == 0 {
 		return false
 	}
@@ -117,7 +117,7 @@ func (adv Advisory) ConcludedAtVersion(version string, packageType string) bool 
 
 // isFixedVersion determines whether the vulnerability discovered for the provided
 // version has been fixed.
-func (adv Advisory) isFixedVersion(version string, packageType string, latest Event) bool {
+func (adv Advisory) isFixedVersion(version, packageType string, latest Event) bool {
 	if packageType != "apk" {
 		return false
 	}

--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -78,7 +78,7 @@ func (adv Advisory) Resolved() bool {
 // ResolvedAtVersion returns true if the advisory indicates that the
 // vulnerability does not affect the distro package at the given package
 // version, or that no further investigation is planned.
-func (adv Advisory) ResolvedAtVersion(version string) bool {
+func (adv Advisory) ResolvedAtVersion(version string, packageType string) bool {
 	if len(adv.Events) == 0 {
 		return false
 	}
@@ -91,7 +91,7 @@ func (adv Advisory) ResolvedAtVersion(version string) bool {
 		return true
 
 	case EventTypeFixed:
-		return adv.isFixedVersion(version, latest)
+		return adv.isFixedVersion(version, packageType, latest)
 
 	default:
 		return false
@@ -101,7 +101,7 @@ func (adv Advisory) ResolvedAtVersion(version string) bool {
 // ConcludedAtVersion returns true if the advisory indicates that the
 // vulnerability has been solved, or those where no change is
 // expected to fix the CVE in the upstream code.
-func (adv Advisory) ConcludedAtVersion(version string) bool {
+func (adv Advisory) ConcludedAtVersion(version string, packageType string) bool {
 	if len(adv.Events) == 0 {
 		return false
 	}
@@ -112,12 +112,16 @@ func (adv Advisory) ConcludedAtVersion(version string) bool {
 	}
 	// NOTE: The resolved set is part of the concluded one
 	// with the exception of the pending-upstream-fix event type.
-	return adv.ResolvedAtVersion(version)
+	return adv.ResolvedAtVersion(version, packageType)
 }
 
 // isFixedVersion determines whether the vulnerability discovered for the provided
 // version has been fixed.
-func (adv Advisory) isFixedVersion(version string, latest Event) bool {
+func (adv Advisory) isFixedVersion(version string, packageType string, latest Event) bool {
+	if packageType != "apk" {
+		return false
+	}
+
 	givenVersion, err := versions.NewVersion(version)
 	if err != nil {
 		return false

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -87,7 +87,7 @@ func filterFindingsWithAllAdvisories(findings []Finding, packageAdvisories v2.Ad
 func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []Finding {
 	return lo.Filter(findings, func(finding Finding, _ int) bool {
 		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
-		if ok && adv.ResolvedAtVersion(currentPackageVersion) {
+		if ok && adv.ResolvedAtVersion(currentPackageVersion, finding.Package.Type) {
 			return false
 		}
 
@@ -98,7 +98,7 @@ func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories 
 				continue
 			}
 
-			if adv.ResolvedAtVersion(currentPackageVersion) {
+			if adv.ResolvedAtVersion(currentPackageVersion, finding.Package.Type) {
 				return false
 			}
 		}
@@ -110,7 +110,7 @@ func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories 
 func filterFindingsWithConcludedAdvisories(findings []Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []Finding {
 	return lo.Filter(findings, func(finding Finding, _ int) bool {
 		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
-		if ok && adv.ConcludedAtVersion(currentPackageVersion) {
+		if ok && adv.ConcludedAtVersion(currentPackageVersion, finding.Package.Type) {
 			return false
 		}
 
@@ -121,7 +121,7 @@ func filterFindingsWithConcludedAdvisories(findings []Finding, packageAdvisories
 				continue
 			}
 
-			if adv.ConcludedAtVersion(currentPackageVersion) {
+			if adv.ConcludedAtVersion(currentPackageVersion, finding.Package.Type) {
 				return false
 			}
 		}

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -147,6 +147,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 						Vulnerability: Vulnerability{
 							ID: "GHSA-2h5h-59f5-c5x9",
 						},
+						// Fixed advisories only work for type "apk"
+						Package: Package{
+							Type: "apk",
+						},
 					},
 				},
 			},
@@ -199,6 +203,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 					{
 						Vulnerability: Vulnerability{
 							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+						// Fixed advisories only work for type "apk"
+						Package: Package{
+							Type: "apk",
 						},
 					},
 				},
@@ -332,6 +340,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 						Vulnerability: Vulnerability{
 							ID: "GHSA-2h5h-59f5-c5x9",
 						},
+						// Fixed advisories only work for type "apk"
+						Package: Package{
+							Type: "apk",
+						},
 					},
 					{
 						Vulnerability: Vulnerability{
@@ -343,6 +355,48 @@ func TestFilterWithAdvisories(t *testing.T) {
 			advisoryIndicesGetter: getSingleAdvisoriesIndex,
 			advisoryFilterSet:     "concluded",
 			expectedFindings: []Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-1999-11111",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
+		},
+		{
+			name: "resolved advisory filter only filters type apk",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "0.13.0-r30",
+				},
+				Findings: []Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+						Package: Package{
+							Type: "go-module",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-1999-11111",
+						},
+					},
+				},
+			},
+			advisoryIndicesGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:     "concluded",
+			expectedFindings: []Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "GHSA-2h5h-59f5-c5x9",
+					},
+					Package: Package{
+						Type: "go-module",
+					},
+				},
 				{
 					Vulnerability: Vulnerability{
 						ID: "CVE-1999-11111",


### PR DESCRIPTION
Over the last 3-4 weeks, we found several instances where some package update PRs have removed valuable CVE fixes from a package. The latest example is `datadog-agent`, here's a rough sequence of events:

1. A new CVE is found: CVE-2024-23653
2. A language-level dependency update fixes the CVE: https://github.com/wolfi-dev/os/pull/12350
3. A new "fixed" advisory is filed in our dataset, noting the APK version that fixes the CVE: https://github.com/wolfi-dev/advisories/pull/1140
<< Issue begin >>
4. A new version of the package is available, the package is updated, but we incorrectly remove the CVE fix: https://github.com/wolfi-dev/os/pull/13291

At this point, the vulnerability scan comes back clean since we have already filed a `fixed` advisory and we have a blindspot. In practice, the `fixed` advisory only removes findings on `apk` packages. That means this package still contains CVEs, but our automation isn't fixing them.

This PR suggests only considering `fixed` advisory as a resolved status for `apk` findings. This will make `wolfictl scan` behave more closely to Grype