### PR TITLE
Add a new filter when listing the CVEs of a package

### DIFF
--- a/docs/cmd/wolfictl_scan.md
+++ b/docs/cmd/wolfictl_scan.md
@@ -50,6 +50,8 @@ filtering. The following sets of advisories are available:
 - "concluded": Only filter out all vulnerabilities that have been fixed, or those
   where no change is planned to fix the vulnerability.
 
+- "concluded-or-pending": Only filter out all vulnerabilities that have been fixed, or those where upstream changes are pending to fix the vulnerability.
+
 ## AUTO-TRIAGING
 
 Wolfictl now supports auto-triaging vulnerabilities found in Go binaries using

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -83,6 +83,9 @@ filtering. The following sets of advisories are available:
 - "concluded": Only filter out all vulnerabilities that have been fixed, or those
   where no change is planned to fix the vulnerability.
 
+- "concluded-or-pending": Only filter out all vulnerabilities that have been fixed, or those
+  where upstream changes are pending to fix the vulnerability.
+
 ## AUTO-TRIAGING
 
 Wolfictl now supports auto-triaging vulnerabilities found in Go binaries using

--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -115,6 +115,23 @@ func (adv Advisory) ConcludedAtVersion(version, packageType string) bool {
 	return adv.ResolvedAtVersion(version, packageType)
 }
 
+// ConcludedOrPendingAtVersion returns true if the advisory indicates that the
+// vulnerability has been solved, or those where upstream changes are
+// expected to fix the CVE in the upstream code.
+func (adv Advisory) ConcludedOrPendingAtVersion(version, packageType string) bool {
+	if len(adv.Events) == 0 {
+		return false
+	}
+
+	latest := adv.Latest()
+	if latest.Type == EventTypePendingUpstreamFix {
+		return true
+	}
+	// NOTE: The resolved set is part of the concluded one
+	// with the exception of the pending-upstream-fix event type.
+	return adv.ConcludedAtVersion(version, packageType)
+}
+
 // isFixedVersion determines whether the vulnerability discovered for the provided
 // version has been fixed.
 func (adv Advisory) isFixedVersion(version, packageType string, latest Event) bool {

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -364,6 +364,41 @@ func TestFilterWithAdvisories(t *testing.T) {
 			errAssertion: assert.NoError,
 		},
 		{
+			name: "use concluded-or-pending advisory filter with a newer version",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "ko",
+					Version: "0.13.0-r30",
+				},
+				Findings: []Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+						// Fixed advisories only work for type "apk"
+						Package: Package{
+							Type: "apk",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-1999-11111",
+						},
+					},
+				},
+			},
+			advisoryIndicesGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:     "concluded-or-pending",
+			expectedFindings: []Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-1999-11111",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
+		},
+		{
 			name: "resolved advisory filter only filters type apk",
 			result: &Result{
 				TargetAPK: TargetAPK{


### PR DESCRIPTION
This new filter includes the type of CVEs marked as concluded + pending-upstream-changes. We are still discussing this new behaviour here https://chainguard-dev.slack.com/archives/C0636FTRFED/p1711971208619639. But I wanted to open a draft PR to save us some time.

The name of the filter is a **TBD**. 

I manually tested using a package:

```
➜  wolfictl scan packages/aarch64/newrelic-infrastructure-agent-1.43-1.43.2-r6.apk --advisories-repo-dir=../enterprise-advisories --advisory-filter=concluded
🔎 Scanning "packages/aarch64/newrelic-infrastructure-agent-1.43-1.43.2-r6.apk"
├── 📄 /usr/bin/newrelic-infra
│       📦 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.13.0 (go-module)
│           High CVE-2023-45142 GHSA-rcjv-mgp8-qvmr fixed in 0.44.0
│
├── 📄 /usr/bin/newrelic-infra-ctl
│       📦 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.13.0 (go-module)
│           High CVE-2023-45142 GHSA-rcjv-mgp8-qvmr fixed in 0.44.0
│
└── 📄 /usr/bin/newrelic-infra-service
        📦 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.13.0 (go-module)
            High CVE-2023-45142 GHSA-rcjv-mgp8-qvmr fixed in 0.44.0

➜  wolfictl scan packages/aarch64/newrelic-infrastructure-agent-1.43-1.43.2-r6.apk --advisories-repo-dir=../enterprise-advisories --advisory-filter=concluded-or-pending
🔎 Scanning "packages/aarch64/newrelic-infrastructure-agent-1.43-1.43.2-r6.apk"
✅ No vulnerabilities found
`
``