### PR TITLE
create a random temp file when importing the adv data

### DIFF
--- a/pkg/advisory/import.go
+++ b/pkg/advisory/import.go
@@ -29,7 +29,10 @@ func ImporAdvisoriesYAML(inputData []byte) (tempDir string, documents *configs.I
 		docs = append(docs, pkg)
 	}
 
-	tempDir = os.TempDir()
+	tempDir, err = os.MkdirTemp("", "adv-")
+	if err != nil {
+		return "", nil, fmt.Errorf("unable to create temporary directory: %v", err)
+	}
 	for _, doc := range docs {
 		f, err := os.Create(filepath.Join(tempDir, fmt.Sprintf("%s.advisories.yaml", doc.Name())))
 		if err != nil {


### PR DESCRIPTION
if we import two different advisories dataset the last one override the first and then it fail

seeing an error in the scan apk packages


```
failed to import advisory data wolfi-production-registry-destination/os/advisories.yaml: unable to index advisory configs for directory "/tmp": unable to open configuration at "hey.advisories.yaml": open /tmp/hey.advisories.yaml: no such file or directory
```