### PR TITLE
advisory guide: enabling advisory data entry by interview

### DIFF
--- a/docs/advisory_guide_flow.md
+++ b/docs/advisory_guide_flow.md
@@ -22,7 +22,7 @@ flowchart TD
 
     anyUnaddressedFindings -- Yes --> selectFinding{Select a vulnerability finding to resolve}
 
-    selectFinding --> hasTriageRecommendation{"Is a triaging recommendation available immediately?\n(see [Triaging recommendations])"}
+    selectFinding --> hasTriageRecommendation{"(NOT IN MVP) Is a triaging recommendation available immediately?\n(see [Triaging recommendations])"}
 
     hasTriageRecommendation -- Yes --> triageRecommendationPrompt{Does this recommendation look right?}
 
@@ -50,7 +50,7 @@ flowchart TD
 
     notSupportedIndication -- No --> fixAttempted{"Have you tried to fix the vulnerability yet?"}
 
-    fixAttempted -- "No, I need help" --> ecosystemSpecificGuidance
+    fixAttempted -- "No, I need help" --> wikiGuidanceOnHowToAttemptCVERemediation
 
     fixAttempted -- "Yes, please do the scan over again" --> scan
 
@@ -76,7 +76,7 @@ We could identify cases where the user shouldn't have to make any decisions, suc
 ## FP reasons
 
 - The maintainers of the component disagree that this is a security problem.
-    - Criteria: a web link for evidence
+    - (NOT FOR MVP) Criteria: a web link for evidence
 - This vulnerability is specific to another distro and not ours.
     - Don't offer FP reason if: no distro name found in CVE description
     - Criteria: select distro name that appears in the CVE description; otherwise don't allow this FP reason
@@ -92,3 +92,10 @@ We could identify cases where the user shouldn't have to make any decisions, suc
         - provide a relevant excerpt of the error message
 - A step I inserted or modified isn't having the effect I expected on the scanner results
     - Criteria: ?
+
+# notes from review session:
+
+- add literal "I DON'T KNOW!!!!!" options
+- maybe try a different approach w/ "is this package unsupported?"
+    - first, is there an explicit support policy that shows that this package is unsupported?
+    -

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/charmbracelet/log v0.4.0
+	github.com/cli/browser v1.3.0
 	github.com/cli/go-gh/v2 v2.8.0
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/dominikbraun/graph v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
+github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/cli/go-gh/v2 v2.8.0 h1:xFDgnhRiVMFanqACszdyRduUaFkoMOiasOrox0sKpKo=
 github.com/cli/go-gh/v2 v2.8.0/go.mod h1:U6GukjNwSqD6coCKP6FTp/yrPk5ttNYjAe+ZYSOFCVc=
 github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=

--- a/pkg/advisory/alias_finder.go
+++ b/pkg/advisory/alias_finder.go
@@ -25,6 +25,9 @@ type HTTPAliasFinder struct {
 	cacheCVEByGHSA  map[string]string
 }
 
