### PR TITLE
fix(sbom,scan)!: BREAKING CHANGES, see description

### DIFF
--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -27,7 +27,6 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/cli/internal/builds"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/internal/wrapped"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
-	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
 	question2 "github.com/wolfi-dev/wolfictl/pkg/question"
@@ -209,7 +208,7 @@ func cmdAdvisoryGuide() *cobra.Command {
 			// (or the user quits early).
 
 			for {
-				filtered, err := filterCollatedVulnerabilities(collated, sess)
+				filtered, err := filterCollatedVulnerabilities(ctx, collated, sess)
 				if err != nil {
 					return fmt.Errorf("filtering APK findings with advisories: %w", err)
 				}
@@ -446,14 +445,14 @@ func collateVulnerabilities(results []scan.Result) []resultWithAPKs {
 	return vulnAPKs
 }
 
-func filterCollatedVulnerabilities(apkResults []resultWithAPKs, sess *advisory.DataSession) ([]resultWithAPKs, error) {
+func filterCollatedVulnerabilities(ctx context.Context, apkResults []resultWithAPKs, sess *advisory.DataSession) ([]resultWithAPKs, error) {
 	var filtered []resultWithAPKs
-	indexes := []*configs.Index[v2.Document]{sess.Index()}
 
 	for _, ar := range apkResults {
 		filteredFindings, err := scan.FilterWithAdvisories(
+			ctx,
 			ar.Result,
-			indexes,
+			sess.Index(),
 			scan.AdvisoriesSetConcluded,
 		)
 		if err != nil {

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -108,7 +108,7 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 	packageCollection := createdSBOM.Artifacts.Packages
 	packageCollection.Add(*apkPackage)
 
-	logger.Debug("finished Syft SBOM generation", "packageCount", packageCollection.PackageCount())
+	logger.Info("finished Syft SBOM generation", "packageCount", packageCollection.PackageCount())
 
 	s := sbom.SBOM{
 		Artifacts: sbom.Artifacts{

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 	"github.com/anchore/syft/syft/source/directorysource"
+	"github.com/chainguard-dev/clog"
 	"github.com/package-url/packageurl-go"
 	"github.com/wolfi-dev/wolfictl/pkg/tar"
 )
@@ -29,17 +31,43 @@ const cpeSourceWolfictl cpe.Source = "wolfictl"
 
 // Generate creates an SBOM for the given APK file.
 func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID string) (*sbom.SBOM, error) {
+	logger := clog.FromContext(ctx)
+
+	logger.Info("generating SBOM for APK file", "path", inputFilePath, "distroID", distroID)
+
 	// Create a temp directory to house the unpacked APK file
 	tempDir, err := os.MkdirTemp("", "wolfictl-sbom-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		logger.Debug("cleaning up temp directory", "path", tempDir)
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	logger.Debug("created temp directory to unpack APK", "path", tempDir)
 
 	// Unpack apk to temp directory
 	err = tar.Untar(f, tempDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unpack apk file: %w", err)
+	}
+	logger.Debug("unpacked APK file to temp directory", "apkFilePath", inputFilePath)
+
+	// Sanity check: count the number of files in the temp directory. Create an fs.FS and walk it.
+
+	tempFsys := os.DirFS(tempDir)
+	err = fs.WalkDir(tempFsys, ".", func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		logger.Debug("apk temp directory item", "path", path)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking APK's temp directory: %w", err)
 	}
 
 	// Analyze the APK metadata
@@ -52,6 +80,7 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 	if err != nil {
 		return nil, fmt.Errorf("failed to create APK package: %w", err)
 	}
+	logger.Debug("synthesized APK package for SBOM", "name", apkPackage.Name, "version", apkPackage.Version, "id", string(apkPackage.ID()))
 
 	src, err := directorysource.New(
 		directorysource.Config{
@@ -61,6 +90,7 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 	if err != nil {
 		return nil, fmt.Errorf("failed to create source from directory: %w", err)
 	}
+	logger.Debug("created Syft source from directory", "description", src.Describe())
 
 	cfg := syft.DefaultCreateSBOMConfig().WithCatalogerSelection(
 		pkgcataloging.NewSelectionRequest().WithDefaults(
@@ -77,6 +107,8 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 
 	packageCollection := createdSBOM.Artifacts.Packages
 	packageCollection.Add(*apkPackage)
+
+	logger.Debug("finished Syft SBOM generation", "packageCount", packageCollection.PackageCount())
 
 	s := sbom.SBOM{
 		Artifacts: sbom.Artifacts{

--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -159,7 +159,7 @@ func (s *Scanner) APKSBOM(ctx context.Context, ssbom *sbomSyft.SBOM) (*Result, e
 	syftPkgs := ssbom.Artifacts.Packages.Sorted()
 	grypePkgs := grypePkg.FromPackages(syftPkgs, grypePkg.SynthesisConfig{GenerateMissingCPEs: false})
 
-	logger.Debug("converted packages to grype packages", "packageCount", len(grypePkgs))
+	logger.Info("converted packages to grype packages", "packageCount", len(grypePkgs))
 
 	// Find vulnerability matches
 	matchesCollection, _, err := s.vulnerabilityMatcher.FindMatches(grypePkgs, grypePkg.Context{

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -18,16 +19,14 @@ const (
 var ValidAdvisoriesSets = []string{AdvisoriesSetResolved, AdvisoriesSetAll, AdvisoriesSetConcluded}
 
 // FilterWithAdvisories filters the findings in the result based on the advisories for the target APK.
-func FilterWithAdvisories(result Result, advisoryDocIndices []*configs.Index[v2.Document], advisoryFilterSet string) ([]Finding, error) {
-	if advisoryDocIndices == nil {
-		return nil, fmt.Errorf("advisory configs cannot be nil")
+func FilterWithAdvisories(_ context.Context, result Result, advisoryDocIndex *configs.Index[v2.Document], advisoryFilterSet string) ([]Finding, error) {
+	// TODO: consider using the context for more detailed logging of the filtering logic.
+
+	if advisoryDocIndex == nil {
+		return nil, fmt.Errorf("advisory document index cannot be nil")
 	}
 
-	var documents []v2.Document
-	for _, index := range advisoryDocIndices {
-		docs := index.Select().WhereName(result.TargetAPK.Origin()).Configurations()
-		documents = append(documents, docs...)
-	}
+	documents := advisoryDocIndex.Select().WhereName(result.TargetAPK.Origin()).Configurations()
 
 	// TODO: Should we error out if we end up with multiple documents for a single package?
 

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -13,20 +13,20 @@ import (
 
 func TestFilterWithAdvisories(t *testing.T) {
 	cases := []struct {
-		name                  string
-		result                *Result
-		advisoryIndicesGetter func(t *testing.T) []*configs.Index[v2.Document]
-		advisoryFilterSet     string
-		expectedFindings      []Finding
-		errAssertion          assert.ErrorAssertionFunc
+		name                string
+		result              *Result
+		advisoryIndexGetter func(t *testing.T) *configs.Index[v2.Document]
+		advisoryFilterSet   string
+		expectedFindings    []Finding
+		errAssertion        assert.ErrorAssertionFunc
 	}{
 		{
-			name:                  "nil advisory index",
-			result:                &Result{},
-			advisoryIndicesGetter: func(_ *testing.T) []*configs.Index[v2.Document] { return nil },
-			advisoryFilterSet:     "",
-			expectedFindings:      nil,
-			errAssertion:          assert.Error,
+			name:                "nil advisory index",
+			result:              &Result{},
+			advisoryIndexGetter: func(_ *testing.T) *configs.Index[v2.Document] { return nil },
+			advisoryFilterSet:   "",
+			expectedFindings:    nil,
+			errAssertion:        assert.Error,
 		},
 		{
 			name: "no filter set",
@@ -47,10 +47,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "",
-			expectedFindings:      nil,
-			errAssertion:          assert.Error,
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "",
+			expectedFindings:    nil,
+			errAssertion:        assert.Error,
 		},
 		{
 			name: "filter set all",
@@ -82,8 +82,8 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "all",
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "all",
 			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
@@ -115,10 +115,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "all",
-			expectedFindings:      []Finding{},
-			errAssertion:          assert.NoError,
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "all",
+			expectedFindings:    []Finding{},
+			errAssertion:        assert.NoError,
 		},
 		{
 			name: "filter set resolved",
@@ -154,8 +154,8 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "resolved",
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
 			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
@@ -186,10 +186,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "resolved",
-			expectedFindings:      []Finding{},
-			errAssertion:          assert.NoError,
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
+			expectedFindings:    []Finding{},
+			errAssertion:        assert.NoError,
 		},
 		{
 			name: "filter set resolved, via origin package",
@@ -211,10 +211,10 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "resolved",
-			expectedFindings:      []Finding{},
-			errAssertion:          assert.NoError,
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
+			expectedFindings:    []Finding{},
+			errAssertion:        assert.NoError,
 		},
 		{
 			name: "filter set resolved, but fixed version not reached",
@@ -231,8 +231,8 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "resolved",
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "resolved",
 			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
@@ -243,41 +243,6 @@ func TestFilterWithAdvisories(t *testing.T) {
 			errAssertion: assert.NoError,
 		},
 		{
-			name: "use multiple advisory indices",
-			result: &Result{
-				TargetAPK: TargetAPK{
-					Name:    "ko",
-					Version: "0.13.0-r2",
-				},
-				Findings: []Finding{
-					{
-						Vulnerability: Vulnerability{
-							ID: "GHSA-2h5h-59f5-c5x9", // In first advisories index (as fixed)
-						},
-					},
-					{
-						Vulnerability: Vulnerability{
-							ID: "GHSA-bbbb-bbbb-bbbb", // In second advisories index (as true positive)
-						},
-					},
-					{
-						Vulnerability: Vulnerability{
-							ID: "GHSA-cccc-cccc-cccc", // Not in any of the advisories indices
-						},
-					},
-				},
-			},
-			advisoryIndicesGetter: getMultipleAdvisoriesIndices,
-			advisoryFilterSet:     "all",
-			expectedFindings: []Finding{
-				{
-					Vulnerability: Vulnerability{
-						ID: "GHSA-cccc-cccc-cccc",
-					},
-				},
-			},
-			errAssertion: assert.NoError,
-		}, {
 			name: "use concluded advisory filter",
 			result: &Result{
 				TargetAPK: TargetAPK{
@@ -307,8 +272,8 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "concluded",
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "concluded",
 			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
@@ -352,8 +317,8 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "concluded",
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "concluded",
 			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
@@ -386,8 +351,8 @@ func TestFilterWithAdvisories(t *testing.T) {
 					},
 				},
 			},
-			advisoryIndicesGetter: getSingleAdvisoriesIndex,
-			advisoryFilterSet:     "concluded",
+			advisoryIndexGetter: getSingleAdvisoriesIndex,
+			advisoryFilterSet:   "concluded",
 			expectedFindings: []Finding{
 				{
 					Vulnerability: Vulnerability{
@@ -409,12 +374,12 @@ func TestFilterWithAdvisories(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			index := tt.advisoryIndicesGetter(t)
+			index := tt.advisoryIndexGetter(t)
 
 			var resultFindings []Finding
 			var err error
 			assert.NotPanics(t, func() {
-				resultFindings, err = FilterWithAdvisories(*tt.result, index, tt.advisoryFilterSet)
+				resultFindings, err = FilterWithAdvisories(context.Background(), *tt.result, index, tt.advisoryFilterSet)
 			})
 			tt.errAssertion(t, err)
 			assert.Equal(t, tt.expectedFindings, resultFindings)
@@ -422,7 +387,7 @@ func TestFilterWithAdvisories(t *testing.T) {
 	}
 }
 
-func getSingleAdvisoriesIndex(t *testing.T) []*configs.Index[v2.Document] {
+func getSingleAdvisoriesIndex(t *testing.T) *configs.Index[v2.Document] {
 	t.Helper()
 
 	advFS := rwos.DirFS(path.Join("testdata", "advisories"))
@@ -431,25 +396,5 @@ func getSingleAdvisoriesIndex(t *testing.T) []*configs.Index[v2.Document] {
 		t.Fatal(err)
 	}
 
-	return []*configs.Index[v2.Document]{index}
-}
-
-func getMultipleAdvisoriesIndices(t *testing.T) []*configs.Index[v2.Document] {
-	t.Helper()
-
-	var indices []*configs.Index[v2.Document]
-
-	for _, dir := range []string{
-		"advisories",
-		"advisories-additional",
-	} {
-		advFS := rwos.DirFS(path.Join("testdata", dir))
-		index, err := v2.NewIndex(context.Background(), advFS)
-		if err != nil {
-			t.Fatal(err)
-		}
-		indices = append(indices, index)
-	}
-
-	return indices
+	return index
 }


### PR DESCRIPTION
- ⚠️ **BREAKING**: The the API of several library methods associated with SBOM generation and vulnerability scanning have been modified in a breaking way.
- ⚠️ **BREAKING**: Scan result filtering with advisories now takes at most one advisories dir/index; multiple were never needed, so this simplifies the operation.
- 📜 Logging with clog and contexts has been plumbed extensively into SBOM generation and vulnerability scanning.
- 🔨  Fix: When the scan command fetched a remote APK, this temp file is now cleaned up after scanning, whereas it was not before.

cc: @cpanato @hectorj2f @rawlingsj @jonjohnsonjr 