### PR TITLE
scan: Actually skip on err instead of pretending

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -269,6 +269,7 @@ func scanEverything(ctx context.Context, p *scanParams, inputs []string, advisor
 			if err := errs[i]; err != nil {
 				if p.outputFormat == outputFormatOutline {
 					fmt.Printf("❌ Skipping scan because SBOM generation failed for %q: %v\n", input, err)
+					continue
 				}
 			}
 


### PR DESCRIPTION
Before:

```
wolfictl scan test
❌ Skipping scan because SBOM generation failed for "test": failed to open input file: failed to open input file: open test: no such file or directory
🔎 Scanning "test"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x103bad734]

goroutine 52 [running]:
github.com/wolfi-dev/wolfictl/pkg/scan.newTargetAPK(0x0)
	/Users/jonjohnson/src/github.com/wolfi-dev/wolfictl/pkg/scan/apk.go:72 +0x54
github.com/wolfi-dev/wolfictl/pkg/scan.(*Scanner).APKSBOM(0x14000658c30, 0x0)
	/Users/jonjohnson/src/github.com/wolfi-dev/wolfictl/pkg/scan/apk.go:162 +0x30
github.com/wolfi-dev/wolfictl/pkg/cli.(*scanParams).doScanCommandForSingleInput(0x14000358150, {0x104ec1690, 0x14000b5acc0}, 0x11?, 0x0, 0x1?, {0x10619d920, 0x0, 0x0})
	/Users/jonjohnson/src/github.com/wolfi-dev/wolfictl/pkg/cli/scan.go:406 +0x48
github.com/wolfi-dev/wolfictl/pkg/cli.scanEverything.func1()
	/Users/jonjohnson/src/github.com/wolfi-dev/wolfictl/pkg/cli/scan.go:282 +0x3a8
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/Users/jonjohnson/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x58
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
	/Users/jonjohnson/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x98
```

After:

```
wolfictl scan test
❌ Skipping scan because SBOM generation failed for "test": failed to open input file: failed to open input file: open test: no such file or directory
2024/03/26 13:06:14 INFO error during command execution: failed to open input file: failed to open input file: open test: no such file or directory
```