### PR TITLE
lint: forbid github /files/ links as they may contain comment attachments

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -36,6 +36,10 @@ var (
 		"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
 	}
 
+	// subtly incorrect URLs to scan for
+	// match https://github.com/microsoft/vcpkg/files/14125503/Cheat.Lab.2.7.2.zip (comment attachment)
+	forbiddenURLRe = regexp.MustCompile(`github\.com\/\w+\/\w+\/files\/\d+\/`)
+
 	// Used for comparing hosts between configs
 	seenHosts = map[string]bool{}
 	// The minimum edit distance between two hostnames
@@ -155,6 +159,11 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 						if err != nil {
 							return fmt.Errorf("uri is invalid URL structure")
 						}
+
+						if forbiddenURLRe.MatchString(uri) {
+							return fmt.Errorf("uri forbidden: %q", uri)
+						}
+
 						if !reValidHostname.MatchString(u.Host) {
 							return fmt.Errorf("uri hostname %q is invalid", u.Host)
 						}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -50,6 +50,22 @@ func TestLinter_Rules(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			file: "forbidden-github-url.yaml",
+			want: EvalResult{
+				File: "forbidden-github-url",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "valid-pipeline-fetch-uri",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[valid-pipeline-fetch-uri]: uri forbidden: \"https://github.com/microsoft/vcpkg/files/14125503/backd00r-${{package.version}}.src.tgz\" (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			file: "forbidden-repository-tagged.yaml",
 			want: EvalResult{
 				File: "forbidden-repository-tagged",

--- a/pkg/lint/testdata/files/forbidden-github-url.yaml
+++ b/pkg/lint/testdata/files/forbidden-github-url.yaml
@@ -1,0 +1,16 @@
+package:
+  name: forbidden-github-url
+  version: 1.0.0
+  epoch: 0
+  description: "a package with a forbidden GitHub URL"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/microsoft/vcpkg/files/14125503/backd00r-${{package.version}}.src.tgz
+      expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269


### PR DESCRIPTION
GitHub /files/ links include comment attachments, meaning that anyone can upload a file that looks like it's official to a particular repository. Due to the opaqueness of who uploaded what, this rule forbids it's use.

See https://www.mcafee.com/blogs/other-blogs/mcafee-labs/redline-stealer-a-novel-approach/ for a recent attack that abused this feature.

NOTE: Do not merge this until we fix the one instance of this URL in wolfi: https://github.com/wolfi-dev/os/pull/17679 is addressed.