### PR TITLE
feat(adv): messages to the user within the interview

### DIFF
--- a/pkg/cli/components/accept/accept.go
+++ b/pkg/cli/components/accept/accept.go
@@ -1,0 +1,47 @@
+package accept
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
+)
+
+type Model struct {
+	// Accepted is true if the message was accepted by the user.
+	Accepted bool
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if ok && keyMsg.String() == "enter" {
+		m.Accepted = true
+	}
+
+	return m, nil
+}
+
+func (m Model) View() string {
+	if m.Accepted {
+		return ""
+	}
+
+	return fmt.Sprintf("%s\n", helpAccept)
+}
+
+var (
+	helpAccept = fmt.Sprintf(
+		"%s %s",
+		styleHelpKey.Render("enter"),
+		styleHelpExplanation.Render("to move on."),
+	)
+)
+
+var (
+	styleHelpKey         = styles.FaintAccent().Copy().Bold(true)
+	styleHelpExplanation = styles.Faint().Copy()
+)

--- a/pkg/cli/components/interview/interview.go
+++ b/pkg/cli/components/interview/interview.go
@@ -1,11 +1,15 @@
 package interview
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/accept"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/picker"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/textinput"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/internal/wrapped"
 	"github.com/wolfi-dev/wolfictl/pkg/question"
 )
 
@@ -15,10 +19,11 @@ type Model[T any] struct {
 	answerComponentStack []tea.Model
 	state                T
 	done                 bool
+	err                  error
 }
 
 // New returns a new interview model.
