### PR TITLE
feat(adv): support free text input and iterate on guide interview flow

### DIFF
--- a/pkg/advisory/question/questions.go
+++ b/pkg/advisory/question/questions.go
@@ -1,6 +1,8 @@
 package question
 
 import (
+	"fmt"
+
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	"github.com/wolfi-dev/wolfictl/pkg/question"
@@ -8,13 +10,11 @@ import (
 
 var (
 	IsFalsePositive = question.Question[advisory.Request]{
-		Text: "Any obvious sign that this is a false positive?",
-		Choices: []question.Choice[advisory.Request]{
+		Text: "Is this a false positive?",
+		Answer: question.MultipleChoice[advisory.Request]{
 			{
-				Text: "No",
-				Choose: func(req advisory.Request) (updated advisory.Request, next *question.Question[advisory.Request]) {
-					return req, &IsPackageSupported
-				},
+				Text:   "No",
+				Choose: question.NewChooseFunc(&IsPackageSupported),
 			},
 			{
 				Text: "Yes",
@@ -28,21 +28,23 @@ var (
 					return req, &WhyFalsePositive
 				},
 			},
+			{
+				Text:   "I'm not sure",
+				Choose: TODOFinal, // TODO: wiki link for "how to spot a false positive"?
+			},
 		},
 	}
 
 	WhyFalsePositive = question.Question[advisory.Request]{
 		Text: "Why is this a false positive?",
-		Choices: []question.Choice[advisory.Request]{
+		Answer: question.MultipleChoice[advisory.Request]{
 			{
 				Text: "The maintainers don't agree that this is a security problem.",
 				Choose: func(req advisory.Request) (updated advisory.Request, next *question.Question[advisory.Request]) {
 					req.Event.Data = v2.FalsePositiveDetermination{
 						Type: v2.FPTypeVulnerabilityRecordAnalysisContested,
-						Note: "The maintainers don't agree that this is a security problem.",
 					}
-					// TODO: Get more specific: Link to a citation? Where is the dispute recorded and who made it?
-					return req, nil
+					return req, &ReferenceForMaintainersDisagree
 				},
 			},
 			{
@@ -52,8 +54,7 @@ var (
 						Type: v2.FPTypeComponentVulnerabilityMismatch,
 						Note: "This is specific to another distro, not ours.",
 					}
-					// TODO: Which distro?
-					return req, nil
+					return req, &WhichOtherDistro
 				},
 			},
 			{
@@ -63,29 +64,134 @@ var (
 						Type: v2.FPTypeVulnerableCodeVersionNotUsed,
 						Note: "This seems to refer to a past version of the software, not the version we have now.",
 					}
-					// TODO: Which version? Why doesn't this apply to our current version?
+					return req, &ProvidePastVersionReferencedByVulnerability
+				},
+			},
+			{
+				// TODO: Make this show only for Go vulnerability matches?
+				// TODO: Automate this scan?
+				Text: "Govulncheck shows that the affected code is not present in our build.",
+				Choose: func(req advisory.Request) (updated advisory.Request, next *question.Question[advisory.Request]) {
+					req.Event.Data = v2.FalsePositiveDetermination{
+						Type: v2.FPTypeVulnerableCodeNotIncludedInPackage,
+						Note: "Govulncheck shows that the affected code is not present in our build.",
+					}
 					return req, nil
 				},
 			},
 		},
 	}
 
+	ProvidePastVersionReferencedByVulnerability = question.Question[advisory.Request]{
+		Text: "Please provide the past version of the software referenced by the vulnerability to show that this doesn't affect our version.",
+		Answer: question.AcceptText[advisory.Request](func(req advisory.Request, text string) (updated advisory.Request, next *question.Question[advisory.Request]) {
+			req.Event.Data = v2.FalsePositiveDetermination{
+				Type: v2.FPTypeVulnerableCodeVersionNotUsed,
+				Note: fmt.Sprintf("This seems to refer to a past version of the software, not the version we have now. Past version: %s", text),
+			}
+
+			return req, nil
+		}),
+	}
+
+	ReferenceForMaintainersDisagree = question.Question[advisory.Request]{
+		Text: "Please provide a web URL to a source that shows the maintainers don't agree that this is a security problem.",
+		Answer: question.AcceptText[advisory.Request](func(req advisory.Request, text string) (updated advisory.Request, next *question.Question[advisory.Request]) {
+			req.Event.Data = v2.FalsePositiveDetermination{
+				Type: v2.FPTypeVulnerabilityRecordAnalysisContested,
+				Note: fmt.Sprintf("The maintainers don't agree that this is a security problem. Source: %s", text),
+			}
+
+			return req, nil
+		}),
+	}
+
+	WhichOtherDistro = question.Question[advisory.Request]{
+		Text: "Which other distro is this specific to?",
+		Answer: question.MultipleChoice[advisory.Request]{
+			{
+				Text: "Alpine", Choose: TODOFinal,
+			},
+			{
+				Text: "Amazon", Choose: TODOFinal,
+			},
+			{
+				Text: "Debian", Choose: TODOFinal,
+			},
+			{
+				Text: "Fedora", Choose: TODOFinal,
+			},
+			{
+				Text: "RHEL", Choose: TODOFinal,
+			},
+			{
+				Text: "SUSE/SLES", Choose: TODOFinal,
+			},
+			{
+				Text: "Ubuntu", Choose: TODOFinal,
+			},
+		},
+	}
+
 	IsPackageSupported = question.Question[advisory.Request]{
-		Text: "Is this package still supported upstream?",
-		Choices: []question.Choice[advisory.Request]{
+		Text: "Is this package still supported upstream?", // TODO: automate this lookup!
+		Answer: question.MultipleChoice[advisory.Request]{
 			{
 				Text: "Yes",
 				Choose: func(req advisory.Request) (updated advisory.Request, next *question.Question[advisory.Request]) {
-					return req, nil
+					return req, &HasFixBeenAttempted
 				},
 			},
 			{
 				Text: "No",
 				Choose: func(req advisory.Request) (updated advisory.Request, next *question.Question[advisory.Request]) {
-					// TODO: Why not? What's the upstream status and how do we know?
-					return req, nil
+					return req, &ReferenceForNotSupportedUpstream
 				},
+			},
+			{
+				Text:   "I'm not sure",
+				Choose: TODOFinal, // TODO: wiki link for "how to check if a package is still supported"?
 			},
 		},
 	}
+
+	ReferenceForNotSupportedUpstream = question.Question[advisory.Request]{
+		Text: "Please provide a web URL to a source that shows the package is no longer supported upstream.",
+		Answer: question.AcceptText[advisory.Request](func(req advisory.Request, text string) (updated advisory.Request, next *question.Question[advisory.Request]) {
+			req.Event.Type = v2.EventTypeFixNotPlanned
+			req.Event.Data = v2.FixNotPlanned{
+				Note: fmt.Sprintf("Package is no longer supported upstream. Source: %s", text),
+			}
+
+			return req, nil
+		}),
+	}
+
+	HasFixBeenAttempted = question.Question[advisory.Request]{
+		Text: "Have you tried to fix the vulnerability yet?",
+		Answer: question.MultipleChoice[advisory.Request]{
+			{
+				Text: "Yes, but I need help.", Choose: TODOFinal,
+			},
+			{
+				Text: "Yes, and I'm surprised this is still showing up in a scan.", Choose: TODOFinal, // TODO: wiki link for "the vuln I fixed is still showing up"?
+			},
+			{
+				Text: "No, I need help.", Choose: TODOFinal, // TODO: CTA: Ask for help in #cve or something
+			},
+			{
+				Text: "No, I'll try to fix this and then come back to the advisory data entry later.", Choose: TODOFinal,
+			},
+		},
+	}
+)
+
+var (
+	// TODO is a placeholder answer for the advisory interview flow.
+	TODO = question.NewChooseFunc[advisory.Request](&question.Question[advisory.Request]{
+		Text: "TODO",
+	})
+
+	// TODOFinal is a placeholder for a terminating answer in the advisory interview flow.
+	TODOFinal = question.NewChooseFunc[advisory.Request](nil)
 )

--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -324,10 +324,10 @@ func humanizeAdvisoryEventType(typ string) string {
 		return "a true positive"
 
 	case v2.EventTypeAnalysisNotPlanned:
-		return "not planned for analysis"
+		return "analysis not planned"
 
 	case v2.EventTypeFixNotPlanned:
-		return "not planned for a fix"
+		return "fix not planned"
 
 	case v2.EventTypeFixed:
 		return "fixed"

--- a/pkg/cli/components/interview/interview.go
+++ b/pkg/cli/components/interview/interview.go
@@ -5,15 +5,16 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/picker"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/textinput"
 	"github.com/wolfi-dev/wolfictl/pkg/question"
 )
 
 type Model[T any] struct {
-	root        question.Question[T]
-	stack       []question.Question[T]
-	pickerStack []picker.Model[question.Choice[T]]
-	state       T
-	done        bool
+	root                 question.Question[T]
+	stack                []question.Question[T]
+	answerComponentStack []tea.Model
+	state                T
+	done                 bool
 }
 
 // New returns a new interview model.
@@ -23,47 +24,123 @@ func New[T any](root question.Question[T], initialState T) Model[T] {
 		state: initialState,
 	}
 
-	pickerOpts := picker.Options[question.Choice[T]]{
-		Items:          root.Choices,
-		ItemRenderFunc: renderChoice[T],
-	}
-	p := picker.New(pickerOpts)
 	m.stack = append(m.stack, root)
-	m.pickerStack = append(m.pickerStack, p)
+
+	ac := newAnswerComponent(root)
+	m.answerComponentStack = append(m.answerComponentStack, ac)
 
 	return m
+}
+
+func newAnswerComponent[T any](q question.Question[T]) tea.Model {
+	switch a := q.Answer.(type) {
+	case question.MultipleChoice[T]:
+		opts := picker.Options[question.Choice[T]]{
+			Items:          a,
+			ItemRenderFunc: renderChoice[T],
+		}
+		return picker.New(opts)
+
+	case question.AcceptText[T]:
+		return textinput.New()
+	}
+
+	// This should never happen.
+	panic("unsupported question answer type")
 }
 
 func (m Model[T]) stackTopIndex() int {
 	return len(m.stack) - 1
 }
 
-func (m Model[T]) pickerStackTop() picker.Model[question.Choice[T]] {
-	return m.pickerStack[m.stackTopIndex()]
+func (m Model[T]) answerComponentStackTop() tea.Model {
+	return m.answerComponentStack[m.stackTopIndex()]
 }
 
 func (m Model[T]) Init() tea.Cmd {
-	return m.pickerStackTop().Init()
+	return m.answerComponentStackTop().Init()
 }
 
 func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Most events should be routed to the picker for the current question.
+	// Most events should be routed to the component for the current question.
 
+	switch m.answerComponentStackTop().(type) {
+	case picker.Model[question.Choice[T]]:
+		return m.updateForPicker(msg)
+
+	case textinput.Model:
+		return m.updateForTextInput(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model[T]) updateForTextInput(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			// The user has submitted a text answer.
+			// Update the state.
+			val := m.answerComponentStackTop().(textinput.Model).Inner.Value()
+
+			// Update the state.
+			var nextQuestion *question.Question[T]
+			m.state, nextQuestion = m.stack[m.stackTopIndex()].Answer.(question.AcceptText[T])(m.state, val)
+			if nextQuestion == nil {
+				// The line of questioning is concluded.
+				m.done = true
+				return m, tea.Quit
+			}
+
+			// The line of questioning continues.
+			// Update the stack.
+			m.stack = append(m.stack, *nextQuestion)
+
+			// Create a new answer component for the next question.
+			ac := newAnswerComponent(*nextQuestion)
+			m.answerComponentStack = append(m.answerComponentStack, ac)
+
+			return m, ac.Init()
+
+		default:
+			return m.routeMsgToTextInputAtTopOfStack(msg)
+		}
+
+	default:
+		return m.routeMsgToTextInputAtTopOfStack(msg)
+	}
+}
+
+func (m Model[T]) routeMsgToTextInputAtTopOfStack(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Pass the message to the text input.
+	tiTea, cmd := m.answerComponentStackTop().Update(msg)
+	ti, ok := tiTea.(textinput.Model)
+	if !ok {
+		// Nothing we can do here, but this shouldn't ever happen.
+		return m, nil
+	}
+
+	m.answerComponentStack[m.stackTopIndex()] = ti
+	return m, cmd
+}
+
+func (m Model[T]) updateForPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "enter", "up", "down":
-			pTea, cmd := m.pickerStackTop().Update(msg)
+			pTea, cmd := m.answerComponentStackTop().Update(msg)
 			p, ok := pTea.(picker.Model[question.Choice[T]])
 			if !ok {
 				// Nothing we can do here, but this shouldn't ever happen.
 				return m, nil
 			}
-			m.pickerStack[m.stackTopIndex()] = p
+			m.answerComponentStack[m.stackTopIndex()] = p
 
-			// Check if the user has picked an answer.
+			// Check if the user has submitted an answer.
 
-			c := m.pickerStackTop().Picked()
+			c := p.Picked()
 			if c == nil {
 				// The user hasn't picked an answer yet.
 				return m, cmd
@@ -87,25 +164,23 @@ func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// The line of questioning continues.
 			// Update the stack.
 			m.stack = append(m.stack, *nextQuestion)
-			nextPickerOpts := picker.Options[question.Choice[T]]{
-				Items:          nextQuestion.Choices,
-				ItemRenderFunc: renderChoice[T],
-			}
-			nextPicker := picker.New(nextPickerOpts)
-			m.pickerStack = append(m.pickerStack, nextPicker)
 
-			return m, nextPicker.Init()
+			// Create a new answer component for the next question.
+			ac := newAnswerComponent(*nextQuestion)
+			m.answerComponentStack = append(m.answerComponentStack, ac)
+
+			return m, ac.Init()
 		}
 
 	default:
 		// Pass the message to the picker.
-		pTea, cmd := m.pickerStackTop().Update(msg)
+		pTea, cmd := m.answerComponentStackTop().Update(msg)
 		p, ok := pTea.(picker.Model[question.Choice[T]])
 		if !ok {
 			// Nothing we can do here, but this shouldn't ever happen.
 			return m, nil
 		}
-		m.pickerStack[m.stackTopIndex()] = p
+		m.answerComponentStack[m.stackTopIndex()] = p
 		return m, cmd
 	}
 
@@ -120,8 +195,8 @@ func (m Model[T]) View() string {
 	for i, q := range m.stack {
 		sb.WriteString(q.Text + "\n\n")
 
-		pickerView := m.pickerStack[i].View()
-		sb.WriteString(pickerView)
+		acView := m.answerComponentStack[i].View()
+		sb.WriteString(acView)
 	}
 
 	return sb.String()

--- a/pkg/cli/components/picker/picker.go
+++ b/pkg/cli/components/picker/picker.go
@@ -74,8 +74,8 @@ func ErrCmd(err error) tea.Cmd {
 	}
 }
 
-// ErrMsg is a bubbletea message that indicates an error occurred during the
-// picker's lifecycle.
+// ErrMsg is a tea.Msg that indicates an error occurred during the picker's
+// lifecycle.
 type ErrMsg error
 
 func (m Model[T]) Init() tea.Cmd {

--- a/pkg/cli/components/textinput/textinput.go
+++ b/pkg/cli/components/textinput/textinput.go
@@ -1,0 +1,38 @@
+package textinput
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Model wraps Charm's textinput.Model to make it an actual tea.Model.
+//
+// I'm not 100% sure why this is necessary, so I've asked on an issue:
+// https://github.com/charmbracelet/bubbles/issues/371#issuecomment-2062787557.
+type Model struct {
+	Inner textinput.Model
+}
+
+// New returns a new text input model.
+func New() Model {
+	ti := textinput.New()
+	ti.Focus()
+
+	return Model{
+		Inner: ti,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.Inner, cmd = m.Inner.Update(msg)
+	return m, cmd
+}
+
+func (m Model) View() string {
+	return m.Inner.View()
+}

--- a/pkg/question/graph/dot_test.go
+++ b/pkg/question/graph/dot_test.go
@@ -12,7 +12,7 @@ func TestDot(t *testing.T) {
 	var (
 		qIcecreamFlavor = question.Question[string]{
 			Text: "What flavor of ice cream do you like?",
-			Choices: []question.Choice[string]{
+			Answer: question.MultipleChoice[string]{
 				{
 					Text: "Vanilla",
 					Choose: func(state string) (string, *question.Question[string]) {
@@ -30,7 +30,7 @@ func TestDot(t *testing.T) {
 
 		qCookieKind = question.Question[string]{
 			Text: "What kind of cookie do you like?",
-			Choices: []question.Choice[string]{
+			Answer: question.MultipleChoice[string]{
 				{
 					Text: "Chocolate chip",
 					Choose: func(state string) (string, *question.Question[string]) {
@@ -42,7 +42,7 @@ func TestDot(t *testing.T) {
 
 		qFavoriteDessert = question.Question[string]{
 			Text: "What is your favorite dessert?",
-			Choices: []question.Choice[string]{
+			Answer: question.MultipleChoice[string]{
 				{
 					Text: "Ice cream",
 					Choose: func(_ string) (string, *question.Question[string]) {
@@ -63,6 +63,7 @@ func TestDot(t *testing.T) {
 		expected = `digraph interview {
 Done;
 "What is your favorite dessert?";
+"START" -> "What is your favorite dessert?"  [ label="" ]
 "What flavor of ice cream do you like?";
 "What is your favorite dessert?" -> "What flavor of ice cream do you like?"  [ label="Ice cream" ]
 "What flavor of ice cream do you like?" -> Done  [ label=Vanilla ]
@@ -74,7 +75,7 @@ Done;
 `
 	)
 
-	dot, err := Dot(context.Background(), qFavoriteDessert, "")
+	dot, err := Dot(context.Background(), qFavoriteDessert, "START")
 	if err != nil {
 		t.Fatalf("Dot() error = %v", err)
 	}

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -4,9 +4,15 @@ type Question[T any] struct {
 	// The question to ask the user.
 	Text string
 
-	// Choices is a list of possible answers to the question.
-	Choices []Choice[T]
+	// The means of answering the question. The concrete type should be one of:
+	// - AcceptText[T]
+	// - MultipleChoice[T]
+	Answer any
 }
+
+type MultipleChoice[T any] []Choice[T]
+
+type AcceptText[T any] func(state T, text string) (T, *Question[T])
 
 type Choice[T any] struct {
 	// The Text of the choice to present to the user.
@@ -16,5 +22,16 @@ type Choice[T any] struct {
 	// choice being selected by the user. It can also return the next question,
 	// unless the line of questioning is concluded, in which case it should return
 	// nil.
-	Choose func(state T) (updated T, next *Question[T])
+	Choose ChooseFunc[T]
+}
+
+// ChooseFunc is a function that can be used as the Choose method of a Choice.
+type ChooseFunc[T any] func(state T) (updated T, next *Question[T])
+
+// NewChooseFunc returns a function that can be used as the Choose method of a
+// Choice. It simply returns the state unmodified and the given next question.
+func NewChooseFunc[T any](next *Question[T]) ChooseFunc[T] {
+	return func(state T) (T, *Question[T]) {
+		return state, next
+	}
 }


### PR DESCRIPTION
This PR iterates on the `wolfictl adv guide` command:

1. Adds support for **free text input** when needed, in addition to just multiple choice answers.
2. Expands the interview with more questions and answers. Updated interview graph shown below.

![Graphviz online](https://github.com/wolfi-dev/wolfictl/assets/5199289/4c5c4722-5511-4a2e-8ff5-25032530350b)
