### PR TITLE
lint: github.com is not the only git hosting

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -384,7 +384,7 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				for _, p := range config.Pipeline {
-					if p.Uses == gitCheckout && strings.Contains(p.With["repository"], "github.com") {
+					if p.Uses == gitCheckout && strings.HasPrefix(p.With["repository"], "https://github.com/") {
 						if config.Update.Enabled && config.Update.GitHubMonitor == nil {
 							return fmt.Errorf("configure update.github when using git-checkout")
 						}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -384,7 +384,7 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				for _, p := range config.Pipeline {
-					if p.Uses == gitCheckout {
+					if p.Uses == gitCheckout && strings.Contains(p.With["repository"], "github.com") {
 						if config.Update.Enabled && config.Update.GitHubMonitor == nil {
 							return fmt.Errorf("configure update.github when using git-checkout")
 						}

--- a/pkg/lint/testdata/files/missing-github-update-git-checkout.yaml
+++ b/pkg/lint/testdata/files/missing-github-update-git-checkout.yaml
@@ -12,7 +12,7 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      uri: https://test.com/missing-copyright/${{package.version}}.tar.gz
+      repository: https://github.com/missing/github-update
       tag: v1.2.3
       expected-commit: 1234567890123456789012345678901234567890
 


### PR DESCRIPTION
Only require github-update when git checkouts actually are from
github.com rather than from freedesktop gitlab debian salsa etc.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
