### PR TITLE
fix(scan): enable pseudoversion comparison

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -212,7 +212,11 @@ func createMatchers(useCPEs bool) []matcher.Matcher {
 	return matcher.NewDefaultMatchers(
 		matcher.Config{
 			Dotnet: dotnet.MatcherConfig{UseCPEs: useCPEs},
-			Golang: golang.MatcherConfig{UseCPEs: useCPEs, AlwaysUseCPEForStdlib: true},
+			Golang: golang.MatcherConfig{
+				UseCPEs:                                useCPEs,
+				AlwaysUseCPEForStdlib:                  true,
+				AllowMainModulePseudoVersionComparison: true,
+			},
 			Java: java.MatcherConfig{
 				ExternalSearchConfig: java.ExternalSearchConfig{
 					SearchMavenUpstream: true,


### PR DESCRIPTION
After my Grype PR (https://github.com/anchore/grype/pull/1797), Anchore added a follow-up PR that makes this behavior cnofigurable. It is on by default for the Grype CLI but not for the Grype library. This commit enables it for the Grype library so we can see this kind of match from wolfictl scans.

E.g.:

```console
$ wolfictl scan ./packages/aarch64/atlantis-0.27.2-r2.apk
🔎 Scanning "./packages/aarch64/atlantis-0.27.2-r2.apk"
└── 📄 /usr/bin/atlantis
        📦 github.com/runatlantis/atlantis v0.0.0-20240308212341-29919209f2a1 (go-module)
            High CVE-2022-24912 GHSA-jxqv-jcvh-7gr4 fixed in 0.19.7
        📦 golang.org/x/net v0.19.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
```