### PR TITLE
scan: turn off Go main module version matching for now

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	chainguard.dev/apko v0.14.1-0.20240308000904-c510767a86aa
 	chainguard.dev/melange v0.6.11
 	github.com/adrg/xdg v0.4.0
-	github.com/anchore/grype v0.75.0
+	github.com/anchore/grype v0.77.0
 	github.com/anchore/stereoscope v0.0.3-0.20240423181235-8b297badafd5
 	github.com/anchore/syft v1.3.0
 	github.com/chainguard-dev/clog v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.75.0 h1:ZxT8u6qdVzBXqMieEpyrbapln82UK4VnExl8o/Ma/gI=
-github.com/anchore/grype v0.75.0/go.mod h1:KQGcelZLdoUQnacEDvMdtopw+Y6RHPbdH3cGdajlNhw=
+github.com/anchore/grype v0.77.0 h1:HoTdZ67INrEpEiSKL713zY+j77HxoEAcsMPIZDZ4yP4=
+github.com/anchore/grype v0.77.0/go.mod h1:k6QLcebOqPm+90y8mMesOJM6A6DYQllOic6Tmz507sc=
 github.com/anchore/packageurl-go v0.1.1-0.20240312213626-055233e539b4 h1:SjemQ90fgflz39HG+VMkNfrpUVJpcFW6ZFA3TDXqzBM=
 github.com/anchore/packageurl-go v0.1.1-0.20240312213626-055233e539b4/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.3-0.20240423181235-8b297badafd5 h1:tXFLSxp66bG8tVnHGPmkblJltm6n/E52tqo1gMWnJ9U=

--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -209,9 +209,9 @@ func createMatchers(useCPEs bool) []matcher.Matcher {
 		matcher.Config{
 			Dotnet: dotnet.MatcherConfig{UseCPEs: useCPEs},
 			Golang: golang.MatcherConfig{
-				UseCPEs:               useCPEs,
-				AlwaysUseCPEForStdlib: true,
-				//AllowMainModulePseudoVersionComparison: true, // remove so compatible with grype v0.75.0
+				UseCPEs:                                useCPEs,
+				AlwaysUseCPEForStdlib:                  true,
+				AllowMainModulePseudoVersionComparison: true,
 			},
 			Java: java.MatcherConfig{
 				ExternalSearchConfig: java.ExternalSearchConfig{

--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -211,7 +211,7 @@ func createMatchers(useCPEs bool) []matcher.Matcher {
 			Golang: golang.MatcherConfig{
 				UseCPEs:                                useCPEs,
 				AlwaysUseCPEForStdlib:                  true,
-				AllowMainModulePseudoVersionComparison: true,
+				AllowMainModulePseudoVersionComparison: false,
 			},
 			Java: java.MatcherConfig{
 				ExternalSearchConfig: java.ExternalSearchConfig{


### PR DESCRIPTION
This is a follow-up to #792 that removes the need to regress the Syft/Grype versions used while still avoiding a known source of false positives in the meantime.

cc: @rawlingsj 