### PR TITLE
new triage framework and automated triaging!

### DIFF
--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -56,6 +56,10 @@ func (req Request) ResolveAliases(ctx context.Context, af AliasFinder) (*Request
 			return nil, fmt.Errorf("resolving GHSA %q: %w", req.VulnerabilityID, err)
 		}
 
+		if cve == "" {
+			return &req, nil
+		}
+
 		req.Aliases = append(req.Aliases, req.VulnerabilityID)
 		slices.Sort(req.Aliases)
 		req.Aliases = slices.Compact(req.Aliases)

--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -176,7 +176,7 @@ func cmdAdvisoryGuide() *cobra.Command {
 
 			distroID := strings.ToLower(detected.Absolute.Name)
 
-			scanner, err := scan.NewScanner("", false)
+			scanner, err := scan.NewScanner(ctx, "", false)
 			if err != nil {
 				return fmt.Errorf("failed to create vulnerability scanner: %w", err)
 			}

--- a/pkg/cli/advisory_triage.go
+++ b/pkg/cli/advisory_triage.go
@@ -1,0 +1,283 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/db/v5/store"
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/go-apk/pkg/expandapk"
+	"github.com/chainguard-dev/yam/pkg/yam/formatted"
+	"github.com/spf13/cobra"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+	"github.com/wolfi-dev/wolfictl/pkg/scan"
+	"github.com/wolfi-dev/wolfictl/pkg/scan/target"
+	"github.com/wolfi-dev/wolfictl/pkg/scan/triage"
+	"github.com/wolfi-dev/wolfictl/pkg/scan/triage/gogitversion"
+	"github.com/wolfi-dev/wolfictl/pkg/scan/triage/govulncheck"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"gopkg.in/yaml.v3"
+)
+
+//nolint:gocyclo // we should refactor this function when the design is more solid
+func cmdAdvisoryTriage() *cobra.Command {
+	p := &triageParams{}
+	cmd := &cobra.Command{
+		Use:   "triage",
+		Short: "Triage vulnerabilities and record analysis in advisory data",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+
+			logger := clog.NewLogger(getLogger(p.verbosity))
+			ctx = clog.WithLogger(ctx, logger)
+
+			if p.traceFile != "" {
+				w, err := os.Create(p.traceFile)
+				if err != nil {
+					return fmt.Errorf("creating trace file: %w", err)
+				}
+				defer w.Close()
+				exporter, err := stdouttrace.New(stdouttrace.WithWriter(w))
+				if err != nil {
+					return fmt.Errorf("creating stdout exporter: %w", err)
+				}
+				tp := trace.NewTracerProvider(trace.WithBatcher(exporter))
+				otel.SetTracerProvider(tp)
+
+				defer func() {
+					if err := tp.Shutdown(context.WithoutCancel(ctx)); err != nil {
+						clog.FromContext(ctx).Errorf("shutting down trace provider: %v", err)
+					}
+				}()
+
+				tctx, span := otel.Tracer("wolfictl").Start(ctx, "advisory triage")
+				defer span.End()
+				ctx = tctx
+
+				logger.Info("tracing enabled", "traceFile", p.traceFile)
+			}
+
+			// TODO: Support triaging multiple packages at once
+			if p.packageName == "" {
+				return fmt.Errorf("--%s is required", flagNamePackage)
+			}
+
+			if p.advisoriesDir == "" {
+				return fmt.Errorf("--%s is required", flagNameAdvisoriesRepoDir)
+			}
+
+			if p.builtPackagesDir == "" {
+				return fmt.Errorf("--%s is required", flagNameBuiltPackagesDir)
+			}
+
+			advIndex, err := v2.NewIndex(ctx, rwos.DirFS(p.advisoriesDir))
+			if err != nil {
+				return fmt.Errorf("creating index of advisories repo: %w", err)
+			}
+
+			if advIndex.Select().Len() == 0 {
+				return fmt.Errorf("no advisory documents found in %q", p.advisoriesDir)
+			}
+
+			o, err := target.New(ctx, os.DirFS(p.builtPackagesDir))
+			if err != nil {
+				return fmt.Errorf("constructing APK opener: %w", err)
+			}
+
+			targetAPK, err := o.LatestVersion(p.packageName)
+			if err != nil {
+				return fmt.Errorf("getting latest version of %q: %w", p.packageName, err)
+			}
+
+			apk, err := o.Open(targetAPK)
+			if err != nil {
+				return fmt.Errorf("opening APK file for %q: %w", targetAPK, err)
+			}
+			defer apk.Close()
+
+			expandedAPKTempDir, err := os.MkdirTemp("", "wolfictl-expanded-apk-*")
+			if err != nil {
+				return fmt.Errorf("creating temporary directory for expanded APK: %w", err)
+			}
+			defer os.RemoveAll(expandedAPKTempDir)
+			apkExpanded, err := expandapk.ExpandApk(ctx, apk, expandedAPKTempDir)
+			if err != nil {
+				return fmt.Errorf("expanding APK: %w", err)
+			}
+
+			// For now, the implementation peeks into the Grype database. But it'd be good
+			// to replace this with a more upstream way to get the vulnerability data, such
+			// as local OSV data stores.
+			grypeStore, err := store.New(filepath.Join(scan.GrypeDBDir(), "5", "vulnerability.db"), false)
+			if err != nil {
+				return fmt.Errorf("creating grype vulnerability data store: %w", err)
+			}
+			grypeVulnProvider, err := db.NewVulnerabilityProvider(grypeStore)
+			if err != nil {
+				return fmt.Errorf("creating grype vulnerability provider: %w", err)
+			}
+			defer grypeStore.Close()
+
+			// TODO: Make this list and its order configurable by the user
+			var triagers []triage.Triager
+			triagers = append(triagers,
+				gogitversion.New(gogitversion.TriagerOptions{
+					RepositoriesCacheDir:       p.upstreamRepoCacheDir,
+					GrypeVulnerabilityProvider: grypeVulnProvider,
+				}),
+				govulncheck.New(apkExpanded.TarFS),
+			)
+
+			// do APK scan
+			scanner, err := scan.NewScanner(ctx, "", false)
+			if err != nil {
+				return fmt.Errorf("creating scanner: %w", err)
+			}
+
+			targetAPKFile, err := o.Open(targetAPK)
+			if err != nil {
+				return fmt.Errorf("opening APK file for %q: %w", targetAPK, err)
+			}
+
+			result, err := scanner.ScanAPK(ctx, targetAPKFile, p.distroDir)
+			if err != nil {
+				return fmt.Errorf("scanning APK %q: %w", targetAPK, err)
+			}
+
+			targetAPKFile.Close()
+
+			// filter results, so we only triage the findings that are not already resolved
+			filteredFindings, err := scan.FilterWithAdvisories(ctx, *result, advIndex, scan.AdvisoriesSetResolved)
+			if err != nil {
+				return fmt.Errorf("filtering findings with advisories: %w", err)
+			}
+			result.Findings = filteredFindings
+
+			requests, err := triage.Do(ctx, triagers, result)
+			if err != nil {
+				return fmt.Errorf("triaging vulnerability scan results for %v: %w", targetAPK, err)
+			}
+
+			af := advisory.NewHTTPAliasFinder(http.DefaultClient)
+			var dryRunWriter io.Writer = os.Stdout
+
+			if p.dryRun {
+				fmt.Fprintln(dryRunWriter) // for visual separation
+			}
+
+			for _, req := range requests {
+				req, err := req.ResolveAliases(ctx, af)
+				if err != nil {
+					return fmt.Errorf("resolving aliases for %s: %w", req.VulnerabilityID, err)
+				}
+
+				if err := req.Validate(); err != nil {
+					return fmt.Errorf(
+						"invalid advisory data request for %s in %s: %w",
+						req.VulnerabilityID,
+						req.Package,
+						err,
+					)
+				}
+
+				if p.dryRun {
+					vuln := req.VulnerabilityID
+					for _, alias := range req.Aliases {
+						vuln += fmt.Sprintf(" / %s", alias)
+					}
+
+					_, err := fmt.Fprintf(
+						dryRunWriter,
+						"%s: %s (DRY RUN)\n",
+						styles.Bold().Render(req.Package),
+						styles.Bold().Render(vuln),
+					)
+					if err != nil {
+						return fmt.Errorf("writing advisory data request to stdout: %w", err)
+					}
+
+					// TODO: We can skip the upfront yaml.Node encoding once yam supports non-node encoding directly.
+					n := new(yaml.Node)
+					err = n.Encode(req.Event)
+					if err != nil {
+						return fmt.Errorf("marshaling advisory event: %w", err)
+					}
+					err = formatted.NewEncoder(dryRunWriter).Encode(n)
+					if err != nil {
+						return fmt.Errorf("writing advisory event to stdout: %w", err)
+					}
+
+					fmt.Fprintln(dryRunWriter) // for visual separation
+					continue
+				}
+
+				doc, err := advIndex.Select().WhereName(req.Package).First()
+				if err != nil {
+					return err
+				}
+				if _, exists := doc.Configuration().Advisories.Get(req.VulnerabilityID); !exists {
+					err := advisory.Create(ctx, *req, advisory.CreateOptions{
+						AdvisoryDocs: advIndex,
+					})
+					if err != nil {
+						return fmt.Errorf("creating advisory: %w", err)
+					}
+				} else {
+					err = advisory.Update(ctx, *req, advisory.UpdateOptions{
+						AdvisoryDocs: advIndex,
+					})
+					if err != nil {
+						return fmt.Errorf("updating advisory data: %w", err)
+					}
+				}
+
+				logger.Info("advisory data updated", "package", req.Package, "vulnerability", req.VulnerabilityID, "eventType", req.Event.Type)
+			}
+
+			logger.Info("triaging complete", "newAdvisoryEventsCount", len(requests), "targetAPK", targetAPK)
+
+			return nil
+		},
+	}
+
+	p.addFlagsTo(cmd)
+	return cmd
+}
+
+type triageParams struct {
+	verbosity            int
+	builtPackagesDir     string
+	advisoriesDir        string
+	distroDir            string
+	upstreamRepoCacheDir string
+	packageName          string
+	traceFile            string
+	dryRun               bool
+}
+
+func (p *triageParams) addFlagsTo(cmd *cobra.Command) {
+	addVerboseFlag(&p.verbosity, cmd)
+	addBuiltPackagesDirFlag(&p.builtPackagesDir, cmd)
+	addAdvisoriesDirFlag(&p.advisoriesDir, cmd)
+	addDistroDirFlag(&p.distroDir, cmd)
+	addPackageFlag(&p.packageName, cmd)
+	cmd.Flags().StringVar(&p.traceFile, flagNameTraceFile, "", "write trace data to file")
+	cmd.Flags().StringVarP(&p.upstreamRepoCacheDir, flagNameUpstreamRepositoryCacheDir, "c", gitRepositoriesCacheDir, "location for caching upstream project git repositories")
+	cmd.Flags().BoolVar(&p.dryRun, "dry-run", false, "don't actually update advisory data, just print the data that would be added")
+}
+
+const flagNameUpstreamRepositoryCacheDir = "upstream-repository-cache-dir"
+const flagNameTraceFile = "trace"
+
+var gitRepositoriesCacheDir = filepath.Join(xdg.CacheHome, "wolfictl", "advisory", "triage", "git")

