### PR TITLE
fix: compare package version epoch as numerics

### DIFF
--- a/pkg/versions/versions_test.go
+++ b/pkg/versions/versions_test.go
@@ -96,6 +96,26 @@ func TestSort_ByLatestStrings(t *testing.T) {
 			input:    []string{"0.1.0-r5", "0.1.0-r4", "0.2.0-r0"},
 			expected: []string{"0.2.0-r0", "0.1.0-r5", "0.1.0-r4"},
 		},
+		{
+			input:    []string{"0.1.0-r5", "0.1.0-r1", "0.1.0-r12"},
+			expected: []string{"0.1.0-r12", "0.1.0-r5", "0.1.0-r1"},
+		},
+		{
+			input:    []string{"0.1.0-r15", "0.1.0-r1", "0.1.0-r12"},
+			expected: []string{"0.1.0-r15", "0.1.0-r12", "0.1.0-r1"},
+		},
+		{
+			input:    []string{"1.1.0-r3", "0.1.0-r1", "0.1.0-r12"},
+			expected: []string{"1.1.0-r3", "0.1.0-r12", "0.1.0-r1"},
+		},
+		{
+			input:    []string{"2.1.0-r1", "2.1.0-r2", "0.1.0-r12"},
+			expected: []string{"2.1.0-r2", "2.1.0-r1", "0.1.0-r12"},
+		},
+		{
+			input:    []string{"5.0.0-r1", "9.1.0-r22", "9.1.0-r20"},
+			expected: []string{"9.1.0-r22", "9.1.0-r20", "5.0.0-r1"},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
This is related to the issue reported on slack [here](https://chainguard-dev.slack.com/archives/C05GYUBM07Q/p1713943656535999) where a list of versions as such `[0.1.0-r12, 0.1.0-r9, 0.1.0-r1]` always returned `0.1.0-r9` as the latest.