+// TODO: Allow providing a standard GitHub client that has taken care of its own
+//  auth.
+
 func NewHTTPAliasFinderWithToken(client *http.Client, ghToken string) *HTTPAliasFinder {
 	return &HTTPAliasFinder{
 		ghToken:         ghToken,

--- a/pkg/advisory/data_session.go
+++ b/pkg/advisory/data_session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -180,8 +181,10 @@ func (ds DataSession) Push(ctx context.Context) error {
 
 // OpenPullRequest opens a pull request for the changes made during the session.
 func (ds DataSession) OpenPullRequest(ctx context.Context) (*PullRequest, error) {
+	slices.Sort(ds.modifiedPackages)
+	compact := slices.Compact(ds.modifiedPackages)
 	newPullRequest := github.NewPullRequest{
-		Title:               github.String(fmt.Sprintf("Add advisory data for %s", strings.Join(ds.modifiedPackages, ", "))),
+		Title:               github.String(fmt.Sprintf("Add advisory data for %s", strings.Join(compact, ", "))),
 		Body:                github.String(pullRequestBody),
 		Head:                github.String(ds.workingBranch),
 		Base:                github.String("main"),

--- a/pkg/advisory/data_session.go
+++ b/pkg/advisory/data_session.go
@@ -1,0 +1,237 @@
+package advisory
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/go-github/v58/github"
+	"github.com/google/uuid"
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+	"github.com/wolfi-dev/wolfictl/pkg/distro"
+	wgit "github.com/wolfi-dev/wolfictl/pkg/git"
+)
+
+type DataSession struct {
+	tempDir          string
+	repo             *git.Repository
+	workingBranch    string
+	distro           distro.Distro
+	index            *configs.Index[v2.Document]
+	githubClient     *github.Client
+	modified         bool
+	modifiedPackages []string
+}
+
+type DataSessionOptions struct {
+	Distro       distro.Distro
+	GitHubClient *github.Client
+}
+
+// NewDataSession initializes a new advisory data session for the specified
+// distro and returns a reference to the session. This call will retrieve the
+// data and manage it in a local temp directory until the session is closed. The
+// session should be closed by calling Close() when it is no longer needed.
+func NewDataSession(ctx context.Context, opts DataSessionOptions) (*DataSession, error) {
+	// create temp directory
+	tempDir, err := os.MkdirTemp("", "wolfictl-advisory-data-session-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	ds := &DataSession{
+		tempDir: tempDir,
+		distro:  opts.Distro,
+	}
+
+	ds.githubClient = opts.GitHubClient
+
+	// clone advisories repo
+	repo, err := git.PlainCloneContext(ctx, tempDir, false, &git.CloneOptions{
+		URL:  opts.Distro.Absolute.AdvisoriesHTTPSCloneURL(),
+		Auth: wgit.GetGitAuth(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloning advisories repo: %w", err)
+	}
+	ds.repo = repo
+
+	// checkout a new branch
+	u := uuid.New()
+	branchName := fmt.Sprintf("wolfictl-data-session-%s", u)
+	ds.workingBranch = branchName
+	wt, err := repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("getting worktree: %w", err)
+	}
+	err = wt.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(branchName),
+		Create: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("checking out new branch: %w", err)
+	}
+
+	// index advisory documents
+	index, err := v2.NewIndex(ctx, rwos.DirFS(tempDir))
+	if err != nil {
+		return nil, fmt.Errorf("indexing advisory documents: %w", err)
+	}
+	ds.index = index
+
+	return ds, nil
+}
+
+// Close closes the advisory data session and cleans up any temporary data that
+// was downloaded.
+func (ds DataSession) Close() error {
+	return os.RemoveAll(ds.tempDir)
+}
+
+// Create creates a new advisory within the context of the data session.
+func (ds *DataSession) Create(ctx context.Context, req Request) error {
+	err := Create(ctx, req, CreateOptions{
+		AdvisoryDocs: ds.index,
+	})
+	if err != nil {
+		return fmt.Errorf("creating advisory: %w", err)
+	}
+
+	err = ds.commit(ctx, req, "create")
+	if err != nil {
+		return fmt.Errorf("committing advisory creation: %w", err)
+	}
+
+	ds.modified = true
+	ds.modifiedPackages = append(ds.modifiedPackages, req.Package)
+
+	return nil
+}
+
+// Update updates an existing advisory within the context of the data session.
+func (ds *DataSession) Update(ctx context.Context, req Request) error {
+	err := Update(ctx, req, UpdateOptions{
+		AdvisoryDocs: ds.index,
+	})
+	if err != nil {
+		return fmt.Errorf("updating advisory: %w", err)
+	}
+
+	err = ds.commit(ctx, req, "update")
+	if err != nil {
+		return fmt.Errorf("committing advisory update: %w", err)
+	}
+
+	ds.modified = true
+	ds.modifiedPackages = append(ds.modifiedPackages, req.Package)
+
+	return nil
+}
+
+// Append creates a new event for an advisory if the advisory already exists, or
+// creates a new advisory with the event if the advisory does not already exist.
+func (ds *DataSession) Append(ctx context.Context, req Request) error {
+	packageSelection := ds.index.Select().WhereName(req.Package)
+	if packageSelection.Len() == 0 {
+		return ds.Create(ctx, req)
+	}
+
+	if _, exists := packageSelection.Configurations()[0].Advisories.GetByVulnerability(req.VulnerabilityID); !exists {
+		return ds.Create(ctx, req)
+	}
+
+	return ds.Update(ctx, req)
+}
+
+// Dir returns the path to the temporary directory where the session's advisory
+// data is currently stored.
+func (ds DataSession) Dir() string {
+	return ds.tempDir
+}
+
+// Index returns the index of advisory documents for the session.
+func (ds DataSession) Index() *configs.Index[v2.Document] {
+	return ds.index
+}
+
+// Modified returns true if any changes have been made to the advisory data
+// during the session.
+func (ds DataSession) Modified() bool {
+	return ds.modified
+}
+
+// Push pushes the changes made during the session to the remote advisories
+// repository.
+func (ds DataSession) Push(ctx context.Context) error {
+	err := ds.repo.PushContext(ctx, &git.PushOptions{
+		RemoteURL: ds.distro.Absolute.AdvisoriesHTTPSCloneURL(),
+		Auth:      wgit.GetGitAuth(),
+	})
+	if err != nil {
+		return fmt.Errorf("pushing changes: %w", err)
+	}
+
+	return nil
+}
+
+// OpenPullRequest opens a pull request for the changes made during the session.
+func (ds DataSession) OpenPullRequest(ctx context.Context) (*PullRequest, error) {
+	newPullRequest := github.NewPullRequest{
+		Title:               github.String(fmt.Sprintf("Add advisory data for %s", strings.Join(ds.modifiedPackages, ", "))),
+		Body:                github.String(pullRequestBody),
+		Head:                github.String(ds.workingBranch),
+		Base:                github.String("main"),
+		MaintainerCanModify: github.Bool(true),
+	}
+
+	pullRequest, _, err := ds.githubClient.PullRequests.Create(
+		ctx,
+		ds.distro.Absolute.DistroRepoOwner,
+		ds.distro.Absolute.DistroAdvisoriesRepo,
+		&newPullRequest,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating pull request on GitHub: %w", err)
+	}
+
+	pr := PullRequest{
+		URL: pullRequest.GetHTMLURL(),
+	}
+
+	return &pr, nil
+}
+
+const pullRequestBody = "This PR was created using the `wolfictl adv guide` command."
+
+type PullRequest struct {
+	URL string
+}
+
+// commit creates a commit in the advisory repo for the specified operation.
+func (ds DataSession) commit(_ context.Context, req Request, operation string) error {
+	commitMessage := fmt.Sprintf(
+		"%s: %s advisory %s",
+		req.Package,
+		operation,
+		req.VulnerabilityID,
+	)
+
+	wt, err := ds.repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("getting worktree: %w", err)
+	}
+	err = wt.AddGlob(fmt.Sprintf("%s.advisories.yaml", req.Package))
+	if err != nil {
+		return fmt.Errorf("staging changes: %w", err)
+	}
+	_, err = wt.Commit(commitMessage, &git.CommitOptions{})
+	if err != nil {
+		return fmt.Errorf("creating commit: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -1,7 +1,10 @@
 package advisory
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
@@ -41,4 +44,37 @@ func (req Request) Validate() error {
 	}
 
 	return req.Event.Validate()
+}
+
+// ResolveAliases ensures that the request ID is a CVE and that any known GHSA
+// IDs are discovered and stored as Aliases.
+func (req Request) ResolveAliases(ctx context.Context, af AliasFinder) (*Request, error) {
+	switch {
+	case vuln.RegexGHSA.MatchString(req.VulnerabilityID):
+		cve, err := af.CVEForGHSA(ctx, req.VulnerabilityID)
+		if err != nil {
+			return nil, fmt.Errorf("resolving GHSA %q: %w", req.VulnerabilityID, err)
+		}
+
+		req.Aliases = append(req.Aliases, req.VulnerabilityID)
+		slices.Sort(req.Aliases)
+		req.Aliases = slices.Compact(req.Aliases)
+
+		req.VulnerabilityID = cve
+		return &req, nil
+
+	case vuln.RegexCVE.MatchString(req.VulnerabilityID):
+		ghsas, err := af.GHSAsForCVE(ctx, req.VulnerabilityID)
+		if err != nil {
+			return nil, fmt.Errorf("resolving CVE %q: %w", req.VulnerabilityID, err)
+		}
+
+		req.Aliases = append(req.Aliases, ghsas...)
+		slices.Sort(req.Aliases)
+		req.Aliases = slices.Compact(req.Aliases)
+
+		return &req, nil
+	}
+
+	return nil, fmt.Errorf("unsupported vulnerability ID format: %q", req.VulnerabilityID)
 }

--- a/pkg/cli/advisory_diff.go
+++ b/pkg/cli/advisory_diff.go
@@ -69,7 +69,7 @@ func cmdAdvisoryDiff() *cobra.Command {
 }
 
 func getAdvisoriesHTTPSRemoteURL(d distro.Distro) (string, error) {
-	for _, u := range d.Absolute.AdvisoriesRemoteURLs {
+	for _, u := range d.Absolute.AdvisoriesRemoteURLs() {
 		if strings.HasPrefix(u, "https://") {
 			return u, nil
 		}

--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,19 +13,25 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/cli/browser"
 	"github.com/dustin/go-humanize"
+	"github.com/google/go-github/v58/github"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/ctrlcwrapper"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/interview"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/keytocontinue"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/picker"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/internal/builds"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/internal/questions"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/internal/wrapped"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
-	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
 	"github.com/wolfi-dev/wolfictl/pkg/scan"
+	"github.com/wolfi-dev/wolfictl/pkg/vuln"
 )
 
 func cmdAdvisoryGuide() *cobra.Command {
@@ -35,6 +43,13 @@ func cmdAdvisoryGuide() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
+
+			// Construct some things we'll need later.
+
+			githubClient := github.NewClient(nil).WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+			af := advisory.NewHTTPAliasFinder(http.DefaultClient)
+
+			// Begin the guide!
 
 			if !opts.speedy {
 				fmt.Println()
@@ -51,7 +66,7 @@ func cmdAdvisoryGuide() *cobra.Command {
 					),
 				).Run()
 				if err != nil {
-					return fmt.Errorf("failed to run key_to_continue program: %w", err)
+					return fmt.Errorf("running key_to_continue: %w", err)
 				}
 				if m, ok := model.(ctrlcwrapper.Any); ok {
 					if m.UserWantsToExit() {
@@ -67,20 +82,18 @@ func cmdAdvisoryGuide() *cobra.Command {
 				return fmt.Errorf("failed to get current working directory: %w", err)
 			}
 
-			detected, err := distro.DetectFromDir(cwd)
+			detected, err := distro.DetectFromDirV2(cwd)
 			if err != nil {
-				if errors.Is(err, distro.ErrNotDistroRepo) {
+				if errors.Is(err, distro.ErrNotPackagesRepo) {
 					wrapped.Fatal(errorForNotADistroDirectory(cwd))
 				}
-
-				// TODO: handle other cases, such as: this is the distro dir but there's no advisories clone for it
 
 				return fmt.Errorf("failed to detect distro: %w", err)
 			}
 
 			wrapped.Println(fmt.Sprintf(
-				"It looks like you're working in the %s distro.",
-				styleBold.Render(detected.Absolute.Name),
+				"It looks like you're working in %s.",
+				styles.Bold().Render(detected.Absolute.Name),
 			))
 			fmt.Println()
 
@@ -92,17 +105,15 @@ func cmdAdvisoryGuide() *cobra.Command {
 
 			wrapped.Println(fmt.Sprintf(
 				"We'll look in %s to see what packages you've built so far.",
-				styleBold.Render(packagesDir),
+				styles.Bold().Render(packagesDir),
 			))
 			fmt.Println()
 
 			opts.pause()
 
 			fsys := os.DirFS(packagesDir)
-
 			buildMap, err := builds.Find(fsys, detected.Absolute.SupportedArchitectures)
 			if err != nil {
-				// TODO: make this a user friendly error!
 				return fmt.Errorf("failed to find builds: %w", err)
 			}
 
@@ -116,47 +127,51 @@ func cmdAdvisoryGuide() *cobra.Command {
 				return buildGroups[i].Origin.FileInfo.ModTime().After(buildGroups[j].Origin.FileInfo.ModTime())
 			})
 
-			// Take at most the 5 latest
+			// Look at only the 5 latest builds
 			if len(buildGroups) > 5 {
 				buildGroups = buildGroups[:5]
 			}
 
-			p := picker.New(buildGroups, renderBuildGroup)
-
-			model, err := tea.NewProgram(ctrlcwrapper.New(p)).Run()
-			if err != nil {
-				return fmt.Errorf("failed to run picker for build groups: %w", err)
+			bgPickerOpts := picker.Options[builds.BuildGroup]{
+				Items:               buildGroups,
+				MessageForZeroItems: "No builds found",
+				ItemRenderFunc:      renderBuildGroup,
 			}
-			if m, ok := model.(ctrlcwrapper.Model[picker.Model[builds.BuildGroup]]); ok {
-				if m.UserWantsToExit() {
+			bgPicker := picker.New(bgPickerOpts)
+			bgPickerTea, err := tea.NewProgram(ctrlcwrapper.New(bgPicker)).Run()
+			if err != nil {
+				return fmt.Errorf("running picker for build groups: %w", err)
+			}
+			if bgPickerCtrlC, ok := bgPickerTea.(ctrlcwrapper.Model[picker.Model[builds.BuildGroup]]); ok {
+				if bgPickerCtrlC.UserWantsToExit() {
 					return nil
 				}
 
-				p = m.Unwrap()
+				bgPicker = bgPickerCtrlC.Unwrap()
 			}
+			bg := bgPicker.Picked()
 
-			bg := p.Picked
-
-			wrapped.Println(fmt.Sprintf("Cool! We'll focus on %s.\n", styleBold.Render(bg.Origin.PkgInfo.Name)))
+			if !opts.speedy {
+				wrapped.Println(fmt.Sprintf("Cool! We'll focus on %s.\n", styles.Bold().Render(bg.Origin.PkgInfo.Name)))
+			}
 
 			opts.pause()
 
 			fmt.Println(sectionDivider)
 			fmt.Println()
 
-			// Step: Scan packages for vulnerabilities
+			if !opts.speedy {
+				wrapped.Println(fmt.Sprintf(
+					"Filing advisory data is necessary %s there are vulnerabilities in the APKs you've built that don't already have the advisory data they need.\n",
+					styleBoldItalic.Render("if and only if"),
+				))
 
-			// TODO: Show the user the equivalent `wolfictl scan ...` command to run if they're curious about isolating this step
+				opts.pause()
 
-			// TODO: factor out this message
-			wrapped.Println(fmt.Sprintf(
-				"Filing advisory data is necessary %s there are vulnerabilities in the APKs you've built that don't already have the advisory data they need.\n",
-				styleBoldItalic.Render("if and only if"),
-			))
+				wrapped.Println("So, to see how much work we have to do, we'll scan your APK file(s) for vulnerabilities, and we'll filter out the vulnerabilities that already have the advisory data they need.\n")
+			}
 
-			opts.pause()
-
-			wrapped.Println("So, to see how much work we have to do, we'll scan your APK file(s) for vulnerabilities.\n")
+			// Scan all APK builds from the build group!
 
 			distroID := strings.ToLower(detected.Absolute.Name)
 
@@ -165,71 +180,190 @@ func cmdAdvisoryGuide() *cobra.Command {
 				return fmt.Errorf("failed to create vulnerability scanner: %w", err)
 			}
 
-			apkfile, err := fsys.Open(bg.Origin.FsysPath)
+			results, err := bg.Scan(ctx, scanner, distroID)
 			if err != nil {
-				return fmt.Errorf("failed to open APK file: %w", err)
+				return fmt.Errorf("failed to scan build group: %w", err)
 			}
+			collated := collateVulnerabilities(results)
 
-			// TODO: insert animation for scanning
+			// Grab the latest advisory data in a new session.
 
-			// TODO: figure out how to ensure the local advisory data is up to date
-
-			advisoryFsys := rwos.DirFS(detected.Local.AdvisoriesRepo.Dir)
-			index, err := v2.NewIndex(ctx, advisoryFsys)
+			sess, err := advisory.NewDataSession(
+				ctx,
+				advisory.DataSessionOptions{
+					Distro:       detected,
+					GitHubClient: githubClient,
+				},
+			)
 			if err != nil {
-				return fmt.Errorf("failed to create advisory index: %w", err)
+				return fmt.Errorf("initializing advisory data session: %w", err)
 			}
+			defer sess.Close()
 
-			result, err := scanner.ScanAPK(ctx, apkfile, distroID)
-			if err != nil {
-				return fmt.Errorf("failed to scan APK: %w", err)
-			}
+			// Important! If there are no vulns from the get-go, exit with a happy message and don't run any pickers.
+			triagingHasBegun := false
 
-			// TODO: scan the rest of the build group, too!
+			// Continue to look for unaddressed vulnerabilities until there are none left
+			// (or the user quits early).
 
-			remainingFindings, err := scan.FilterWithAdvisories(*result, []*configs.Index[v2.Document]{index}, scan.AdvisoriesSetResolved)
-			if err != nil {
-				return err
-			}
+			for {
+				filtered, err := filterCollatedVulnerabilities(collated, sess)
+				if err != nil {
+					return fmt.Errorf("filtering APK findings with advisories: %w", err)
+				}
 
-			countRemainingFindings := len(remainingFindings)
-			if countRemainingFindings == 0 {
+				if len(filtered) == 0 && !triagingHasBegun {
+					wrapped.Println("🎉 No vulnerabilities found that need advisory data. You're all set!\n")
+					return nil
+				}
+				triagingHasBegun = true
+
+				sort.Slice(filtered, func(i, j int) bool {
+					return filtered[i].Result.Findings[0].Vulnerability.ID < filtered[j].Result.Findings[0].Vulnerability.ID
+				})
+
+				// Let the user pick a package vulnerability match to focus on.
+
+				wrapped.Println("Remaining vulnerabilities:\n")
+
+				var actions []picker.CustomAction[resultWithAPKs]
+				if len(filtered) > 0 {
+					actions = append(actions, customActionBrowser)
+				}
+				if sess.Modified() {
+					actions = append(actions, newCustomActionPR(ctx, sess))
+				}
+
+				vaPickerOpts := picker.Options[resultWithAPKs]{
+					Items:               filtered,
+					MessageForZeroItems: "✅ No vulnerabilities left. Let's open a PR!",
+					ItemRenderFunc:      renderResultWithAPKs,
+					CustomActions:       actions,
+				}
+				vaPicker := picker.New(vaPickerOpts)
+				vaPickerTea, err := tea.NewProgram(ctrlcwrapper.New(vaPicker)).Run()
+				if err != nil {
+					return fmt.Errorf("running picker for vulnerabilities: %w", err)
+				}
+				if vaPickerCtrlC, ok := vaPickerTea.(ctrlcwrapper.Model[picker.Model[resultWithAPKs]]); ok {
+					if vaPickerCtrlC.UserWantsToExit() {
+						return nil
+					}
+
+					vaPicker = vaPickerCtrlC.Unwrap()
+				}
+				vaPicked := vaPicker.Picked()
+				if vaPicked == nil {
+					// The user selected a custom action that quit the picker. Nothing was picked.
+					return nil
+				}
+
+				// Interview the user about the selected vulnerability match to derive an
+				// advisory request.
+
+				req := advisory.Request{
+					Package:         vaPicked.APKs[0],
+					VulnerabilityID: vaPicked.Result.Findings[0].Vulnerability.ID,
+				}
+				resolvedReq, err := req.ResolveAliases(ctx, af)
+				if err != nil {
+					return fmt.Errorf("resolving aliases for advisory request: %w", err)
+				}
+				req = *resolvedReq
+
+				iv := interview.New(questionIsThisAFalsePositive, req)
+				ivTea, err := tea.NewProgram(ctrlcwrapper.New(iv)).Run()
+				if err != nil {
+					return fmt.Errorf("running interview for advisory request: %w", err)
+				}
+				if ivCtrlC, ok := ivTea.(ctrlcwrapper.Model[interview.Model[advisory.Request]]); ok {
+					if ivCtrlC.UserWantsToExit() {
+						return nil
+					}
+
+					iv = ivCtrlC.Unwrap()
+				}
+
+				req = iv.State()
+
+				err = sess.Append(ctx, req)
+				if err != nil {
+					return fmt.Errorf("adding advisory data: %w", err)
+				}
+
+				aka := ""
+				if len(req.Aliases) > 0 {
+					aka = fmt.Sprintf(" (%s)", strings.Join(req.Aliases, ", "))
+				}
+
 				wrapped.Println(fmt.Sprintf(
-					"Great news! We didn't find any vulnerabilities in %s that don't already have resolutions in the advisory data.\n",
-					styleBold.Render(bg.Origin.PkgInfo.Name),
+					"🙌 Nice! We've marked %s in %s as %s.\n",
+					styles.Bold().Render(req.VulnerabilityID+aka),
+					styles.Bold().Render(req.Package),
+					styles.Bold().Render(humanizeAdvisoryEventType(req.Event.Type)),
 				))
-
-				opts.pause()
-
-				wrapped.Println("You're all done with this package! 🎉\n")
-
-				return nil
 			}
-
-			vulnNoun := "vulnerability"
-			vulnPronoun := "it"
-			if countRemainingFindings > 1 {
-				vulnNoun = "vulnerabilities"
-				vulnPronoun = "them"
-			}
-
-			wrapped.Println(fmt.Sprintf(
-				"Alrighty then! We found %d %s in %s lacking a resolution in the advisory data. Let's take a look at %s.",
-				countRemainingFindings,
-				vulnNoun,
-				styleBold.Render(bg.Origin.PkgInfo.Name),
-				vulnPronoun,
-			))
-
-			fmt.Println()
-
-			return nil
 		},
 	}
 
 	opts.addToCmd(cmd)
 	return cmd
 }
+
+func humanizeAdvisoryEventType(typ string) string {
+	switch typ {
+	case v2.EventTypeFalsePositiveDetermination:
+		return "a false positive"
+
+	case v2.EventTypeTruePositiveDetermination:
+		return "a true positive"
+
+	case v2.EventTypeAnalysisNotPlanned:
+		return "not planned for analysis"
+
+	case v2.EventTypeFixNotPlanned:
+		return "not planned for a fix"
+
+	case v2.EventTypeFixed:
+		return "fixed"
+	}
+
+	return typ
+}
+
+var (
+	customActionBrowser = picker.CustomAction[resultWithAPKs]{
+		Key:         "b",
+		Description: "to see the vulnerability in a web browser",
+		Do: func(selected resultWithAPKs) tea.Cmd {
+			id := selected.Result.Findings[0].Vulnerability.ID
+			u := vuln.URL(id)
+			_ = browser.OpenURL(u)
+			return nil
+		},
+	}
+
+	newCustomActionPR = func(ctx context.Context, sess *advisory.DataSession) picker.CustomAction[resultWithAPKs] {
+		return picker.CustomAction[resultWithAPKs]{
+			Key:         "p",
+			Description: "to open a PR with your updates",
+			Do: func(_ resultWithAPKs) tea.Cmd {
+				err := sess.Push(ctx)
+				if err != nil {
+					return picker.ErrCmd(fmt.Errorf("data session push: %w", err))
+				}
+
+				pr, err := sess.OpenPullRequest(ctx)
+				if err != nil {
+					return picker.ErrCmd(fmt.Errorf("data session pull request: %w", err))
+				}
+
+				_ = browser.OpenURL(pr.URL)
+				return tea.Quit
+			},
+		}
+	}
+)
 
 type advisoryGuideParams struct {
 	speedy bool
@@ -243,6 +377,87 @@ func (p advisoryGuideParams) pause() {
 	if !p.speedy {
 		time.Sleep(1200 * time.Millisecond)
 	}
+}
+
+// resultWithAPKs holds a scan result with a single finding and a list of the
+// APK names affected by the vulnerability.
+type resultWithAPKs struct {
+	Result scan.Result
+	APKs   []string
+}
+
+func renderResultWithAPKs(r resultWithAPKs) string {
+	finding := r.Result.Findings[0]
+	return fmt.Sprintf(
+		"%s (%s) %s @ %s (%d APKs)",
+		finding.Vulnerability.ID,
+		finding.Package.Type,
+		finding.Package.Name,
+		finding.Package.Version,
+		len(r.APKs),
+	)
+}
+
+// collateVulnerabilities takes a slice of scan.Result and returns a slice of
+// resultWithAPKs.
+func collateVulnerabilities(results []scan.Result) []resultWithAPKs {
+	vulnAPKsMap := make(map[string]resultWithAPKs)
+
+	for _, result := range results {
+		for _, finding := range result.Findings {
+			match, exists := vulnAPKsMap[finding.Vulnerability.ID]
+			if !exists {
+				match = resultWithAPKs{
+					Result: scan.Result{
+						TargetAPK: result.TargetAPK,
+						Findings:  []scan.Finding{finding},
+					},
+					APKs: []string{},
+				}
+			}
+			match.APKs = append(match.APKs, result.TargetAPK.Name)
+			vulnAPKsMap[finding.Vulnerability.ID] = match
+		}
+	}
+
+	var vulnAPKs []resultWithAPKs
+	for _, v := range vulnAPKsMap {
+		vulnAPKs = append(vulnAPKs, v)
+	}
+
+	return vulnAPKs
+}
+
+func filterCollatedVulnerabilities(apkResults []resultWithAPKs, sess *advisory.DataSession) ([]resultWithAPKs, error) {
+	var filtered []resultWithAPKs
+	indexes := []*configs.Index[v2.Document]{sess.Index()}
+
+	for _, ar := range apkResults {
+		filteredFindings, err := scan.FilterWithAdvisories(
+			ar.Result,
+			indexes,
+			scan.AdvisoriesSetConcluded,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("filtering result findings with advisories: %w", err)
+		}
+
+		if len(filteredFindings) == 0 {
+			continue
+		}
+
+		filteredResult := resultWithAPKs{
+			Result: scan.Result{
+				TargetAPK: ar.Result.TargetAPK,
+				Findings:  filteredFindings,
+			},
+			APKs: ar.APKs,
+		}
+
+		filtered = append(filtered, filteredResult)
+	}
+
+	return filtered, nil
 }
 
 func renderBuildGroup(bg builds.BuildGroup) string {
@@ -295,16 +510,100 @@ var (
 	sectionDivider = wrapped.Repeat("—")
 
 	welcomeMessage = func() string {
-		return fmt.Sprintf(welcomeMessageFormat, styleBold.Render("ctrl+C"))
+		return fmt.Sprintf(welcomeMessageFormat, styles.Bold().Render("ctrl+C"))
 	}()
 
 	errorForNotADistroDirectory = func(cwd string) string {
 		return fmt.Sprintf(
 			notADistroDirectoryMessageFormat,
-			styleBold.Render(cwd),
-			styleBold.Copy().Italic(true).Render("is"),
+			styles.Bold().Render(cwd),
+			styles.Bold().Copy().Italic(true).Render("is"),
 		)
 	}
 
 	styleBoldItalic = lipgloss.NewStyle().Bold(true).Italic(true)
+)
+
+var (
+	questionIsThisAFalsePositive = questions.Question[advisory.Request]{
+		Text: "Any obvious sign that this is a false positive?",
+		Choices: []questions.Choice[advisory.Request]{
+			{
+				Text: "No",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *questions.Question[advisory.Request]) {
+					return req, &questionIsPackageSupported
+				},
+			},
+			{
+				Text: "Yes",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *questions.Question[advisory.Request]) {
+					e := v2.Event{
+						Timestamp: v2.Now(),
+						Type:      v2.EventTypeFalsePositiveDetermination,
+					}
+
+					req.Event = e
+					return req, &questionWhyFalsePositive
+				},
+			},
+		},
+	}
+
+	questionWhyFalsePositive = questions.Question[advisory.Request]{
+		Text: "Why is this a false positive?",
+		Choices: []questions.Choice[advisory.Request]{
+			{
+				Text: "The maintainers don't agree that this is a security problem.",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *questions.Question[advisory.Request]) {
+					req.Event.Data = v2.FalsePositiveDetermination{
+						Type: v2.FPTypeVulnerabilityRecordAnalysisContested,
+						Note: "The maintainers don't agree that this is a security problem.",
+					}
+					// TODO: Get more specific: Link to a citation? Where is the dispute recorded and who made it?
+					return req, nil
+				},
+			},
+			{
+				Text: "This is specific to another distro, not ours.",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *questions.Question[advisory.Request]) {
+					req.Event.Data = v2.FalsePositiveDetermination{
+						Type: v2.FPTypeComponentVulnerabilityMismatch,
+						Note: "This is specific to another distro, not ours.",
+					}
+					// TODO: Which distro?
+					return req, nil
+				},
+			},
+			{
+				Text: "This seems to refer to a past version of the software, not the version we have now.",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *questions.Question[advisory.Request]) {
+					req.Event.Data = v2.FalsePositiveDetermination{
+						Type: v2.FPTypeVulnerableCodeVersionNotUsed,
+						Note: "This seems to refer to a past version of the software, not the version we have now.",
+					}
+					// TODO: Which version? Why doesn't this apply to our current version?
+					return req, nil
+				},
+			},
+		},
+	}
+
+	questionIsPackageSupported = questions.Question[advisory.Request]{
+		Text: "Is this package still supported upstream?",
+		Choices: []questions.Choice[advisory.Request]{
+			{
+				Text: "Yes",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *questions.Question[advisory.Request]) {
+					return req, nil
+				},
+			},
+			{
+				Text: "No",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *questions.Question[advisory.Request]) {
+					// TODO: Why not? What's the upstream status and how do we know?
+					return req, nil
+				},
+			},
+		},
+	}
 )

--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -34,6 +34,7 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/vuln"
 )
 
+//nolint:gocyclo
 func cmdAdvisoryGuide() *cobra.Command {
 	opts := &advisoryGuideParams{}
 
@@ -338,7 +339,7 @@ var (
 		Do: func(selected resultWithAPKs) tea.Cmd {
 			id := selected.Result.Findings[0].Vulnerability.ID
 			u := vuln.URL(id)
-			_ = browser.OpenURL(u)
+			_ = browser.OpenURL(u) //nolint:errcheck
 			return nil
 		},
 	}
@@ -358,7 +359,7 @@ var (
 					return picker.ErrCmd(fmt.Errorf("data session pull request: %w", err))
 				}
 
-				_ = browser.OpenURL(pr.URL)
+				_ = browser.OpenURL(pr.URL) //nolint:errcheck
 				return tea.Quit
 			},
 		}
@@ -404,7 +405,7 @@ func collateVulnerabilities(results []scan.Result) []resultWithAPKs {
 	vulnAPKsMap := make(map[string]resultWithAPKs)
 
 	for _, result := range results {
-		for _, finding := range result.Findings {
+		for _, finding := range result.Findings { //nolint:gocritic
 			match, exists := vulnAPKsMap[finding.Vulnerability.ID]
 			if !exists {
 				match = resultWithAPKs{

--- a/pkg/cli/components/breather/breather.go
+++ b/pkg/cli/components/breather/breather.go
@@ -43,6 +43,11 @@ func (m Model) View() string {
 	return m.style.Foreground(color).Render(m.Text)
 }
 
+// ViewStatic returns the view without any animations.
+func (m Model) ViewStatic() string {
+	return m.style.Render(m.Text)
+}
+
 type TickMsg time.Time
 
 func (t TickMsg) sineValue() float64 {

--- a/pkg/cli/components/ctrlcwrapper/ctrlcwrapper.go
+++ b/pkg/cli/components/ctrlcwrapper/ctrlcwrapper.go
@@ -73,6 +73,9 @@ func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			m.inner = inner
+
+			// We'll give the inner model a second to clean up before we exit. This is like
+			// a SIGINT.
 			delayedExitCmd := tea.Tick(1*time.Second, func(time.Time) tea.Msg {
 				return tickExpiredMsg{}
 			})
@@ -82,6 +85,7 @@ func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case innerIsReadyMsg, tickExpiredMsg:
 		// The inner has finished its cleanup and is ready to exit.
+		// Or, the "SIGINT" delay has expired, so we're going to exit anyway!
 		return m, tea.Quit
 	}
 

--- a/pkg/cli/components/interview/interview.go
+++ b/pkg/cli/components/interview/interview.go
@@ -1,0 +1,136 @@
+package interview
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/picker"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/internal/questions"
+)
+
+type Model[T any] struct {
+	root        questions.Question[T]
+	stack       []questions.Question[T]
+	pickerStack []picker.Model[questions.Choice[T]]
+	state       T
+	done        bool
+}
+
+// New returns a new interview model.
+func New[T any](root questions.Question[T], initialState T) Model[T] {
+	m := Model[T]{
+		root:  root,
+		state: initialState,
+	}
+
+	pickerOpts := picker.Options[questions.Choice[T]]{
+		Items:          root.Choices,
+		ItemRenderFunc: renderChoice[T],
+	}
+	p := picker.New(pickerOpts)
+	m.stack = append(m.stack, root)
+	m.pickerStack = append(m.pickerStack, p)
+
+	return m
+}
+
+func (m Model[T]) stackTopIndex() int {
+	return len(m.stack) - 1
+}
+
+func (m Model[T]) pickerStackTop() picker.Model[questions.Choice[T]] {
+	return m.pickerStack[m.stackTopIndex()]
+}
+
+func (m Model[T]) Init() tea.Cmd {
+	return m.pickerStackTop().Init()
+}
+
+func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Most events should be routed to the picker for the current question.
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter", "up", "down":
+			pTea, cmd := m.pickerStackTop().Update(msg)
+			p, ok := pTea.(picker.Model[questions.Choice[T]])
+			if !ok {
+				// Nothing we can do here, but this shouldn't ever happen.
+				return m, nil
+			}
+			m.pickerStack[m.stackTopIndex()] = p
+
+			// Check if the user has picked an answer.
+
+			c := m.pickerStackTop().Picked()
+			if c == nil {
+				// The user hasn't picked an answer yet.
+				return m, cmd
+			}
+
+			// The user has picked an answer.
+
+			if c.Choose == nil {
+				return m, nil
+			}
+
+			// Update the state.
+			var nextQuestion *questions.Question[T]
+			m.state, nextQuestion = c.Choose(m.state)
+			if nextQuestion == nil {
+				// The line of questioning is concluded.
+				m.done = true
+				return m, tea.Quit
+			}
+
+			// The line of questioning continues.
+			// Update the stack.
+			m.stack = append(m.stack, *nextQuestion)
+			nextPickerOpts := picker.Options[questions.Choice[T]]{
+				Items:          nextQuestion.Choices,
+				ItemRenderFunc: renderChoice[T],
+			}
+			nextPicker := picker.New(nextPickerOpts)
+			m.pickerStack = append(m.pickerStack, nextPicker)
+
+			return m, nextPicker.Init()
+		}
+
+	default:
+		// Pass the message to the picker.
+		pTea, cmd := m.pickerStackTop().Update(msg)
+		p, ok := pTea.(picker.Model[questions.Choice[T]])
+		if !ok {
+			// Nothing we can do here, but this shouldn't ever happen.
+			return m, nil
+		}
+		m.pickerStack[m.stackTopIndex()] = p
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m Model[T]) View() string {
+	// TODO: consider rendering differently if m.done is true.
+
+	sb := strings.Builder{}
+
+	for i, q := range m.stack {
+		sb.WriteString(q.Text + "\n\n")
+
+		pickerView := m.pickerStack[i].View()
+		sb.WriteString(pickerView)
+	}
+
+	return sb.String()
+}
+
+func (m Model[T]) State() T {
+	return m.state
+}
+
+func renderChoice[T any](c questions.Choice[T]) string {
+	return c.Text
+}

--- a/pkg/cli/components/picker/picker.go
+++ b/pkg/cli/components/picker/picker.go
@@ -11,25 +11,72 @@ import (
 )
 
 type Model[T any] struct {
-	// Picked is the item that was picked by the user.
-	Picked T
+	items               []T
+	itemRendererFunc    func(T) string
+	customActions       []CustomAction[T]
+	selected            int
+	picked              bool
+	aboutToExit         bool
+	breather            breather.Model
+	messageForZeroItems string
 
-	items            []T
-	itemRendererFunc func(T) string
-	selected         int
-	aboutToExit      bool
-	breather         breather.Model
+	// Error is the error that occurred during the picker's lifecycle, if any.
+	Error error
+}
+
+type Options[T any] struct {
+	// Items is the list of items to display, from which the user can pick.
+	Items []T
+
+	// MessageForZeroItems is the message to display when there are no items to
+	// list.
+	MessageForZeroItems string
+
+	// ItemRenderFunc is the function to use to render each item in the list. If
+	// nil, the item will be rendered via fmt.Sprintf("%v", item).
+	ItemRenderFunc func(T) string
+
+	// CustomActions is a list of custom actions that the user can take.
+	CustomActions []CustomAction[T]
 }
 
 // New returns a new picker model. The render function is used to render each
 // item in the list.
-func New[T any](items []T, render func(T) string) Model[T] {
+func New[T any](opts Options[T]) Model[T] {
 	return Model[T]{
-		items:            items,
-		itemRendererFunc: render,
-		breather:         breather.New(">"),
+		items:               opts.Items,
+		itemRendererFunc:    opts.ItemRenderFunc,
+		customActions:       opts.CustomActions,
+		messageForZeroItems: opts.MessageForZeroItems,
+		breather:            breather.New(">"),
 	}
 }
+
+type CustomAction[T any] struct {
+	// Key is the key that the user should press to select this action.
+	Key string
+
+	// Description is a short description of what this action does, used in help
+	// text.
+	//
+	// For example, in the help text "o to open.", "to open" is the description.
+	Description string
+
+	// Do is the function to call when the user presses the key for this action.
+	Do func(selected T) tea.Cmd
+}
+
+// ErrCmd returns a command that will cause the picker to display an error
+// message and exit.
+func ErrCmd(err error) tea.Cmd {
+	return func() tea.Msg {
+		return ErrMsg(err)
+	}
+}
+
+// ErrMsg is a bubbletea message that indicates an error occurred during the
+// picker's lifecycle.
+type ErrMsg error
 
 func (m Model[T]) Init() tea.Cmd {
 	return m.breather.Init()
@@ -40,6 +87,10 @@ func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ctrlcwrapper.AboutToExitMsg:
 		m.aboutToExit = true
 		return m, ctrlcwrapper.InnerIsReady
+
+	case ErrMsg:
+		m.Error = msg
+		return m, tea.Quit
 
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -54,9 +105,23 @@ func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "enter":
-			m.Picked = m.items[m.selected]
+			m.picked = true
 			m.aboutToExit = true
 			return m, tea.Quit
+		}
+
+		for _, action := range m.customActions {
+			if msg.String() == action.Key {
+				if action.Do == nil {
+					continue
+				}
+
+				var selected T
+				if len(m.items) > 0 {
+					selected = m.items[m.selected]
+				}
+				return m, action.Do(selected)
+			}
 		}
 
 	case breather.TickMsg:
@@ -69,36 +134,78 @@ func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model[T]) View() string {
+	sb := new(strings.Builder)
+
 	if len(m.items) == 0 {
-		// TODO: handle this better!
-		return "(No items to display)"
+		sb.WriteString(m.messageForZeroItems + "\n")
 	}
 
-	sb := new(strings.Builder)
+	var breatherView string
+	if m.aboutToExit {
+		// Don't animate, picking and/or exiting has happened.
+		breatherView = m.breather.ViewStatic()
+	} else {
+		breatherView = m.breather.View()
+	}
+
 	for i, item := range m.items {
 		if i == m.selected {
-			sb.WriteString(fmt.Sprintf("%s %s\n", m.breather.View(), m.itemRendererFunc(item)))
+			sb.WriteString(fmt.Sprintf("%s %s\n", breatherView, m.itemRendererFunc(item)))
 			continue
 		}
 
-		sb.WriteString(fmt.Sprintf("  %s\n", m.itemRendererFunc(item)))
+		if !m.aboutToExit {
+			sb.WriteString(fmt.Sprintf("  %s\n", m.itemRendererFunc(item)))
+		}
 	}
 
 	sb.WriteString("\n")
 
 	if !m.aboutToExit {
-		sb.WriteString(help)
+		if count := len(m.items); count > 0 {
+			if count > 1 {
+				sb.WriteString(helpChangeSelection + " ")
+			}
+
+			sb.WriteString(helpConfirm + "\n")
+		}
+
+		for _, action := range m.customActions {
+			sb.WriteString(fmt.Sprintf(
+				"%s %s\n",
+				styleHelpKey.Render(action.Key),
+				styleHelpExplanation.Render(action.Description+"."),
+			))
+		}
 	}
 
 	return sb.String()
 }
 
-var help = fmt.Sprintf(
-	"%s %s %s %s\n",
-	styleHelpKey.Render("↑/↓"),
-	styleHelpExplanation.Render("to change selection."),
-	styleHelpKey.Render("enter"),
-	styleHelpExplanation.Render("to confirm your choice."),
+// Picked returns the item that was picked by the user, if any. If no item has
+// been picked, this returns nil.
+func (m Model[T]) Picked() *T {
+	if !m.picked {
+		// The user hasn't picked anything yet.
+		return nil
+	}
+
+	picked := m.items[m.selected]
+	return &picked
+}
+
+var (
+	helpChangeSelection = fmt.Sprintf(
+		"%s %s",
+		styleHelpKey.Render("↑/↓"),
+		styleHelpExplanation.Render("to change selection."),
+	)
+
+	helpConfirm = fmt.Sprintf(
+		"%s %s",
+		styleHelpKey.Render("enter"),
+		styleHelpExplanation.Render("to confirm."),
+	)
 )
 
 var (

--- a/pkg/cli/internal/questions/questions.go
+++ b/pkg/cli/internal/questions/questions.go
@@ -1,0 +1,20 @@
+package questions
+
+type Question[T any] struct {
+	// The question to ask the user.
+	Text string
+
+	// Choices is a list of possible answers to the question.
+	Choices []Choice[T]
+}
+
+type Choice[T any] struct {
+	// The Text of the choice to present to the user.
+	Text string
+
+	// Choose should update and return the given state in consideration of this
+	// choice being selected by the user. It can also return the next question,
+	// unless the line of questioning is concluded, in which case it should return
+	// nil.
+	Choose func(state T) (updated T, next *Question[T])
+}

--- a/pkg/cli/internal/utils.go
+++ b/pkg/cli/internal/utils.go
@@ -1,0 +1,10 @@
+package internal
+
+// SelectPlurality returns the singular or plural form of a word based on the
+// count.
+func SelectPlurality(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/savioxavier/termlink"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/buildlog"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
@@ -818,13 +819,12 @@ func renderTriaging(verticalLine string, trs []scan.TriageAssessment) string {
 }
 
 func renderTriageAssessment(verticalLine string, tr scan.TriageAssessment) string {
-	label := styleBold.Render(fmt.Sprintf("%t positive", tr.TruePositive))
+	label := styles.Bold().Render(fmt.Sprintf("%t positive", tr.TruePositive))
 	return fmt.Sprintf("%s             ⚖️  %s according to %s", verticalLine, label, tr.Source)
 }
 
 var (
 	styleSubtle = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
-	styleBold   = lipgloss.NewStyle().Bold(true)
 
 	styleNegligible = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
 	styleLow        = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ff00"))

--- a/pkg/cli/styles/styles.go
+++ b/pkg/cli/styles/styles.go
@@ -8,8 +8,9 @@ var (
 	defaultStyle = lipgloss.NewStyle()
 	accented     = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffffff"))
 	secondary    = lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
-	faint        = lipgloss.NewStyle().Foreground(lipgloss.Color("#606060"))
-	faintAccent  = lipgloss.NewStyle().Foreground(lipgloss.Color("#777777"))
+	faint        = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
+	faintAccent  = lipgloss.NewStyle().Foreground(lipgloss.Color("#aaaaaa"))
+	bold         = lipgloss.NewStyle().Bold(true)
 
 	accentedLight    = lipgloss.NewStyle().Foreground(lipgloss.Color("#000000"))
 	secondaryLight   = lipgloss.NewStyle().Foreground(lipgloss.Color("#444444"))
@@ -47,4 +48,8 @@ func FaintAccent() lipgloss.Style {
 		return faintAccentLight
 	}
 	return faintAccent
+}
+
+func Bold() lipgloss.Style {
+	return bold
 }

--- a/pkg/distro/detect.go
+++ b/pkg/distro/detect.go
@@ -123,7 +123,7 @@ func identifyDistroFromLocalRepoDir(dir string) (Distro, error) {
 			// Fill in the local properties that we can cheaply here. We'll fill in the rest
 			// later, outside of this function call.
 
-			if slices.Contains(d.DistroRemoteURLs, url) {
+			if slices.Contains(d.DistroRemoteURLs(), url) {
 				return Distro{
 					Absolute: d,
 					Local: LocalProperties{
@@ -136,7 +136,7 @@ func identifyDistroFromLocalRepoDir(dir string) (Distro, error) {
 				}, nil
 			}
 
-			if slices.Contains(d.AdvisoriesRemoteURLs, url) {
+			if slices.Contains(d.AdvisoriesRemoteURLs(), url) {
 				return Distro{
 					Absolute: d,
 					Local: LocalProperties{

--- a/pkg/distro/detect_test.go
+++ b/pkg/distro/detect_test.go
@@ -125,3 +125,92 @@ func TestDetect(t *testing.T) {
 	assert.Equal(t, expectedAdvisoriesRepoDir, d.Local.AdvisoriesRepo.Dir)
 	assert.Equal(t, "https://packages.wolfi.dev/os", d.Absolute.APKRepositoryURL)
 }
+
+func TestDetectV2(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-distro-detect-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.RemoveAll(tempDir)
+		require.NoError(t, err)
+	})
+
+	r := struct {
+		name       string
+		remoteURLs []string
+	}{
+		name: "my-wolfi",
+		remoteURLs: []string{
+			"https://github.com/wolfi-dev/os.git",
+			"https://foo.git",
+		},
+	}
+
+	repoDir := filepath.Join(tempDir, r.name)
+	err = os.Mkdir(repoDir, 0o755)
+	require.NoError(t, err)
+
+	_, err = git.PlainInit(repoDir, false)
+	require.NoError(t, err)
+
+	repo, err := git.PlainOpen(repoDir)
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: r.remoteURLs,
+	})
+	require.NoError(t, err)
+
+	// We need to create a commit so that HEAD exists.
+	w, err := repo.Worktree()
+	require.NoError(t, err)
+	commit, err := w.Commit("Initial commit", &git.CommitOptions{
+		AllowEmptyCommits: true,
+		Author: &object.Signature{
+			Name:  "test",
+			Email: "test@test.com",
+			When:  time.Unix(0, 0),
+		},
+	})
+	require.NoError(t, err)
+
+	// Create a branch named "main" and set it as the HEAD of the repository.
+	mainRef := plumbing.NewHashReference("refs/heads/main", commit)
+	err = repo.Storer.SetReference(mainRef)
+	require.NoError(t, err)
+
+	// Create a symbolic reference named "refs/remotes/origin/main" that points to the local "main" branch.
+	originMainRef := plumbing.NewSymbolicReference("refs/remotes/origin/main", mainRef.Name())
+	err = repo.Storer.SetReference(originMainRef)
+	require.NoError(t, err)
+
+	symbolicRef := plumbing.NewSymbolicReference(plumbing.HEAD, mainRef.Name())
+	err = repo.Storer.SetReference(symbolicRef)
+	require.NoError(t, err)
+
+	originalWorkDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWorkDir) //nolint:errCheck
+	})
+
+	err = os.Chdir(repoDir)
+	require.NoError(t, err)
+
+	// Run the function under test
+
+	d, err := DetectV2()
+	require.NoError(t, err)
+
+	// Check the results
+
+	// (We need to resolve the symlinks because this test uses temp dirs, which are symlinked on some operating systems.)
+	expectedDistroRepoDir, err := filepath.EvalSymlinks(func(repoName string) string {
+		return filepath.Join(tempDir, repoName)
+	}(r.name))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Wolfi", d.Absolute.Name)
+	assert.Equal(t, expectedDistroRepoDir, d.Local.PackagesRepo.Dir)
+	assert.Equal(t, "https://packages.wolfi.dev/os", d.Absolute.APKRepositoryURL)
+}

--- a/pkg/distro/detectv2.go
+++ b/pkg/distro/detectv2.go
@@ -1,0 +1,86 @@
+package distro
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/go-git/go-git/v5"
+)
+
+// DetectV2 tries to detect which distro the user wants to operate on by seeing
+// if the current working directory is the distro's packages repo. No
+// advisory-related repositories are detected.
+func DetectV2() (Distro, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return Distro{}, err
+	}
+
+	d, err := DetectFromDirV2(cwd)
+	if err != nil {
+		return Distro{}, err
+	}
+
+	return d, nil
+}
+
+// DetectFromDirV2 tries to identify a Distro by inspecting the given directory
+// to see if it is a repository for a distro's packages.
+func DetectFromDirV2(dir string) (Distro, error) {
+	distro, err := identifyDistroFromLocalPackagesRepoDir(dir)
+	if err != nil {
+		return Distro{}, err
+	}
+
+	forkPoint, err := findRepoForkPoint(distro.Local.PackagesRepo.Dir, distro.Local.PackagesRepo.UpstreamName)
+	if err != nil {
+		return Distro{}, err
+	}
+	distro.Local.PackagesRepo.ForkPoint = forkPoint
+
+	return distro, nil
+}
+
+var ErrNotPackagesRepo = fmt.Errorf("directory is not a distro (packages) repository")
+
+func identifyDistroFromLocalPackagesRepoDir(dir string) (Distro, error) {
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		return Distro{}, fmt.Errorf("unable to identify distro: couldn't open git repo: %v: %w", err, ErrNotDistroRepo)
+	}
+
+	config, err := repo.Config()
+	if err != nil {
+		return Distro{}, err
+	}
+
+	for _, remoteConfig := range config.Remotes {
+		urls := remoteConfig.URLs
+		if len(urls) == 0 {
+			continue
+		}
+
+		url := urls[0]
+
+		for _, d := range []AbsoluteProperties{wolfiDistro, chainguardDistro, extraPackagesDistro} {
+			// Fill in the local properties that we can cheaply here. We'll fill in the rest
+			// later, outside of this function call.
+
+			if slices.Contains(d.DistroRemoteURLs(), url) {
+				return Distro{
+					Absolute: d,
+					Local: LocalProperties{
+						PackagesRepo: LocalRepo{
+							Dir:          dir,
+							UpstreamName: remoteConfig.Name,
+							ForkPoint:    "", // This is slightly expensive to compute, so we do it later and only once per repo.
+						},
+					},
+				}, nil
+			}
+		}
+	}
+
+	return Distro{}, ErrNotPackagesRepo
+}

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -1,5 +1,9 @@
 package distro
 
+import (
+	"fmt"
+)
+
 // Distro represents a wolfictl-compatible distro, along with important
 // properties discovered about how the user interacts with the distro.
 type Distro struct {
@@ -40,11 +44,14 @@ type AbsoluteProperties struct {
 	// The Name of the distro, e.g. "Wolfi".
 	Name string
 
-	// The known possible git remote URLs of the distro repo.
-	DistroRemoteURLs []string
+	// DistroRepoOwner is the GitHub organization name that owns the packages repo.
+	DistroRepoOwner string
 
-	// The known possible git remote URLs of the distro's advisories repo.
-	AdvisoriesRemoteURLs []string
+	// DistroPackagesRepo is the name of the distro's packages repo.
+	DistroPackagesRepo string
+
+	// DistroAdvisoriesRepo is the name of the distro's advisories repo.
+	DistroAdvisoriesRepo string
 
 	// APKRepositoryURL is the URL to the distro's package repository (e.g.
 	// "https://packages.wolfi.dev/os").
@@ -54,22 +61,55 @@ type AbsoluteProperties struct {
 	SupportedArchitectures []string
 }
 
+const (
+	githubURLFormatGit   = "git@github.com:%s/%s"
+	githubURLFormatHTTPS = "https://github.com/%s/%s"
+	gitSuffix            = ".git"
+)
+
+// DistroRemoteURLs is the known set of possible git remote URLs of the distro
+// repo.
+func (ap AbsoluteProperties) DistroRemoteURLs() []string {
+	return githubRemoteURLs(ap.DistroRepoOwner, ap.DistroPackagesRepo)
+}
+
+// AdvisoriesRemoteURLs is the known set of possible git remote URLs of the
+// advisories repo.
+func (ap AbsoluteProperties) AdvisoriesRemoteURLs() []string {
+	return githubRemoteURLs(ap.DistroRepoOwner, ap.DistroAdvisoriesRepo)
+}
+
+func githubRemoteURLs(owner, repo string) []string {
+	formats := []string{
+		githubURLFormatGit,
+		githubURLFormatHTTPS,
+	}
+
+	suffixes := []string{
+		gitSuffix,
+		"",
+	}
+
+	var urls []string
+	for _, format := range formats {
+		for _, suffix := range suffixes {
+			urls = append(urls, fmt.Sprintf(format, owner, repo)+suffix)
+		}
+	}
+	return urls
+}
+
+func (ap AbsoluteProperties) AdvisoriesHTTPSCloneURL() string {
+	return fmt.Sprintf(githubURLFormatHTTPS, ap.DistroRepoOwner, ap.DistroAdvisoriesRepo) + gitSuffix
+}
+
 var (
 	wolfiDistro = AbsoluteProperties{
-		Name: "Wolfi",
-		DistroRemoteURLs: []string{
-			"git@github.com:wolfi-dev/os.git",
-			"git@github.com:wolfi-dev/os",
-			"https://github.com/wolfi-dev/os.git",
-			"https://github.com/wolfi-dev/os",
-		},
-		AdvisoriesRemoteURLs: []string{
-			"git@github.com:wolfi-dev/advisories.git",
-			"git@github.com:wolfi-dev/advisories",
-			"https://github.com/wolfi-dev/advisories.git",
-			"https://github.com/wolfi-dev/advisories",
-		},
-		APKRepositoryURL: "https://packages.wolfi.dev/os",
+		Name:                 "Wolfi",
+		DistroRepoOwner:      "wolfi-dev",
+		DistroPackagesRepo:   "os",
+		DistroAdvisoriesRepo: "advisories",
+		APKRepositoryURL:     "https://packages.wolfi.dev/os",
 		SupportedArchitectures: []string{
 			"x86_64",
 			"aarch64",
@@ -77,20 +117,11 @@ var (
 	}
 
 	chainguardDistro = AbsoluteProperties{
-		Name: "Chainguard",
-		DistroRemoteURLs: []string{
-			"git@github.com:chainguard-dev/enterprise-packages.git",
-			"git@github.com:chainguard-dev/enterprise-packages",
-			"https://github.com/chainguard-dev/enterprise-packages.git",
-			"https://github.com/chainguard-dev/enterprise-packages",
-		},
-		AdvisoriesRemoteURLs: []string{
-			"git@github.com:chainguard-dev/enterprise-advisories.git",
-			"git@github.com:chainguard-dev/enterprise-advisories",
-			"https://github.com/chainguard-dev/enterprise-advisories.git",
-			"https://github.com/chainguard-dev/enterprise-advisories",
-		},
-		APKRepositoryURL: "https://packages.cgr.dev/os",
+		Name:                 "Enterprise Packages",
+		DistroRepoOwner:      "chainguard-dev",
+		DistroPackagesRepo:   "enterprise-packages",
+		DistroAdvisoriesRepo: "enterprise-advisories",
+		APKRepositoryURL:     "https://packages.cgr.dev/os",
 		SupportedArchitectures: []string{
 			"x86_64",
 			"aarch64",
@@ -98,20 +129,11 @@ var (
 	}
 
 	extraPackagesDistro = AbsoluteProperties{
-		Name: "Extra Packages",
-		DistroRemoteURLs: []string{
-			"git@github.com:chainguard-dev/extra-packages.git",
-			"git@github.com:chainguard-dev/extra-packages",
-			"https://github.com/chainguard-dev/extra-packages.git",
-			"https://github.com/chainguard-dev/extra-packages",
-		},
-		AdvisoriesRemoteURLs: []string{
-			"git@github.com:chainguard-dev/extra-advisories.git",
-			"git@github.com:chainguard-dev/extra-advisories",
-			"https://github.com/chainguard-dev/extra-advisories.git",
-			"https://github.com/chainguard-dev/extra-advisories",
-		},
-		APKRepositoryURL: "https://packages.cgr.dev/extras",
+		Name:                 "Extra Packages",
+		DistroRepoOwner:      "chainguard-dev",
+		DistroPackagesRepo:   "extra-packages",
+		DistroAdvisoriesRepo: "extra-advisories",
+		APKRepositoryURL:     "https://packages.cgr.dev/extras",
 		SupportedArchitectures: []string{
 			"x86_64",
 			"aarch64",

--- a/pkg/vuln/url.go
+++ b/pkg/vuln/url.go
@@ -1,0 +1,16 @@
+package vuln
+
+import "fmt"
+
+// URL returns the canonical web URL for the given vulnerability ID.
+func URL(id string) string {
+	switch {
+	case RegexCVE.MatchString(id):
+		return fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", id)
+
+	case RegexGHSA.MatchString(id):
+		return fmt.Sprintf("https://github.com/advisories/%s", id)
+	}
+
+	return ""
+}


### PR DESCRIPTION
This PR is a (substantial) follow-up to https://github.com/wolfi-dev/wolfictl/pull/631, which introduced a partially implemented `wolfictl adv guide` command.

To recap, the purpose of this command is to rethink the user experience of entering advisory data for a package.

This PR introduces several notable improvements to the original state:

1. **Short-lived advisory data sessions** — This command is the first to try a new approach, where `wolfictl` no longer expects you to have cloned any advisories repos in advance. Instead, when you run the command, it grabs the latest data from GitHub, makes updates to that data on your behalf locally, and then lets you open a PR with your changes — all without having had to interact with YAML. This is driven by a new internal `advisory.DataSession` object which manages the session for you.

2. **"Interviews"** — A concept where we can ask a series of questions to the user, where each answer might result in an update to state (e.g. the details of a new advisory entry). The questions and answers compose a directed labeled graph of sorts, which themselves are decoupled from the terminal UI altogether, so we can iterate on the questions and answers quickly.

3. **"Build groups"** — This lets `wolfictl` now operate on a Melange-produced origin APK with its subpackage APKs as a contextualized set.

### What's missing

To be useful, we need to iterate on the **interview questions** and answers to the point where they collectively cover an acceptable portion of cases that engineers encounter when triaging vulnerabilities in newly built APKs.

I've also been making note of useful **UX polish** opportunities, but I've been deferring them for now to facilitate faster iteration. But as users begin trying this out, it'd be great to respond to their feedback and minimize the friction associated with this command.

This also needs to be further tested with **workstations**, to ensure auth and the rest of the workflow behaves as intended.