--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -70,7 +70,7 @@ print an error message that specifies where and how the data is invalid.`,
 			var packagesRepoDir string
 			var apkRepositoryURL string
 
-			logger := clog.NewLogger(newLogger(p.verbosity))
+			logger := clog.NewLogger(getLogger(p.verbosity))
 			ctx := clog.WithLogger(cmd.Context(), logger)
 
 			if p.doNotDetectDistro {

--- a/pkg/cli/advisory_validate_fixes.go
+++ b/pkg/cli/advisory_validate_fixes.go
@@ -28,7 +28,7 @@ func cmdAdvisoryValidateFixes() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			logger := clog.NewLogger(newLogger(p.verbosity))
+			logger := clog.NewLogger(getLogger(p.verbosity))
 			ctx := clog.WithLogger(cmd.Context(), logger)
 
 			if p.advisoriesRepoDir == "" {
@@ -115,12 +115,9 @@ type validateFixesParams struct {
 func (p *validateFixesParams) addFlagsToCommand(cmd *cobra.Command) {
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
 	addVerboseFlag(&p.verbosity, cmd)
-
-	cmd.Flags().StringVarP(&p.builtPackagesDir, flagNameBuiltPackagesDir, "b", "", "directory containing built packages")
-	cmd.Flags().StringVar(&p.distro, "distro", "wolfi", "distro to use during vulnerability matching")
+	addBuiltPackagesDirFlag(&p.builtPackagesDir, cmd)
+	addDistroFlag(&p.distro, cmd)
 }
-
-const flagNameBuiltPackagesDir = "built-packages-dir"
 
 func findPathsOfAPKs(fsys fs.FS) ([]string, error) {
 	var pathsToAPKs []string
@@ -207,7 +204,7 @@ func findInvalidFixedAdvisoriesForAPK(
 	}
 
 	// Scan the APK
-	scanner, err := scan.NewScanner("", false)
+	scanner, err := scan.NewScanner(ctx, "", false)
 	if err != nil {
 		return nil, fmt.Errorf("creating scanner: %w", err)
 	}

--- a/pkg/cli/sbom.go
+++ b/pkg/cli/sbom.go
@@ -31,7 +31,7 @@ func cmdSBOM() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := clog.NewLogger(newLogger(p.verbosity))
+			logger := clog.NewLogger(getLogger(p.verbosity))
 			ctx := clog.WithLogger(cmd.Context(), logger)
 
 			if !slices.Contains([]string{sbomFormatOutline, sbomFormatSyftJSON}, p.outputFormat) {

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -144,7 +144,7 @@ wolfictl scan package1 package2 --remote
 		Args:          cobra.MinimumNArgs(1),
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := clog.NewLogger(newLogger(p.verbosity))
+			logger := clog.NewLogger(getLogger(p.verbosity))
 			ctx := clog.WithLogger(cmd.Context(), logger)
 
 			if p.outputFormat == "" {
@@ -263,7 +263,7 @@ func scanEverything(ctx context.Context, p *scanParams, inputs []string, advisor
 	// Immediately start a goroutine, so we can initialize the vulnerability database.
 	// Once that's finished, we will start to pull sboms off of done as they become ready.
 	g.Go(func() error {
-		scanner, err := scan.NewScanner(p.localDBFilePath, p.useCPEMatching)
+		scanner, err := scan.NewScanner(ctx, p.localDBFilePath, p.useCPEMatching)
 		if err != nil {
 			return fmt.Errorf("failed to create scanner: %w", err)
 		}
@@ -442,7 +442,7 @@ func (p *scanParams) doScanCommandForSingleInput(
 	// If requested, triage vulnerabilities in Go binaries using govulncheck
 
 	if p.triageWithGoVulnCheck {
-		triagedFindings, err := scan.Triage(ctx, *result, inputFile)
+		triagedFindings, err := scan.Triage(ctx, *result, inputFile) //nolint:staticcheck // we'll clean this when we remove the deprecated code
 		if err != nil {
 			return nil, fmt.Errorf("failed to triage vulnerability matches: %w", err)
 		}
@@ -772,7 +772,7 @@ func (t findingsTree) render() string {
 					renderSeverity(f.Vulnerability.Severity),
 					renderVulnerabilityID(f.Vulnerability),
 					renderFixedIn(f.Vulnerability),
-					renderTriaging(verticalLine, f.TriageAssessments),
+					renderTriaging(verticalLine, f.TriageAssessments), //nolint:staticcheck // we'll clean this when we remove the deprecated code
 				)
 				lines = append(lines, line)
 			}
@@ -849,6 +849,7 @@ func renderFixedIn(vuln scan.Vulnerability) string {
 	return fmt.Sprintf(" fixed in %s", vuln.FixedVersion)
 }
 
+//nolint:staticcheck // we'll clean this when we remove the deprecated code
 func renderTriaging(verticalLine string, trs []scan.TriageAssessment) string {
 	if len(trs) == 0 {
 		return ""
@@ -868,6 +869,7 @@ func renderTriaging(verticalLine string, trs []scan.TriageAssessment) string {
 	return "\n" + strings.Join(lines, "\n")
 }
 
+//nolint:staticcheck // we'll clean this when we remove the deprecated code
 func renderTriageAssessment(verticalLine string, tr scan.TriageAssessment) string {
 	label := styles.Bold().Render(fmt.Sprintf("%t positive", tr.TruePositive))
 	return fmt.Sprintf("%s             ⚖️  %s according to %s", verticalLine, label, tr.Source)

--- a/pkg/configs/index.go
+++ b/pkg/configs/index.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chainguard-dev/yam/pkg/yam"
 	"github.com/chainguard-dev/yam/pkg/yam/formatted"
 	"github.com/wolfi-dev/wolfictl/pkg/configs/rwfs"
+	"go.opentelemetry.io/otel"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,6 +42,9 @@ type Index[T Configuration] struct {
 // fs.FS, decode the file to type T, and return a reference the "type T" data,
 // or an error if there was a problem.
 func NewIndex[T Configuration](ctx context.Context, fsys rwfs.FS, cfgDecodeFunc func(context.Context, string) (*T, error)) (*Index[T], error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, "configs.NewIndex")
+	defer span.End()
+
 	if cfgDecodeFunc == nil {
 		return nil, errors.New("must supply a cfgDecodeFunc")
 	}

--- a/pkg/internal/gomod/discovery.go
+++ b/pkg/internal/gomod/discovery.go
@@ -1,0 +1,91 @@
+package gomod
+
+// Adapted from https://github.com/golang/go/blob/660a071906a3f010a947457521b7671041b5f737/src/cmd/go/internal/vcs/discovery.go
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// parseMetaGoImports returns meta imports from the HTML in r.
+// Parsing ends at the end of the <head> section or the beginning of the <body>.
+func parseMetaGoImports(r io.Reader) ([]metaImport, error) {
+	d := xml.NewDecoder(r)
+	d.CharsetReader = charsetReader
+	d.Strict = false
+	var imports []metaImport
+	for {
+		t, err := d.RawToken()
+		if err != nil {
+			if err != io.EOF && len(imports) == 0 {
+				return nil, err
+			}
+			break
+		}
+		if e, ok := t.(xml.StartElement); ok && strings.EqualFold(e.Name.Local, "body") {
+			break
+		}
+		if e, ok := t.(xml.EndElement); ok && strings.EqualFold(e.Name.Local, "head") {
+			break
+		}
+		e, ok := t.(xml.StartElement)
+		if !ok || !strings.EqualFold(e.Name.Local, "meta") {
+			continue
+		}
+		if attrValue(e.Attr, "name") != "go-import" {
+			continue
+		}
+		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+			imports = append(imports, metaImport{
+				Prefix:   f[0],
+				VCS:      f[1],
+				RepoRoot: f[2],
+			})
+		}
+	}
+
+	// Extract mod entries if we are paying attention to them.
+	var list []metaImport
+
+	// Append non-mod entries, ignoring those superseded by a mod entry.
+	for _, m := range imports {
+		if m.VCS != "mod" {
+			list = append(list, m)
+		}
+	}
+	return list, nil
+}
+
+// metaImport represents the parsed <meta name="go-import"
+// content="prefix vcs reporoot" /> tags from HTML files.
+type metaImport struct {
+	Prefix, VCS, RepoRoot string
+}
+
+// charsetReader returns a reader that converts from the given charset to UTF-8.
+// Currently it only supports UTF-8 and ASCII. Otherwise, it returns a meaningful
+// error which is printed by go get, so the user can find why the package
+// wasn't downloaded if the encoding is not supported. Note that, in
+// order to reduce potential errors, ASCII is treated as UTF-8 (i.e. characters
+// greater than 0x7f are not rejected).
+func charsetReader(charset string, input io.Reader) (io.Reader, error) {
+	switch strings.ToLower(charset) {
+	case "utf-8", "ascii":
+		return input, nil
+	default:
+		return nil, fmt.Errorf("can't decode XML document using charset %q", charset)
+	}
+}
+
+// attrValue returns the attribute value for the case-insensitive key
+// `name', or the empty string if nothing is found.
+func attrValue(attrs []xml.Attr, name string) string {
+	for _, a := range attrs {
+		if strings.EqualFold(a.Name.Local, name) {
+			return a.Value
+		}
+	}
+	return ""
+}

