### PR TITLE
ci: stop specifying default linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -99,22 +99,8 @@ linters-settings:
   gocritic:
     enabled-checks:
       # Diagnostic
-      - appendAssign
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
       - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
       - nilValReturn
-      - offBy1
       - sloppyReassign
       - weakCond
       - octalLiteral
@@ -128,31 +114,16 @@ linters-settings:
       - rangeValCopy
 
       # Style
-      - assignOp
       - boolExprSimplify
-      - captLocal
-      - commentFormatting
       - commentedOutImport
-      - defaultCaseOrder
       - docStub
-      - elseif
       - emptyFallthrough
       - emptyStringTest
       - hexLiteral
       - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
       - stringXbytes
-      - switchTrue
       - typeAssertChain
-      - typeSwitchVar
-      - underef
       - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
       - yodaStyleExpr
       # - ifElseChain
 


### PR DESCRIPTION
Some gocritic rules are enabled by default, but we were specifying them in our `.golangci.yaml` file anyway, which produces noisy warnings when running linting locally. This PR removes those rules from the config to prevent the log warnings — they're still enabled, just not via the config any more.

Before:

```console
$ golangci-lint run                           
WARN [linters_context] gocritic: no need to enable check "appendAssign": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "argOrder": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "badCond": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "caseOrder": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "codegenComment": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "deprecatedComment": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "dupArg": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "dupBranchBody": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "dupCase": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "dupSubExpr": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "exitAfterDefer": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "flagDeref": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "flagName": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "offBy1": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "assignOp": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "captLocal": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "commentFormatting": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "defaultCaseOrder": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "elseif": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "regexpMust": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "singleCaseSwitch": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "sloppyLen": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "switchTrue": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "typeSwitchVar": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "underef": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "unlambda": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "unslice": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "valSwap": it's already enabled 
WARN [linters_context] gocritic: no need to enable check "wrapperFunc": it's already enabled
$
```

After:

```console
$ golangci-lint run
$
```