### PR TITLE
build: Consider subpackages for build order

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -148,9 +148,9 @@ func walkConfigs(ctx context.Context, cfg *global) (*configStuff, error) {
 	}
 
 	// Only return main packages (configs) because we can't build just subpackages.
-	g, err = g.Filter(dag.OnlyMainPackages(pkgs))
+	g, err = g.Targets()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("targets: %w", err)
 	}
 
 	m, err := g.Graph.AdjacencyMap()

--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -99,10 +99,7 @@ func text(g dag.Graph, pkgs *dag.Packages, arch string, t textType, w io.Writer)
 
 	for _, node := range all {
 		name := node.Name()
-		pkg, err := pkgs.PkgInfo(name)
-		if err != nil {
-			return err
-		}
+		pkg := pkgs.PkgInfo(name)
 
 		if pkg == nil {
 			// Expected for subpackages.

--- a/pkg/dag/testdata/subpackages/one.yaml
+++ b/pkg/dag/testdata/subpackages/one.yaml
@@ -1,0 +1,23 @@
+package:
+  name: one
+  version: "1.2.3"
+  epoch: 1
+  description:
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation:
+      license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+pipeline:
+  - runs: |
+      echo "pretending to build one"
+
+subpackages:
+  - name: one-dev

--- a/pkg/dag/testdata/subpackages/three.yaml
+++ b/pkg/dag/testdata/subpackages/three.yaml
@@ -1,0 +1,21 @@
+package:
+  name: three
+  version: "4.5.6"
+  epoch: 1
+  description:
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation:
+      license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - two
+pipeline:
+  - runs: |
+      echo "pretending to build three"

--- a/pkg/dag/testdata/subpackages/two.yaml
+++ b/pkg/dag/testdata/subpackages/two.yaml
@@ -1,0 +1,21 @@
+package:
+  name: two
+  version: "4.5.6"
+  epoch: 1
+  description:
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation:
+      license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - one-dev
+pipeline:
+  - runs: |
+      echo "pretending to build two"


### PR DESCRIPTION
Previously, we would just filter out any non-main packages in our build graph. Unfortunately, that filtered out any edges to subpackages that were important for build ordering.

As one real example, consider this dependency:

  spdlog -> fmt-dev

Since spdlog depends on fmt-dev, we need to build fmt-dev before we can build spdlog.

We can't build fmt-dev directly, since it's a subpackage of fmt, so we need to build fmt before we build spdlog.

Before this change, that edge would just get dropped and we would try to build spdlog and fmt at the same time. The spdlog build would fail because fmt-dev would not exist until after fmt completes.

With this change, dag.Graph.Targets() essentially flattens any subpackage nodes in the graph so that they are equivalent to the main package.

So after calling Targets(), that edge looks like this:

  spdlog -> fmt

Which preserves the necessary build order rather than ignoring it.

The reason this hasn't been a problem in the past is that we usually don't introduce two packages at the same time that have a dependency between them, so builds justs fall back to the version that already exists.