--- a/pkg/internal/gomod/pseudoversion.go
+++ b/pkg/internal/gomod/pseudoversion.go
@@ -1,0 +1,14 @@
+package gomod
+
+import "regexp"
+
+var (
+	pseudoVersionPattern = `^v\d+\.\d+\.\d+-\d{14}-[0-9a-f]{12}$`
+	pseudoVersionRegexp  = regexp.MustCompile(pseudoVersionPattern)
+)
+
+// IsPseudoVersion reports whether the given version is a Go pseudo-version
+// (https://go.dev/ref/mod#pseudo-versions).
+func IsPseudoVersion(version string) bool {
+	return pseudoVersionRegexp.MatchString(version)
+}

--- a/pkg/internal/gomod/repo.go
+++ b/pkg/internal/gomod/repo.go
@@ -1,0 +1,39 @@
+package gomod
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+)
+
+// Repo returns the source code repository URL for the given module import path.
+func Repo(ctx context.Context, importpath string) (string, error) {
+	_, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("resolving git URL for go module %s", importpath))
+	defer span.End()
+
+	if strings.HasPrefix(importpath, "github.com/") {
+		trimmed := trimMajorVersionSuffix(importpath)
+		return "https://" + trimmed, nil
+	}
+
+	resp, err := http.Get("https://" + importpath + "?go-get=1")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	metas, err := parseMetaGoImports(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return metas[0].RepoRoot, nil
+}
+
+var majorVersionSuffixRegex = regexp.MustCompile(`/v\d+$`)
+
+func trimMajorVersionSuffix(v string) string {
+	return majorVersionSuffixRegex.ReplaceAllString(v, "")
+}