-func New[T any](root question.Question[T], initialState T) Model[T] {
+func New[T any](root question.Question[T], initialState T) (Model[T], error) {
 	m := Model[T]{
 		root:  root,
 		state: initialState,
@@ -26,27 +31,33 @@ func New[T any](root question.Question[T], initialState T) Model[T] {
 
 	m.stack = append(m.stack, root)
 
-	ac := newAnswerComponent(root)
+	ac, err := newAnswerComponent(root)
+	if err != nil {
+		return m, fmt.Errorf("creating answer component: %w", err)
+	}
 	m.answerComponentStack = append(m.answerComponentStack, ac)
 
-	return m
+	return m, nil
 }
 
-func newAnswerComponent[T any](q question.Question[T]) tea.Model {
+func newAnswerComponent[T any](q question.Question[T]) (tea.Model, error) {
 	switch a := q.Answer.(type) {
 	case question.MultipleChoice[T]:
 		opts := picker.Options[question.Choice[T]]{
 			Items:          a,
 			ItemRenderFunc: renderChoice[T],
 		}
-		return picker.New(opts)
+		return picker.New(opts), nil
 
 	case question.AcceptText[T]:
-		return textinput.New()
+		return textinput.New(), nil
+
+	case question.MessageOnly[T]:
+		return accept.Model{}, nil
 	}
 
 	// This should never happen.
-	panic("unsupported question answer type")
+	return nil, fmt.Errorf("unsupported question answer type %T for question %q", q.Answer, q.Text)
 }
 
 func (m Model[T]) stackTopIndex() int {
@@ -70,9 +81,67 @@ func (m Model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case textinput.Model:
 		return m.updateForTextInput(msg)
+
+	case accept.Model:
+		return m.updateForMessage(msg)
 	}
 
 	return m, nil
+}
+
+func (m Model[T]) updateForMessage(msg tea.Msg) (tea.Model, tea.Cmd) {
+	messageTea, cmd := m.answerComponentStackTop().Update(msg)
+	messageModel, ok := messageTea.(accept.Model)
+	if !ok {
+		// Nothing we can do here, but this shouldn't ever happen.
+		return m, nil
+	}
+	m.answerComponentStack[m.stackTopIndex()] = messageModel
+
+	if !messageModel.Accepted {
+		// The user hasn't acknowledged the message yet.
+		return m, cmd
+	}
+
+	// The user has acknowledged the message.
+
+	// Update the state.
+	var nextQuestion *question.Question[T]
+	var err error
+	m.state, nextQuestion, err = m.stack[m.stackTopIndex()].Answer.(question.MessageOnly[T])(m.state)
+	if err != nil {
+		if errors.Is(err, question.ErrTerminate) {
+			// Exit the interview without a resulting state.
+			m.done = true
+			m.err = err
+			return m, tea.Quit
+		}
+
+		// An error occurred.
+		m.err = err
+		return m, tea.Quit
+	}
+
+	if nextQuestion == nil {
+		// The line of questioning is concluded.
+		m.done = true
+		return m, tea.Quit
+	}
+
+	// The line of questioning continues.
+	// Update the stack.
+	m.stack = append(m.stack, *nextQuestion)
+
+	// Create a new answer component for the next question.
+	ac, err := newAnswerComponent(*nextQuestion)
+	if err != nil {
+		// An error occurred.
+		m.err = err
+		return m, tea.Quit
+	}
+	m.answerComponentStack = append(m.answerComponentStack, ac)
+
+	return m, ac.Init()
 }
 
 func (m Model[T]) updateForTextInput(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -86,7 +155,20 @@ func (m Model[T]) updateForTextInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Update the state.
 			var nextQuestion *question.Question[T]
-			m.state, nextQuestion = m.stack[m.stackTopIndex()].Answer.(question.AcceptText[T])(m.state, val)
+			var err error
+			m.state, nextQuestion, err = m.stack[m.stackTopIndex()].Answer.(question.AcceptText[T])(m.state, val)
+			if err != nil {
+				if errors.Is(err, question.ErrTerminate) {
+					// Exit the interview without a resulting state.
+					m.done = true
+					m.err = err
+					return m, tea.Quit
+				}
+
+				// An error occurred.
+				m.err = err
+				return m, tea.Quit
+			}
 			if nextQuestion == nil {
 				// The line of questioning is concluded.
 				m.done = true
@@ -98,7 +180,12 @@ func (m Model[T]) updateForTextInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stack = append(m.stack, *nextQuestion)
 
 			// Create a new answer component for the next question.
-			ac := newAnswerComponent(*nextQuestion)
+			ac, err := newAnswerComponent(*nextQuestion)
+			if err != nil {
+				// An error occurred.
+				m.err = err
+				return m, tea.Quit
+			}
 			m.answerComponentStack = append(m.answerComponentStack, ac)
 
 			return m, ac.Init()
@@ -154,7 +241,20 @@ func (m Model[T]) updateForPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Update the state.
 			var nextQuestion *question.Question[T]
-			m.state, nextQuestion = c.Choose(m.state)
+			var err error
+			m.state, nextQuestion, err = c.Choose(m.state)
+			if err != nil {
+				if errors.Is(err, question.ErrTerminate) {
+					// Exit the interview without a resulting state.
+					m.done = true
+					m.err = err
+					return m, tea.Quit
+				}
+
+				// An error occurred.
+				m.err = err
+				return m, tea.Quit
+			}
 			if nextQuestion == nil {
 				// The line of questioning is concluded.
 				m.done = true
@@ -166,7 +266,12 @@ func (m Model[T]) updateForPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stack = append(m.stack, *nextQuestion)
 
 			// Create a new answer component for the next question.
-			ac := newAnswerComponent(*nextQuestion)
+			ac, err := newAnswerComponent(*nextQuestion)
+			if err != nil {
+				// An error occurred.
+				m.err = err
+				return m, tea.Quit
+			}
 			m.answerComponentStack = append(m.answerComponentStack, ac)
 
 			return m, ac.Init()
@@ -193,7 +298,8 @@ func (m Model[T]) View() string {
 	sb := strings.Builder{}
 
 	for i, q := range m.stack {
-		sb.WriteString(q.Text + "\n\n")
+		qText := wrapped.Sprint(q.Text)
+		sb.WriteString(qText + "\n\n")
 
 		acView := m.answerComponentStack[i].View()
 		sb.WriteString(acView)
@@ -202,8 +308,8 @@ func (m Model[T]) View() string {
 	return sb.String()
 }
 
-func (m Model[T]) State() T {
-	return m.state
+func (m Model[T]) State() (T, error) {
+	return m.state, m.err
 }
 
 func renderChoice[T any](c question.Choice[T]) string {

--- a/pkg/cli/internal/wrapped/wrapped.go
+++ b/pkg/cli/internal/wrapped/wrapped.go
@@ -28,6 +28,11 @@ func Println(msg string) {
 	fmt.Println(wrapToLineLength(msg))
 }
 
+// Sprint wraps the given message using LineLength and returns it as a string.
+func Sprint(msg string) string {
+	return wrapToLineLength(msg)
+}
+
 // Fatal wraps the given message using LineLength and prints it to stderr with a
 // trailing newline, then exits with a non-zero status code.
 func Fatal(msg string) {

--- a/pkg/question/graph/dot_test.go
+++ b/pkg/question/graph/dot_test.go
@@ -15,14 +15,14 @@ func TestDot(t *testing.T) {
 			Answer: question.MultipleChoice[string]{
 				{
 					Text: "Vanilla",
-					Choose: func(state string) (string, *question.Question[string]) {
-						return "vanilla " + state, nil
+					Choose: func(state string) (string, *question.Question[string], error) {
+						return "vanilla " + state, nil, nil
 					},
 				},
 				{
 					Text: "Chocolate",
-					Choose: func(state string) (string, *question.Question[string]) {
-						return "chocolate " + state, nil
+					Choose: func(state string) (string, *question.Question[string], error) {
+						return "chocolate " + state, nil, nil
 					},
 				},
 			},
@@ -33,8 +33,8 @@ func TestDot(t *testing.T) {
 			Answer: question.MultipleChoice[string]{
 				{
 					Text: "Chocolate chip",
-					Choose: func(state string) (string, *question.Question[string]) {
-						return "chocolate chip " + state, nil
+					Choose: func(state string) (string, *question.Question[string], error) {
+						return "chocolate chip " + state, nil, nil
 					},
 				},
 			},
@@ -45,14 +45,14 @@ func TestDot(t *testing.T) {
 			Answer: question.MultipleChoice[string]{
 				{
 					Text: "Ice cream",
-					Choose: func(_ string) (string, *question.Question[string]) {
-						return "ice cream", &qIcecreamFlavor
+					Choose: func(_ string) (string, *question.Question[string], error) {
+						return "ice cream", &qIcecreamFlavor, nil
 					},
 				},
 				{
 					Text: "Cookie",
-					Choose: func(_ string) (string, *question.Question[string]) {
-						return "cookie", &qCookieKind
+					Choose: func(_ string) (string, *question.Question[string], error) {
+						return "cookie", &qCookieKind, nil
 					},
 				},
 			},

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1,18 +1,21 @@
 package question
 
+import "errors"
+
 type Question[T any] struct {
 	// The question to ask the user.
 	Text string
 
 	// The means of answering the question. The concrete type should be one of:
 	// - AcceptText[T]
+	// - MessageOnly[T]
 	// - MultipleChoice[T]
 	Answer any
 }
 
+// MultipleChoice is a means of answering a question where the user can choose
+// an option (Choice) from a list.
 type MultipleChoice[T any] []Choice[T]
-
-type AcceptText[T any] func(state T, text string) (T, *Question[T])
 
 type Choice[T any] struct {
 	// The Text of the choice to present to the user.
@@ -26,12 +29,54 @@ type Choice[T any] struct {
 }
 
 // ChooseFunc is a function that can be used as the Choose method of a Choice.
-type ChooseFunc[T any] func(state T) (updated T, next *Question[T])
+type ChooseFunc[T any] func(state T) (updated T, next *Question[T], err error)
 
 // NewChooseFunc returns a function that can be used as the Choose method of a
 // Choice. It simply returns the state unmodified and the given next question.
 func NewChooseFunc[T any](next *Question[T]) ChooseFunc[T] {
-	return func(state T) (T, *Question[T]) {
-		return state, next
+	return func(state T) (T, *Question[T], error) {
+		return state, next, nil
 	}
 }
+
+// AcceptText is a means of answering a question where the user can provide
+// freeform text.
+type AcceptText[T any] func(state T, text string) (T, *Question[T], error)
+
+// MessageOnly is a means of answering a question where the user is presented
+// with a message only, and where the only possible action is to proceed to the
+// next question.
+//
+// In other words, this effectively turns the Question into a message that the
+// user must acknowledge before proceeding.
+type MessageOnly[T any] func(state T) (T, *Question[T], error)
+
+// NewMessage returns a new "Question" that is only a message for the user to
+// acknowledge. Once acknowledged, the user will proceed to the supplied next
+// question, and the state will be passed through unmodified.
+func NewMessage[T any](text string, next *Question[T]) Question[T] {
+	return Question[T]{
+		Text: text,
+		Answer: MessageOnly[T](func(state T) (T, *Question[T], error) {
+			return state, next, nil
+		}),
+	}
+}
+
+// NewTerminatingMessage returns a new "Question" that is only a message for the
+// user to acknowledge. Once acknowledged, the interview should terminate.
+func NewTerminatingMessage[T any](text string) Question[T] {
+	return Question[T]{
+		Text: text,
+		Answer: MessageOnly[T](func(state T) (T, *Question[T], error) {
+			return state, nil, ErrTerminate
+		}),
+	}
+}
+
+var (
+	// ErrTerminate is a sentinel error an answer function can return to indicate
+	// that the interview should terminate, and the tracked state should be
+	// discarded rather than persisted or returned to the user.
+	ErrTerminate = errors.New("interview terminated")
+)


### PR DESCRIPTION
Enhances the interview process by:

- Allowing the interview to include "messages", which are like questions but only user choice is to accept the message and move on. Animation included below.

![Kapture 2024-04-18 at 17 42 04](https://github.com/wolfi-dev/wolfictl/assets/5199289/49971576-d336-417c-8a47-0cdd44d7ff50)

- Allowing interview answers to result in terminating the interview early, such that the tracked state is **_not_** persisted (e.g. with advisory data, this discards the state rather than writing to the local advisory data session). Logically this is handled by a question's answer function returning `question.ErrTerminate`.

- Finishing a "complete" first draft of the advisory guide interview process, where all TODOs have been replaced with real behavior. The latest interview graph is shown below.

![image](https://github.com/wolfi-dev/wolfictl/assets/5199289/88aa5751-c8b4-4d22-a49d-d5b74b51f68e)
