### PR TITLE
if the package only exist for x86 dont fail and continue the scanning

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -626,7 +626,13 @@ func resolveInputForRemoteTarget(ctx context.Context, input string) (downloadedA
 		})
 
 		if len(nameMatches) == 0 {
-			return nil, nil, fmt.Errorf("no Wolfi package found with name %q in arch %q", input, arch)
+
+			if arch != "aarch64" {
+				return nil, nil, fmt.Errorf("no Wolfi package found with name %q in arch %q", input, arch)
+			}
+
+			logger.Warnf("no Wolfi package found with name %q in arch %q but will continue, it might not have a package built for this arch.", input, arch)
+			continue
 		}
 
 		vers := lo.Map(nameMatches, func(pkg *apk.Package, _ int) string {


### PR DESCRIPTION
before
```
 wolfictl scan -r chromium                                                                                                                                                                                                                                                                                                                                                                                                                                                                               📡 Finding remote packages
2024/05/06 15:52:37 INFO error during command execution: failed to resolve input "chromium" for remote scanning: no Wolfi package found with name "chromium" in arch "aarch64"
```


after

```
$ wolfictl scan -r chromium
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-chromium-124.0.6367.91-r0-27198284.apk"
└── 📄 /.PKGINFO
        📦 chromium 124.0.6367.91-r0 (apk)
            Unknown CVE-2024-4331
            Unknown CVE-2024-4368

```