--- a/pkg/scan/finding.go
+++ b/pkg/scan/finding.go
@@ -14,8 +14,17 @@ import (
 
 // Finding represents a vulnerability finding for a single package.
 type Finding struct {
-	Package           Package
-	Vulnerability     Vulnerability
+	// Package describes the software component to which the scan matched a
+	// vulnerability. This may be an APK package, but it may also be any component
+	// within the APK, such as a Go module, npm package, etc.
+	Package Package
+
+	// Vulnerability describes the known software vulnerability that was matched to
+	// a Package.
+	Vulnerability Vulnerability
+
+	// Deprecated: Triaging is now handled in the package "scan/triage", as a
+	// downstream stage in the vulnerability management workflow.
 	TriageAssessments []TriageAssessment
 }
 
@@ -34,6 +43,8 @@ type Vulnerability struct {
 	FixedVersion string
 }
 
+// Deprecated: Triaging is now handled in the package "scan/triage", as a
+// downstream stage in the vulnerability management workflow.
 type TriageAssessment struct {
 	// Source is the name of the source of the triage assessment, e.g.
 	// "govulncheck".

--- a/pkg/scan/govulncheck.go
+++ b/pkg/scan/govulncheck.go
@@ -21,6 +21,9 @@ const (
 
 // runGovulncheck is our entrypoint for running govulncheck on a Go binary (as
 // the exe parameter).
+//
+// Deprecated: this function is deprecated and will be removed in a future. This
+// functionality is now available in the "scan/triage/govulncheck" package.
 func runGovulncheck(ctx context.Context, exe io.ReaderAt) (*vulncheck.Result, error) {
 	// TODO: implement a smarter client that can cache the DB locally.
 	c, err := client.NewClient(govulncheckDB, nil)
@@ -41,19 +44,19 @@ func runGovulncheck(ctx context.Context, exe io.ReaderAt) (*vulncheck.Result, er
 	return result, nil
 }
 
-type GoVulnDBIndex struct {
-	index map[string]GoVulnDBIndexEntry
+type goVulnDBIndex struct {
+	index map[string]goVulnDBIndexEntry
 }
 
-type GoVulnDBIndexEntry struct {
+type goVulnDBIndexEntry struct {
 	ID       string    `json:"id"`
 	Modified time.Time `json:"modified"`
 	Aliases  []string  `json:"aliases,omitempty"`
 }
 
-// BuildIndexForGoVulnDB builds an index of GoVulnDB entries, keyed by aliases
+// buildIndexForGoVulnDB builds an index of GoVulnDB entries, keyed by aliases
 // (like CVE IDs and GHSA IDs).
-func BuildIndexForGoVulnDB(ctx context.Context) (*GoVulnDBIndex, error) {
+func buildIndexForGoVulnDB(ctx context.Context) (*goVulnDBIndex, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", govulncheckDB+indexEndpoint, nil)
 	if err != nil {
 		return nil, err
@@ -66,12 +69,12 @@ func BuildIndexForGoVulnDB(ctx context.Context) (*GoVulnDBIndex, error) {
 	}
 	defer resp.Body.Close()
 
-	var entries []GoVulnDBIndexEntry
+	var entries []goVulnDBIndexEntry
 	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
 		return nil, err
 	}
 
-	index := make(map[string]GoVulnDBIndexEntry)
+	index := make(map[string]goVulnDBIndexEntry)
 	for _, entry := range entries {
 		index[entry.ID] = entry
 		for _, alias := range entry.Aliases {
@@ -79,12 +82,12 @@ func BuildIndexForGoVulnDB(ctx context.Context) (*GoVulnDBIndex, error) {
 		}
 	}
 
-	return &GoVulnDBIndex{index}, nil
+	return &goVulnDBIndex{index}, nil
 }
 
 // Get returns the GoVulnDB index entry for the given ID, or false if it doesn't
 // exist.
-func (i *GoVulnDBIndex) Get(id string) (GoVulnDBIndexEntry, bool) {
+func (i *goVulnDBIndex) Get(id string) (goVulnDBIndexEntry, bool) {
 	entry, ok := i.index[id]
 	return entry, ok
 }

--- a/pkg/scan/result.go
+++ b/pkg/scan/result.go
@@ -1,0 +1,69 @@
+package scan
+
+import (
+	"sort"
+
+	"github.com/anchore/grype/grype/db"
+)
+
+// Result represents the result of a vulnerability scan of an APK package.
+type Result struct {
+	// TargetAPK is the APK package that was scanned.
+	TargetAPK TargetAPK
+
+	// Findings is a list of vulnerability matches found among the component
+	// packages within the APK package.
+	Findings []Finding
+
+	// Deprecated: GrypeDBStatus would be a better fit attached to a different
+	// struct. The Result struct is meant for the _output_ of a scan, and it's
+	// scanner _agnostic_. In contrast, the GrypeDBStatus field is scanner
+	// _specific_ and is known _ahead_ of the scan. For consumers that need both the
+	// scan result and the Grype DB status, it might be better to have a separate
+	// struct that combines the two.
+	GrypeDBStatus *db.Status
+}
+
+func (r Result) ByVuln() ByVulnResult {
+	byVuln := make(map[string][]Finding)
+
+	for i := range r.Findings {
+		f := r.Findings[i]
+		byVuln[f.Vulnerability.ID] = append(byVuln[f.Vulnerability.ID], f)
+	}
+
+	return ByVulnResult{
+		TargetAPK: r.TargetAPK,
+		ByVuln:    byVuln,
+	}
+}
+
+type ByVulnResult struct {
+	TargetAPK TargetAPK
+	ByVuln    map[string][]Finding
+}
+
+func (r ByVulnResult) Split() []VulnFindings {
+	var vfs []VulnFindings
+
+	for vulnID, findings := range r.ByVuln {
+		vfs = append(vfs, VulnFindings{
+			VulnerabilityID: vulnID,
+			TargetAPK:       r.TargetAPK,
+			Findings:        findings,
+		})
+	}
+
+	// Sort by vulnerability ID for deterministic output.
+	sort.Slice(vfs, func(i, j int) bool {
+		return vfs[i].VulnerabilityID < vfs[j].VulnerabilityID
+	})
+
+	return vfs
+}
+
+type VulnFindings struct {
+	VulnerabilityID string
+	TargetAPK       TargetAPK
+	Findings        []Finding
+}

--- a/pkg/scan/target/opener.go
+++ b/pkg/scan/target/opener.go
@@ -1,0 +1,119 @@
+package target
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+
+	goapk "github.com/chainguard-dev/go-apk/pkg/apk"
+	"github.com/wolfi-dev/wolfictl/pkg/apk"
+	"github.com/wolfi-dev/wolfictl/pkg/scan"
+	"github.com/wolfi-dev/wolfictl/pkg/versions"
+	"go.opentelemetry.io/otel"
+)
+
+type Opener struct {
+	fsys                   fs.FS
+	index                  map[scan.TargetAPK]string
+	packageToVersionsIndex map[string][]scan.TargetAPK
+}
+
+// New creates a new Opener that can open APK files from the given fs.FS.
+func New(ctx context.Context, fsys fs.FS) (*Opener, error) {
+	_, span := otel.Tracer("wolfictl").Start(ctx, "scan/target.New")
+	defer span.End()
+
+	o := &Opener{
+		fsys:                   fsys,
+		index:                  make(map[scan.TargetAPK]string),
+		packageToVersionsIndex: make(map[string][]scan.TargetAPK),
+	}
+
+	err := fs.WalkDir(o.fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if path == "." {
+			return nil
+		}
+
+		// TODO: consider a recursive option
+		if d.IsDir() {
+			return fs.SkipDir
+		}
+
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		// if extension isn't apk, skip
+		if filepath.Ext(path) != ".apk" {
+			return nil
+		}
+
+		f, err := o.fsys.Open(path)
+		if err != nil {
+			return fmt.Errorf("opening APK file: %w", err)
+		}
+		defer f.Close()
+
+		pkginfo, err := apk.PKGINFOFromAPK(f)
+		if err != nil {
+			return fmt.Errorf("parsing APK file %q: %w", path, err)
+		}
+
+		target := pkginfoToTarget(pkginfo)
+		o.index[target] = path
+		o.packageToVersionsIndex[pkginfo.Name] = append(
+			o.packageToVersionsIndex[pkginfo.Name],
+			pkginfoToTarget(pkginfo),
+		)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+func pkginfoToTarget(pkginfo *goapk.Package) scan.TargetAPK {
+	return scan.TargetAPK{
+		Name:              pkginfo.Name,
+		Version:           pkginfo.Version,
+		OriginPackageName: pkginfo.Origin,
+	}
+}
+
+// Open opens and returns the APK file for the given target.
+func (o Opener) Open(target scan.TargetAPK) (fs.File, error) {
+	path, ok := o.index[target]
+	if !ok {
+		return nil, fmt.Errorf("no APK found for target %v", target)
+	}
+
+	return o.fsys.Open(path)
+}
+
+// LatestVersion returns the latest version of the APK with the given package
+// name that's known to the Opener.
+func (o Opener) LatestVersion(name string) (scan.TargetAPK, error) {
+	targets, ok := o.packageToVersionsIndex[name]
+	if !ok || len(targets) == 0 {
+		return scan.TargetAPK{}, fmt.Errorf("no APK found for package named %q", name)
+	}
+
+	if len(targets) == 1 {
+		return targets[0], nil
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		return versions.Less(targets[i].Version, targets[j].Version)
+	})
+
+	return targets[0], nil
+}

--- a/pkg/scan/triage.go
+++ b/pkg/scan/triage.go
@@ -13,11 +13,14 @@ import (
 	"golang.org/x/vuln/pkg/vulncheck"
 )
 
-const TriageSourceGovulncheck = "govulncheck"
+const triageSourceGovulncheck = "govulncheck"
 
 // Triage inspects an existing scan Result and attempts to triage each finding,
 // returning a copy of the Result's list of findings, modified to include
 // TriageAssessments where applicable.
+//
+// Deprecated: this function is deprecated and will be removed in a future
+// release. Use the "scan/triage" package instead.
 func Triage(ctx context.Context, result Result, apkFile io.ReadSeeker) ([]Finding, error) {
 	findings := slices.Clone(result.Findings)
 
@@ -81,7 +84,7 @@ func Triage(ctx context.Context, result Result, apkFile io.ReadSeeker) ([]Findin
 		}
 	}
 
-	govulnDBIndex, err := BuildIndexForGoVulnDB(ctx)
+	govulnDBIndex, err := buildIndexForGoVulnDB(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +118,7 @@ func Triage(ctx context.Context, result Result, apkFile io.ReadSeeker) ([]Findin
 				foundByGovulncheck = true
 
 				assessment := TriageAssessment{
-					Source:       TriageSourceGovulncheck,
+					Source:       triageSourceGovulncheck,
 					TruePositive: true,
 					Reason: fmt.Sprintf(
 						"affected symbol %q is present in Go binary (see %s)",
@@ -141,7 +144,7 @@ func Triage(ctx context.Context, result Result, apkFile io.ReadSeeker) ([]Findin
 			}
 
 			assessment := TriageAssessment{
-				Source:       TriageSourceGovulncheck,
+				Source:       triageSourceGovulncheck,
 				TruePositive: false,
 				Reason: fmt.Sprintf(
 					"no known affected symbols present in Go binary (see %s)",
@@ -155,7 +158,7 @@ func Triage(ctx context.Context, result Result, apkFile io.ReadSeeker) ([]Findin
 	return findings, nil
 }
 
-func isKnownToGoVulnDB(v Vulnerability, govulnDBIndex *GoVulnDBIndex) bool {
+func isKnownToGoVulnDB(v Vulnerability, govulnDBIndex *goVulnDBIndex) bool {
 	_, ok := govulnDBIndex.Get(v.ID)
 	if ok {
 		return true

--- a/pkg/scan/triage/conclusion.go
+++ b/pkg/scan/triage/conclusion.go
@@ -1,0 +1,54 @@
+package triage
+
+import (
+	"errors"
+
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+)
+
+// ErrNoConclusion is the sentinel error returned by a Triager when it cannot
+// reach a conclusion.
+var ErrNoConclusion = errors.New("no triage conclusion was reached")
+
+type ConclusionType int
+
+const (
+	Unknown ConclusionType = iota
+	TruePositive
+	FalsePositive
+)
+
+// Conclusion represents a triager conclusion for a single finding.
+type Conclusion struct {
+	Type   ConclusionType
+	Reason interface{}
+}
+
+// EventTypeFromConclusions returns the advisory event type that should be used
+// to capture the conclusions as an advisory request.
+//
+// If all findings are false positives, the returned request's event type will
+// reflect a false positive.
+//
+// If any finding is a true positive, the returned request's event type will
+// reflect a true positive. If no conclusions were reached, the returned event
+// type will be an empty string.
+func EventTypeFromConclusions(conclusions []Conclusion) string {
+	allAreFalsePositives := true
+
+	for _, c := range conclusions {
+		switch c.Type {
+		case TruePositive:
+			return v2.EventTypeTruePositiveDetermination
+
+		case Unknown:
+			allAreFalsePositives = false
+		}
+	}
+
+	if allAreFalsePositives {
+		return v2.EventTypeFalsePositiveDetermination
+	}
+
+	return ""
+}

--- a/pkg/scan/triage/gogitversion/triager.go
+++ b/pkg/scan/triage/gogitversion/triager.go
@@ -1,0 +1,714 @@
+package gogitversion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	v5 "github.com/anchore/grype/grype/db/v5"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/chainguard-dev/clog"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	"github.com/wolfi-dev/wolfictl/pkg/internal/gomod"
+	"github.com/wolfi-dev/wolfictl/pkg/scan"
+	"github.com/wolfi-dev/wolfictl/pkg/scan/triage"
+	"github.com/wolfi-dev/wolfictl/pkg/versions"
+	"go.opentelemetry.io/otel"
+)
+
+type Triager struct {
+	repositoriesCacheDir string
+	grypeVulnProvider    vulnerability.Provider
+
+	// moduleToGitURL lets us cache the git URLs we resolve from Go module names.
+	moduleToGitURL map[string]string
+
+	// gitURLToRepo is a map of git URLs to their git.Repository objects. This lets
+	// us open each repo exactly once per session. This also helps signal to the
+	// code in this object that the repository has already been refreshed (pulled or
+	// cloned) this session and is ready to use.
+	gitURLToRepo map[string]*git.Repository
+
+	// repoVersionToCommit is a map of git repository URLs to a map of module
+	// versions to the commit that version corresponds to.
+	repoVersionToCommit map[string]map[string]*object.Commit
+
+	// isAncestorCache is a map of commit hashes to whether the fixed commit is an
+	// ancestor of the installed commit.
+	isAncestorCache map[commitHashes]bool
+
+	// vulnerabilityIDToModuleNameToCommits is a map of vulnerability IDs to a map of
+	// module names to the installed and fixed commits for that vulnerability and
+	// module.
+	vulnerabilityIDToModuleNameToCommits map[string]map[string]commits
+
+	// commitToTags is a map of commit hashes to the tag(s) that correspond to that
+	// commit.
+	commitToTags map[string][]string
+}
+
+type TriagerOptions struct {
+	RepositoriesCacheDir       string
+	GrypeVulnerabilityProvider vulnerability.Provider
+}
+
+func New(opts TriagerOptions) *Triager {
+	return &Triager{
+		repositoriesCacheDir:                 opts.RepositoriesCacheDir,
+		grypeVulnProvider:                    opts.GrypeVulnerabilityProvider,
+		repoVersionToCommit:                  make(map[string]map[string]*object.Commit),
+		gitURLToRepo:                         make(map[string]*git.Repository),
+		moduleToGitURL:                       make(map[string]string),
+		vulnerabilityIDToModuleNameToCommits: make(map[string]map[string]commits),
+		isAncestorCache:                      make(map[commitHashes]bool),
+		commitToTags:                         make(map[string][]string),
+	}
+}
+
+type isAncestorReason struct {
+	installedCommit string
+	fixedCommit     string
+	isAncestor      bool
+	location        string
+	moduleName      string
+}
+
+type commitHasTagOfLaterVersionReason struct {
+	installedCommit    string
+	installedCommitTag string
+	fixedVersion       string
+	location           string
+	moduleName         string
+}
+
+type commits struct {
+	installed *object.Commit
+	fixed     *object.Commit
+}
+
+type commitHashes struct {
+	installed string
+	fixed     string
+}
+
+const grypeDBNamespaceForGitHubGo = "github:language:go"
+
+func (t *Triager) Triage(ctx context.Context, vfs scan.VulnFindings) (*advisory.Request, error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("gogitversion triage %s in %s", vfs.VulnerabilityID, vfs.TargetAPK.Name))
+	defer span.End()
+
+	logger := clog.FromContext(ctx)
+	logger = logger.With("triager", "gogitversion")
+	logger.Info("triaging", "vulnerabilityID", vfs.VulnerabilityID, "targetAPK", vfs.TargetAPK.Name, "targetAPKVersion", vfs.TargetAPK.Version, "cacheDir", t.repositoriesCacheDir)
+
+	conclusions := make([]triage.Conclusion, len(vfs.Findings))
+
+	for i := range vfs.Findings {
+		finding := vfs.Findings[i]
+
+		if finding.Package.Type != string(pkg.GoModulePkg) {
+			return nil, fmt.Errorf("%s (at %s) is not a Go module: %w", finding.Package.Name, finding.Package.Location, triage.ErrNoConclusion)
+		}
+
+		moduleName := finding.Package.Name
+
+		if finding.Vulnerability.FixedVersion == "" {
+			logger.Debug("no fixed version in scanner finding", "vulnerabilityID", vfs.VulnerabilityID, "moduleName", moduleName)
+
+			// NOTE: This is an *experimental* workaround for the fact that Grype sometimes
+			// doesn't provide a fixed version for vulnerabilities, if there are multiple
+			// "fixed" version ranges in its database and the original vulnerability
+			// scanning selected a non-fixed range. It'd be better to avoid using Grype's
+			// database for fixed versions ALWAYS, deferring instead to an upstream data
+			// source like GHSA.
+
+			vs, err := t.grypeVulnProvider.Get(finding.Vulnerability.ID, grypeDBNamespaceForGitHubGo)
+			if err != nil {
+				return nil, fmt.Errorf("getting vulnerability details for %q from Grype: %w", finding.Vulnerability.ID, err)
+			}
+
+			var newFixedVersion string
+			for i := range vs {
+				v := vs[i]
+
+				if v.ID != finding.Vulnerability.ID || v.Fix.State != v5.FixedState {
+					continue
+				}
+
+				if len(v.Fix.Versions) != 1 {
+					continue
+				}
+
+				newFixedVersion = v.Fix.Versions[0]
+				break
+			}
+
+			if newFixedVersion == "" {
+				// Oh well, it was worth a shot!
+				continue
+			}
+
+			logger.Warn("swapping in new fixed version from Grype database", "vulnerabilityID", finding.Vulnerability.ID, "moduleName", moduleName, "newFixedVersion", newFixedVersion)
+			finding.Vulnerability.FixedVersion = newFixedVersion
+		}
+
+		cs, err := t.resolveCommits(ctx, finding)
+		if err != nil {
+			logger.Warn("unable to resolve fixed and/or installed commit for finding", "vulnerabilityID", vfs.VulnerabilityID, "moduleName", moduleName, "error", err)
+			continue
+		}
+
+		// Check if the fixed commit is an ancestor of the installed commit
+		isAncestor, err := t.isAncestor(ctx, cs.fixed, cs.installed)
+		if err != nil {
+			return nil, err
+		}
+
+		if isAncestor {
+			c := triage.Conclusion{
+				Type: triage.FalsePositive,
+				Reason: isAncestorReason{
+					installedCommit: cs.installed.Hash.String(),
+					fixedCommit:     cs.fixed.Hash.String(),
+					isAncestor:      isAncestor,
+					location:        finding.Package.Location,
+					moduleName:      moduleName,
+				},
+			}
+			conclusions[i] = c
+			continue
+		}
+
+		// Check if the installed commit corresponds to a semver tag, and if that tag is
+		// later than the fixed version.
+
+		tag, err := t.checkInstalledCommitForTagLaterThanFixedVersion(ctx, moduleName, cs.installed, finding.Vulnerability.FixedVersion)
+		if err != nil {
+			return nil, fmt.Errorf("checking installed commit for tag later than fixed version: %w", err)
+		}
+
+		if tag == "" {
+			continue
+		}
+
+		c := triage.Conclusion{
+			Type: triage.FalsePositive,
+			Reason: commitHasTagOfLaterVersionReason{
+				installedCommit:    cs.installed.Hash.String(),
+				installedCommitTag: tag,
+				fixedVersion:       finding.Vulnerability.FixedVersion,
+				location:           finding.Package.Location,
+				moduleName:         moduleName,
+			},
+		}
+		conclusions[i] = c
+	}
+
+	event := eventFromConclusions(conclusions)
+
+	if event == nil {
+		logger.Info("no conclusion reached", "vulnerabilityID", vfs.VulnerabilityID)
+		return nil, triage.ErrNoConclusion
+	}
+
+	logger.Info("found false positive", "vulnerabilityID", vfs.VulnerabilityID)
+
+	return &advisory.Request{
+		Package:         vfs.TargetAPK.OriginPackageName,
+		VulnerabilityID: vfs.VulnerabilityID,
+		Event:           *event,
+	}, nil
+}
+
+func (t *Triager) checkInstalledCommitForTagLaterThanFixedVersion(ctx context.Context, moduleName string, installedCommit *object.Commit, fixedVersion string) (string, error) {
+	logger := clog.FromContext(ctx)
+
+	repo, err := t.getRepoAtLatest(ctx, t.moduleToGitURL[moduleName])
+	if err != nil {
+		return "", err
+	}
+
+	tags, err := t.tagsForCommit(ctx, repo, installedCommit)
+	if err != nil {
+		return "", fmt.Errorf("getting tags for commit %q: %w", installedCommit.Hash, err)
+	}
+
+	fixedVersionParsed, err := versions.NewVersion(fixedVersion)
+	if err != nil {
+		return "", fmt.Errorf("parsing fixed version %q: %w", fixedVersion, err)
+	}
+
+	for _, tag := range tags {
+		installedVersion, err := versions.NewVersion(tag)
+		if err != nil {
+			logger.Debug("tag not usable", "tag", tag)
+			continue
+		}
+
+		if installedVersion.GreaterThan(fixedVersionParsed) {
+			return tag, nil
+		}
+	}
+
+	logger.Debug("no version tag found that is later than the fixed version", "fixedVersion", fixedVersion)
+
+	return "", nil
+}
+
+func (t *Triager) tagsForCommit(ctx context.Context, repo *git.Repository, commit *object.Commit) ([]string, error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("tagsForCommit (%s)", commit.Hash))
+	defer span.End()
+
+	logger := clog.FromContext(ctx)
+
+	if tags, ok := t.commitToTags[commit.Hash.String()]; ok {
+		return tags, nil
+	}
+
+	logger.Debug("resolving tags for commit", "commit", commit.Hash.String())
+
+	var tags []string
+
+	// Iterate over all tags
+	tagrefs, err := repo.Tags()
+	if err != nil {
+		return nil, err
+	}
+
+	err = tagrefs.ForEach(func(tagref *plumbing.Reference) error {
+		var tagCommit *object.Commit
+
+		// Resolve tag to a commit
+		obj, err := repo.TagObject(tagref.Hash())
+		if err == nil {
+			// Annotated tag
+			tagCommit, err = obj.Commit()
+			if err != nil {
+				return err
+			}
+		} else {
+			// Lightweight tag
+			tagCommit, err = repo.CommitObject(tagref.Hash())
+			if err != nil {
+				return err
+			}
+		}
+
+		// Check if the tag's commit matches the given commit
+		if tagCommit.Hash == commit.Hash {
+			tags = append(tags, tagref.Name().Short())
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug("tags for commit", "commit", commit.Hash.String(), "tags", strings.Join(tags, ","))
+	t.commitToTags[commit.Hash.String()] = tags
+
+	return tags, nil
+}
+
+func (t *Triager) isAncestor(ctx context.Context, fixed, installed *object.Commit) (bool, error) {
+	_, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("isAncestor (%s, %s)", fixed.Hash, installed.Hash))
+	defer span.End()
+
+	hashes := commitHashes{
+		fixed:     fixed.Hash.String(),
+		installed: installed.Hash.String(),
+	}
+
+	if isAncestor, ok := t.isAncestorCache[hashes]; ok {
+		return isAncestor, nil
+	}
+
+	isAncestor, err := fixed.IsAncestor(installed)
+	if err != nil {
+		return false, fmt.Errorf("checking if %q is an ancestor of %q: %w", fixed.Hash, installed.Hash, err)
+	}
+
+	t.isAncestorCache[hashes] = isAncestor
+
+	return isAncestor, nil
+}
+
+func (t *Triager) resolveCommits(ctx context.Context, finding scan.Finding) (*commits, error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("resolveCommits for %s in %s", finding.Vulnerability.ID, finding.Package.Name))
+	defer span.End()
+
+	logger := clog.FromContext(ctx)
+
+	moduleName := finding.Package.Name
+
+	// Check if we've already resolved the commits for this vulnerability and package.
+	vulnID, ok := t.vulnerabilityIDToModuleNameToCommits[finding.Vulnerability.ID]
+	if ok {
+		commits, ok := vulnID[moduleName]
+		if ok {
+			return &commits, nil
+		}
+	}
+
+	// Only do the online go-module-to-git-URL resolution *once* per module.
+	gitURL, ok := t.moduleToGitURL[moduleName]
+	if !ok {
+		var err error
+		gitURL, err = gomod.Repo(ctx, moduleName)
+		if err != nil {
+			return nil, fmt.Errorf("determining git repository for %s: %w", moduleName, err)
+		}
+		logger.Debug("determined git repository", "module", moduleName, "gitURL", gitURL)
+
+		t.moduleToGitURL[moduleName] = gitURL
+	}
+
+	componentVersion := finding.Package.Version
+	installedCommit, err := t.resolveModuleVersionToCommit(ctx, gitURL, componentVersion)
+	if err != nil {
+		return nil, fmt.Errorf("resolving installed version %q to commit: %w", componentVersion, err)
+	}
+	logger.Debug("resolved installed version to commit", "version", componentVersion, "commit", installedCommit.Hash.String())
+
+	fixedVersion := finding.Vulnerability.FixedVersion
+
+	// Adjust the tag for certain Go modules. This is a workaround for the fact that
+	// some Go modules have non-standard tagging conventions. Another approach would
+	// be to learn how this tag adjustment should work from the Melange YAML, but
+	// this would only work for main modules and wouldn't generalize for most Go
+	// module findings.
+	if adjuster, ok := versionTagAdjustersByGoModule[moduleName]; ok {
+		fixedVersion = adjuster(fixedVersion)
+	}
+
+	// Grype sometimes trims the "v" prefix in the fixed version, which can be fixed
+	// like this:
+
+	//nolint:gocritic // intentionally commented out
+	// if !strings.HasPrefix(fixedVersion, "v") {
+	// 	fixedVersion = "v" + fixedVersion
+	// }
+
+	// But we should generalize this, so we can try both forms, depending on what
+	// the actual git repo ends up having.
+
+	fixedCommit, err := t.resolveModuleVersionToCommit(ctx, gitURL, fixedVersion)
+	if err != nil {
+		return nil, fmt.Errorf("resolving fixed version %q to commit: %w", fixedVersion, err)
+	}
+	logger.Debug("resolved fixed version to commit", "vulnerabilityID", finding.Vulnerability.ID, "version", fixedVersion, "commit", fixedCommit.Hash.String())
+
+	cs := commits{
+		installed: installedCommit,
+		fixed:     fixedCommit,
+	}
+
+	if _, ok := t.vulnerabilityIDToModuleNameToCommits[finding.Vulnerability.ID]; !ok {
+		t.vulnerabilityIDToModuleNameToCommits[finding.Vulnerability.ID] = make(map[string]commits)
+	}
+	t.vulnerabilityIDToModuleNameToCommits[finding.Vulnerability.ID][moduleName] = cs
+
+	return &cs, nil
+}
+
+// getRepoAtLatest returns a reference to a git repository, which the caller can
+// assume is at the latest commit. If the repository is not in the cache, it
+// will be cloned fresh and then cached. If the repository is already in the
+// cache, it will be opened. If the repository is in the cache but hasn't been
+// pulled since the Triager object was created, it will be pulled before being
+// returned.
+func (t *Triager) getRepoAtLatest(ctx context.Context, gitURL string) (*git.Repository, error) {
+	logger := clog.FromContext(ctx)
+
+	if repo, ok := t.gitURLToRepo[gitURL]; ok {
+		return repo, nil
+	}
+
+	// Check if the repo cache dir exists
+	_, err := os.Stat(t.repoCacheDir(gitURL))
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Debug("repository not in cache, cloning", "gitURL", gitURL)
+			return t.cloneAndCacheRepo(ctx, gitURL)
+		}
+
+		return nil, fmt.Errorf("checking if repository %q is in cache: %w", gitURL, err)
+	}
+
+	logger.Debug("repository was found in cache but hasn't been pulled yet this session, pulling now", "gitURL", gitURL)
+	return t.openAndPullRepo(ctx, gitURL)
+}
+
+func (t *Triager) cloneAndCacheRepo(ctx context.Context, gitURL string) (*git.Repository, error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("cloning %s", gitURL))
+	defer span.End()
+
+	repo, err := git.PlainCloneContext(ctx, t.repoCacheDir(gitURL), false, &git.CloneOptions{
+		URL:  gitURL,
+		Tags: git.AllTags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloning repository %q: %w", gitURL, err)
+	}
+
+	t.gitURLToRepo[gitURL] = repo
+
+	return repo, nil
+}
+
+func (t *Triager) openAndPullRepo(ctx context.Context, gitURL string) (*git.Repository, error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("pulling %s", gitURL))
+	defer span.End()
+
+	repo, err := git.PlainOpen(t.repoCacheDir(gitURL))
+	if err != nil {
+		return nil, fmt.Errorf("opening repository %q: %w", gitURL, err)
+	}
+
+	err = repo.FetchContext(ctx, &git.FetchOptions{
+		Tags: git.AllTags,
+	})
+	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		return nil, fmt.Errorf("fetching repository %q: %w", gitURL, err)
+	}
+
+	t.gitURLToRepo[gitURL] = repo
+
+	return repo, nil
+}
+
+func (t Triager) repoCacheDir(gitURL string) string {
+	trimmed := strings.TrimSuffix(gitURL, ".git")
+	trimmed = strings.TrimPrefix(trimmed, "https://")
+	trimmed = strings.TrimPrefix(trimmed, "http://")
+	leafName := strings.ReplaceAll(trimmed, "/", "--")
+
+	return filepath.Join(t.repositoriesCacheDir, leafName)
+}
+
+func eventFromConclusions(conclusions []triage.Conclusion) *v2.Event {
+	eventType := triage.EventTypeFromConclusions(conclusions)
+
+	if eventType == "" {
+		// No conclusion reached
+		return nil
+	}
+
+	e := &v2.Event{
+		Timestamp: v2.Now(),
+		Type:      eventType,
+	}
+
+	// This triager only ever finds false positives or doesn't reach a conclusion.
+	if eventType == v2.EventTypeFalsePositiveDetermination {
+		e.Data = v2.FalsePositiveDetermination{
+			Type: v2.FPTypeVulnerableCodeVersionNotUsed,
+			Note: getNoteForFalsePositive(conclusions),
+		}
+		return e
+	}
+
+	return nil
+}
+
+func getNoteForFalsePositive(conclusions []triage.Conclusion) string {
+	// Opportunistically try to condense the explanation for the false positive.
+
+	if explanation := condenseExplanationForIsAncestorReason(conclusions); explanation != "" {
+		return explanation
+	}
+
+	if explanation := condenseExplanationForCommitHasTagOfLaterVersionReason(conclusions); explanation != "" {
+		return explanation
+	}
+
+	// We'll just return the full explanation if we can't condense it, so we don't lose any information.
+
+	sb := strings.Builder{}
+	var moduleMessages []string
+	for _, c := range conclusions {
+		switch r := c.Reason.(type) {
+		case isAncestorReason:
+			m := fmt.Sprintf(
+				"For path %q, module %q: the commit of the fixed version (%s) is an ancestor of installed commit (%s).",
+				r.location,
+				r.moduleName,
+				r.fixedCommit,
+				r.installedCommit,
+			)
+			moduleMessages = append(moduleMessages, m)
+
+		case commitHasTagOfLaterVersionReason:
+			m := fmt.Sprintf(
+				"For path %q, module %q: the installed commit (%s) corresponds to a version tag (%s) that is later than the fixed version (%s).",
+				r.location,
+				r.moduleName,
+				r.installedCommit,
+				r.installedCommitTag,
+				r.fixedVersion,
+			)
+			moduleMessages = append(moduleMessages, m)
+		}
+	}
+
+	sb.WriteString(strings.Join(moduleMessages, " "))
+
+	return sb.String()
+}
+
+func condenseExplanationForIsAncestorReason(conclusions []triage.Conclusion) string {
+	if len(conclusions) == 0 {
+		return ""
+	}
+
+	// This will only work if the conclusions all use the isAncestorReason type.
+	var reasons []isAncestorReason
+	var locations []string
+	var installedCommits []string
+	for _, c := range conclusions {
+		r, ok := c.Reason.(isAncestorReason)
+		if !ok {
+			return ""
+		}
+		locations = append(locations, r.location)
+		installedCommits = append(installedCommits, r.installedCommit)
+		reasons = append(reasons, r)
+	}
+
+	slices.Sort(locations)
+	locations = slices.Compact(locations)
+
+	slices.Sort(installedCommits)
+	installedCommits = slices.Compact(installedCommits)
+
+	return fmt.Sprintf(
+		"This vulnerability was matched to the module %q at the following location(s): %s. In all cases, the fixed version of the module (git commit %s) is an ancestor of the installed version commit (%s).",
+		reasons[0].moduleName,
+		strings.Join(locations, ", "),
+		reasons[0].fixedCommit,
+		strings.Join(installedCommits, ", "),
+	)
+}
+
+func condenseExplanationForCommitHasTagOfLaterVersionReason(conclusions []triage.Conclusion) string {
+	if len(conclusions) == 0 {
+		return ""
+	}
+
+	// This will only work if the conclusions all use the commitHasTagOfLaterVersionReason type.
+	var reasons []commitHasTagOfLaterVersionReason
+	var locations []string
+	var installedCommits []string
+	for _, c := range conclusions {
+		r, ok := c.Reason.(commitHasTagOfLaterVersionReason)
+		if !ok {
+			return ""
+		}
+		locations = append(locations, r.location)
+		installedCommits = append(installedCommits, r.installedCommit)
+		reasons = append(reasons, r)
+	}
+
+	slices.Sort(locations)
+	locations = slices.Compact(locations)
+
+	slices.Sort(installedCommits)
+	installedCommits = slices.Compact(installedCommits)
+	if len(installedCommits) > 1 {
+		// If there are multiple installed commits, we can't condense the explanation.
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"This vulnerability was matched to the module %q at the following location(s): %s. In all cases, the installed version of the module (git commit %s) corresponds to a version tag (%s) that is later than the fixed version (%s).",
+		reasons[0].moduleName,
+		strings.Join(locations, ", "),
+		reasons[0].installedCommit,
+		reasons[0].installedCommitTag,
+		reasons[0].fixedVersion,
+	)
+}
+
+func (t *Triager) resolveModuleVersionToCommit(ctx context.Context, gitURL, version string) (*object.Commit, error) {
+	repo, err := t.getRepoAtLatest(ctx, gitURL)
+	if err != nil {
+		return nil, fmt.Errorf("getting repository at latest commit: %w", err)
+	}
+
+	if commit, ok := t.repoVersionToCommit[gitURL][version]; ok {
+		return commit, nil
+	}
+
+	if gomod.IsPseudoVersion(version) {
+		// Extract the commit hash from the pseudo-version
+		commitHash := strings.Split(version, "-")[2]
+
+		// Resolve the partial commit hash to a full commit hash
+		fullHash, err := repo.ResolveRevision(plumbing.Revision(commitHash))
+		if err != nil {
+			return nil, fmt.Errorf("resolving partial commit hash %q: %w", commitHash, err)
+		}
+
+		// Get the commit object for the commit hash
+		commit, err := repo.CommitObject(*fullHash)
+		if err != nil {
+			return nil, fmt.Errorf("getting commit object for hash %q: %w", commitHash, err)
+		}
+
+		t.repoVersionToCommit[gitURL] = map[string]*object.Commit{
+			version: commit,
+		}
+
+		return commit, nil
+	}
+
+	// Assume the version is a Git tag
+	tagRef, err := repo.Tag(version)
+	if err != nil {
+		return nil, fmt.Errorf("getting tag %q: %w", version, err)
+	}
+
+	// Try to get the tag object for the tag
+	tag, err := repo.TagObject(tagRef.Hash())
+	if err != nil {
+		// If there's an error, assume it's a lightweight tag and get the commit object directly
+		commit, err := repo.CommitObject(tagRef.Hash())
+		if err != nil {
+			return nil, fmt.Errorf("getting commit object for lightweight tag %q: %w", version, err)
+		}
+
+		t.repoVersionToCommit[gitURL] = map[string]*object.Commit{
+			version: commit,
+		}
+
+		return commit, nil
+	}
+
+	// If it's an annotated tag, get the commit object for the tag
+	commit, err := repo.CommitObject(tag.Target)
+	if err != nil {
+		return nil, fmt.Errorf("getting commit object for annotated tag %q: %w", version, err)
+	}
+
+	t.repoVersionToCommit[gitURL] = map[string]*object.Commit{
+		version: commit,
+	}
+
+	return commit, nil
+}
+
+var versionTagAdjustersByGoModule = map[string]func(string) string{
+	"k8s.io/ingress-nginx": func(v string) string {
+		return fmt.Sprintf("controller-v%s", v)
+	},
+}

--- a/pkg/scan/triage/govulncheck/triager.go
+++ b/pkg/scan/triage/govulncheck/triager.go
@@ -1,0 +1,349 @@
+package govulncheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/chainguard-dev/clog"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	"github.com/wolfi-dev/wolfictl/pkg/scan"
+	"github.com/wolfi-dev/wolfictl/pkg/scan/triage"
+	"go.opentelemetry.io/otel"
+	"golang.org/x/vuln/pkg/client"
+	"golang.org/x/vuln/pkg/govulncheck"
+	vulnscan "golang.org/x/vuln/pkg/scan"
+	"golang.org/x/vuln/pkg/vulncheck"
+)
+
+// Triager uses govulncheck to triage Go module vulnerabilities by inspecting
+// the APK's Go binaries for affected symbols.
+//
+// For more information on the govulncheck project, see
+// https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck.
+type Triager struct {
+	apkFS fs.FS
+
+	datastore                *goVulnDBIndex
+	datastoreGenerationMutex *sync.Mutex
+
+	govulncheckResultCache map[string]*vulncheck.Result
+}
+
+// New creates a new Triager.
+func New(apkFS fs.FS) *Triager {
+	return &Triager{
+		apkFS:                    apkFS,
+		datastoreGenerationMutex: &sync.Mutex{},
+		govulncheckResultCache:   make(map[string]*vulncheck.Result),
+	}
+}
+
+type reason struct {
+	location        string
+	affectedSymbols []string
+}
+
+// Triage implements triage.Triager.
+func (t *Triager) Triage(ctx context.Context, vfs scan.VulnFindings) (*advisory.Request, error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("govulncheck triage %s in %s", vfs.VulnerabilityID, vfs.TargetAPK.Name))
+	defer span.End()
+
+	logger := clog.FromContext(ctx)
+	logger = logger.With("triager", "govulncheck")
+
+	logger.Info("triaging", "vulnerabilityID", vfs.VulnerabilityID, "targetAPK", vfs.TargetAPK.Name)
+
+	conclusions := make([]triage.Conclusion, len(vfs.Findings))
+
+	for i := range vfs.Findings {
+		finding := vfs.Findings[i]
+
+		if finding.Package.Type != string(pkg.GoModulePkg) {
+			return nil, fmt.Errorf("%s (at %s) is not a Go module: %w", finding.Package.Name, finding.Package.Location, triage.ErrNoConclusion)
+		}
+
+		vcResult, err := t.runGovulncheck(ctx, finding.Package)
+		if err != nil {
+			return nil, fmt.Errorf("running govulncheck on file in APK: %s: %w", finding.Package.Location, err)
+		}
+
+		if vcResult == nil {
+			return nil, fmt.Errorf("nil result running govulncheck on file in APK: %s", finding.Package.Location)
+		}
+
+		govulnDBIndex, err := t.buildDatastoreForGoVulnDB(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("building go vulnDB index: %w", err)
+		}
+
+		var affectedSymbolsFound []string
+		for _, vuln := range vcResult.Vulns {
+			gvAliases := vuln.OSV.Aliases
+			for _, alias := range gvAliases {
+				if !slices.Contains(append(finding.Vulnerability.Aliases, finding.Vulnerability.ID), alias) {
+					// This govulncheck result vuln alias is not relevant to this finding.
+					continue
+				}
+
+				affectedSymbolsFound = append(affectedSymbolsFound, vuln.Symbol)
+			}
+		}
+
+		if len(affectedSymbolsFound) > 0 {
+			// Deduplicate the affected symbols.
+			slices.Sort(affectedSymbolsFound)
+			affectedSymbolsFound = slices.Compact(affectedSymbolsFound)
+
+			c := triage.Conclusion{
+				Type: triage.TruePositive,
+				Reason: reason{
+					location:        finding.Package.Location,
+					affectedSymbols: affectedSymbolsFound,
+				},
+			}
+			conclusions[i] = c
+			continue
+		}
+
+		// If govulncheck didn't confirm the finding, but it did know what to look for
+		// (that is, the vulnerability exists in Go's vulndb), then we can assume it's a
+		// false positive. Otherwise, we can't make any assumptions, because govulncheck
+		// didn't even consider the vulnerability.
+		if !govulnDBIndex.isKnownToGoVulnDB(finding.Vulnerability) {
+			logger.Debug("vulnerability not in Go vulndb", "vulnerabilityID", finding.Vulnerability.ID, "component", finding.Package.Name, "location", finding.Package.Location)
+			continue
+		}
+
+		c := triage.Conclusion{
+			Type: triage.FalsePositive,
+			Reason: reason{
+				location: finding.Package.Location,
+			},
+		}
+		conclusions[i] = c
+	}
+
+	event := eventFromConclusions(conclusions)
+
+	if event == nil {
+		logger.Info("no conclusion reached", "vulnerabilityID", vfs.VulnerabilityID)
+		return nil, triage.ErrNoConclusion
+	}
+
+	logger.Info("conclusion reached", "vulnerabilityID", vfs.VulnerabilityID, "eventType", event.Type)
+
+	return &advisory.Request{
+		Package:         vfs.TargetAPK.OriginPackageName,
+		VulnerabilityID: vfs.VulnerabilityID,
+		Event:           *event,
+	}, nil
+}
+
+func eventFromConclusions(conclusions []triage.Conclusion) *v2.Event {
+	eventType := triage.EventTypeFromConclusions(conclusions)
+
+	if eventType == "" {
+		// No conclusion reached
+		return nil
+	}
+
+	e := &v2.Event{
+		Timestamp: v2.Now(),
+		Type:      eventType,
+	}
+
+	if eventType == v2.EventTypeTruePositiveDetermination {
+		e.Data = v2.TruePositiveDetermination{
+			Note: getNoteForTruePositive(conclusions),
+		}
+		return e
+	}
+
+	if eventType == v2.EventTypeFalsePositiveDetermination {
+		e.Data = v2.FalsePositiveDetermination{
+			Type: v2.FPTypeVulnerableCodeNotIncludedInPackage,
+			Note: getNoteForFalsePositive(conclusions),
+		}
+		return e
+	}
+
+	// This case is unexpected, but it would be worse to assume a TP if not a FP, or
+	// vice versa.
+	return nil
+}
+
+func getNoteForTruePositive(conclusions []triage.Conclusion) string {
+	sb := strings.Builder{}
+	sb.WriteString("A govulncheck analysis found the following affected symbols in the APK: ")
+
+	var symbolsAtLocationMessage []string
+	for _, c := range conclusions {
+		if r, ok := c.Reason.(reason); ok {
+			symbolsAtLocationMessage = append(
+				symbolsAtLocationMessage,
+				fmt.Sprintf(
+					"%s (at %s)",
+					strings.Join(r.affectedSymbols, ", "),
+					r.location,
+				),
+			)
+		}
+	}
+
+	sb.WriteString(strings.Join(symbolsAtLocationMessage, ", ") + ".")
+
+	return sb.String()
+}
+
+func getNoteForFalsePositive(conclusions []triage.Conclusion) string {
+	sb := strings.Builder{}
+	sb.WriteString("A govulncheck analysis found that none of the known affected symbols were present in the APK, after examining the following paths within the package: ")
+
+	var pathsExamined []string
+	for _, c := range conclusions {
+		if r, ok := c.Reason.(reason); ok {
+			pathsExamined = append(pathsExamined, r.location)
+		}
+	}
+
+	sb.WriteString(strings.Join(pathsExamined, ", ") + ".")
+
+	return sb.String()
+}
+
+const (
+	govulncheckDB = "https://vuln.go.dev"
+	indexEndpoint = "/index/vulns.json"
+)
+
+// runGovulncheck is our entrypoint for running govulncheck on a Go binary (as
+// the exe parameter).
+func (t *Triager) runGovulncheck(ctx context.Context, p scan.Package) (*vulncheck.Result, error) {
+	ctx, span := otel.Tracer("wolfictl").Start(ctx, fmt.Sprintf("runGovulncheck on %s", p.Location))
+	defer span.End()
+
+	location := p.Location
+
+	if result, ok := t.govulncheckResultCache[location]; ok {
+		return result, nil
+	}
+
+	// Find the Go binary in the APK.
+	pathInAPK := strings.TrimPrefix(location, "/")
+	file, err := t.apkFS.Open(pathInAPK)
+	if err != nil {
+		return nil, fmt.Errorf("opening file %q: %w", pathInAPK, err)
+	}
+	ra, ok := file.(io.ReaderAt)
+	if !ok {
+		return nil, fmt.Errorf("file %q is not a ReaderAt, which is required for govulncheck", location)
+	}
+
+	// TODO: implement a smarter client that can cache the DB locally.
+	c, err := client.NewClient(govulncheckDB, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating DB client: %w", err)
+	}
+
+	cfg := &govulncheck.Config{
+		ScanLevel: "symbol",
+	}
+	result, err := vulncheck.Binary(ctx, ra, cfg, c)
+	if err != nil {
+		return nil, err
+	}
+
+	err = file.Close()
+	if err != nil {
+		return nil, fmt.Errorf("closing file %q: %w", location, err)
+	}
+
+	result.Vulns = vulnscan.UniqueVulns(result.Vulns)
+
+	// Save result to make next time fast!
+	t.govulncheckResultCache[location] = result
+
+	return result, nil
+}
+
+type goVulnDBIndex struct {
+	index map[string]goVulnDBIndexEntry
+}
+
+type goVulnDBIndexEntry struct {
+	ID       string    `json:"id"`
+	Modified time.Time `json:"modified"`
+	Aliases  []string  `json:"aliases,omitempty"`
+}
+
+func (i *goVulnDBIndex) isKnownToGoVulnDB(v scan.Vulnerability) bool {
+	_, ok := i.Get(v.ID)
+	if ok {
+		return true
+	}
+
+	for _, alias := range v.Aliases {
+		_, ok := i.Get(alias)
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildDatastoreForGoVulnDB builds an index of GoVulnDB entries, keyed by
+// aliases (like CVE IDs and GHSA IDs).
+func (t *Triager) buildDatastoreForGoVulnDB(ctx context.Context) (*goVulnDBIndex, error) {
+	if t.datastore != nil {
+		// We already have the index, so return it.
+		return t.datastore, nil
+	}
+
+	t.datastoreGenerationMutex.Lock()
+	defer t.datastoreGenerationMutex.Unlock()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", govulncheckDB+indexEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var entries []goVulnDBIndexEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, err
+	}
+
+	index := make(map[string]goVulnDBIndexEntry)
+	for _, entry := range entries {
+		index[entry.ID] = entry
+		for _, alias := range entry.Aliases {
+			index[alias] = entry
+		}
+	}
+
+	return &goVulnDBIndex{index}, nil
+}
+
+// Get returns the GoVulnDB index entry for the given ID, or false if it doesn't
+// exist.
+func (i *goVulnDBIndex) Get(id string) (goVulnDBIndexEntry, bool) {
+	entry, ok := i.index[id]
+	return entry, ok
+}

--- a/pkg/scan/triage/triager.go
+++ b/pkg/scan/triage/triager.go
@@ -1,0 +1,68 @@
+package triage
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
+	"github.com/wolfi-dev/wolfictl/pkg/scan"
+)
+
+// Triager is the interface that wraps the Triage method.
+type Triager interface {
+	// Triage takes a scan result and returns a triage conclusion.
+	//
+	// It is expected that the implementation will account for all cases of a given
+	// vulnerability in the scan result before returning an advisory request for the
+	// vulnerability, such that the returned request can be considered ready to
+	// apply to an advisory data set.
+	//
+	// Triage implementations can indicate that they did not reach a conclusion by
+	// returning a nil request. Optionally, they can additionally return
+	// ErrNoConclusion, which allows more information to be passed to the caller via
+	// error-wrapping.
+	Triage(ctx context.Context, vulnFindings scan.VulnFindings) (*advisory.Request, error)
+}
+
+// Do handles triaging of an APK's scan.Result by running the given triagers,
+// using the triagers sequentially until one returns a non-nil request. Do
+// returns a slice of advisory requests, each of which represents a triage
+// conclusion for a unique vulnerability in the package.
+func Do(ctx context.Context, triagers []Triager, result *scan.Result) ([]advisory.Request, error) {
+	logger := clog.FromContext(ctx)
+	logger.Info("begin triaging", "targetAPK", result.TargetAPK, "triagerCount", len(triagers), "findingCount", len(result.Findings))
+
+	var requests []advisory.Request
+
+	vulnFindings := result.ByVuln().Split()
+
+	for _, vf := range vulnFindings {
+		for _, triager := range triagers {
+			req, err := triager.Triage(ctx, vf)
+			if err != nil {
+				if errors.Is(err, ErrNoConclusion) {
+					continue
+				}
+				return nil, err
+			}
+
+			if req != nil {
+				requests = append(requests, *req)
+				break
+			}
+		}
+	}
+
+	return requests, nil
+}
+
+type APKOpener interface {
+	// Open returns the APK file associated with the given distro package scan
+	// target. The specified package can be either an origin package or a
+	// subpackage. The caller is responsible for closing the returned file.
+	Open(target scan.TargetAPK) (fs.File, error)
+
+	// TODO: This interface would perhaps be a better fit in the scan package.
+}

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -90,11 +90,19 @@ func (by ByLatestStrings) Len() int {
 }
 
 func (by ByLatestStrings) Less(i, j int) bool {
-	vi, err := NewVersion(by[i])
+	return Less(by[i], by[j])
+}
+
+func (by ByLatestStrings) Swap(i, j int) {
+	by[i], by[j] = by[j], by[i]
+}
+
+func Less(a, b string) bool {
+	vi, err := NewVersion(a)
 	if err != nil {
 		return false
 	}
-	vj, err := NewVersion(by[j])
+	vj, err := NewVersion(b)
 	if err != nil {
 		return false
 	}
@@ -131,8 +139,4 @@ func (by ByLatestStrings) Less(i, j int) bool {
 		}
 	}
 	return vi.GreaterThan(vj)
-}
-
-func (by ByLatestStrings) Swap(i, j int) {
-	by[i], by[j] = by[j], by[i]
 }


### PR DESCRIPTION
### Design 🗺️ 

This introduces a **new triaging framework** centered on this new interface:

```go
type Triager interface {
	// Triage takes a scan result and returns a triage conclusion.
	Triage(ctx context.Context, vulnFindings scan.VulnFindings) (*advisory.Request, error)
}
```

The idea is that we arrange findings for a single vulnerability in an APK package as a `scan.VulnFindings`, such that triager implementations can take this and return their conclusion on whether the vulnerability truly affects the APK package. The result is an `advisory.Request` — i.e. new advisory data all ready to be applied to our advisory data set.

The consumer can wire up as many triagers as needed. Each triager can bring along its own state or network clients as necessary. So while some triagers may only need access to the APK data, others might want to access other local information or even do online lookups.

### Features 🚀 

Automated triaging! 🎉 

This PR adds **two concrete implementations** of the Triager interface, **which have already been massively helpful at dealing with vulnerabilities** (these dealt with ~130 vulnerabilities in ~10 minutes net runtime):

1. "govulncheck" — Based on the _tool_ govulncheck, this implementation cross-references the input findings with an analysis of symbols found in Go binaries to decide if an otherwise present vulnerability has no impact on the APK.
2. "gogitversion" — This clones git repositories for affected Go modules to do version-control-aware analysis of whether remediating commits have been incorporated into the version of the Go module used in a binary in an APK package. The implementation maintains a local cache of git repositories to drastically speed up triaging.

Orthogonal to these features, this PR also was designed for incorporating into future **services**, and therefore has been instrumented with lots of **logging** and **tracing**. 📊 

### Caveats ☠️ 

Since this PR was written to illustrate a concept, with more work originally intended to come later, there are several aspects that would need further work before considering this logic ready-to-use in production.

1. There are no tests — and this is the kind of logic that needs THOROUGH testing. We cannot afford inaccurate advisory data to be automatically added to our data set without proper verification of the validity of triaging assessments.
2. There are many spots in the execution when context cancellation should be considered due to the long-running nature of several pieces in the logic flow.
3. We need a more robust strategy for mapping fixed version data to tags in a source code repo (for "gogitversion"); so far I've been manually adjusting code to expect a leading `v` prefix and to not expect one.
4. The "gogitversion" implementation can likely be generalized to handle cases beyond Go.
5. The commit-to-later-tag version check needs to be taken with a grain of salt, since we're not checking all affected version ranges, only a simple comparison to the "fixed version" reported by Grype.
6. This code doesn't understand the notion of APK "build groups" yet (i.e. an origin packages and its subpackages all produced in the same Melange build). This matters! Because we should not draw a conclusion about a vulnerability affecting an APK package without assessing the impact on the entire build group, since the advisory data is used to apply to the entire build group.
7. Same thing as above, but for multiple architectures instead of multiple packages within a build group.
8. More care should be taken on understanding the latest advisory data for a given vulnerability before proceeding to triage. For example, if we've already drawn our conclusion about a vulnerability (say as a TP or FP), we probably don't want to automatically append an updated triage assessment after that, in contexts when we're not certain that the automated triaging has as much context as went into the previous triage assessment.
9. We should use a better source of truth for fixed version data than the Grype database. Perhaps a local OSV database.