### PR TITLE
git: fix panic while handling non-github git URLs, disallow plain-text http

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -110,13 +110,22 @@ func ParseGitURL(rawURL string) (*URL, error) {
 
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
-		return gitURL, fmt.Errorf("failed to parse git url %s: %w", rawURL, err)
+		return nil, fmt.Errorf("failed to parse git url %s: %w", rawURL, err)
 	}
 	gitURL.Scheme = parsedURL.Scheme
+	if gitURL.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme: %v", parsedURL.Scheme)
+	}
+
 	gitURL.Host = parsedURL.Host
 	parts := strings.Split(parsedURL.Path, "/")
-	gitURL.Organisation = parts[1]
-	gitURL.Name = parts[2]
+	if parsedURL.Host == "github.com" {
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid github path: %s", parsedURL.Path)
+		}
+		gitURL.Organisation = parts[1]
+		gitURL.Name = parts[2]
+	}
 	gitURL.RawURL = rawURL
 
 	return gitURL, nil

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -11,34 +11,57 @@ import (
 
 func TestParseGitURL(t *testing.T) {
 	tests := []struct {
-		rawURL   string
-		scheme   string
-		org      string
-		repoName string
+		rawURL    string
+		scheme    string
+		org       string
+		repoName  string
+		errorText string
 	}{
 		{
-			rawURL:   "https://github.com/foo/bar",
-			scheme:   "https",
-			org:      "foo",
-			repoName: "bar",
+			rawURL:    "https://github.com/foo/bar",
+			scheme:    "https",
+			org:       "foo",
+			repoName:  "bar",
+			errorText: "",
 		},
 		{
-			rawURL:   "https://github.com/foo/bar.git",
-			scheme:   "https",
-			org:      "foo",
-			repoName: "bar",
+			rawURL:    "https://github.com/foo/bar.git",
+			scheme:    "https",
+			org:       "foo",
+			repoName:  "bar",
+			errorText: "",
 		},
 		{
-			rawURL:   "git@github.com:cheese/wine.git",
-			scheme:   "git",
-			org:      "cheese",
-			repoName: "wine",
+			rawURL:    "git@github.com:cheese/wine.git",
+			scheme:    "git",
+			org:       "cheese",
+			repoName:  "wine",
+			errorText: "",
+		},
+		{
+			rawURL:    "https://example.com/",
+			scheme:    "https",
+			org:       "",
+			repoName:  "",
+			errorText: "",
+		},
+		{
+			rawURL:    "http://example.com/",
+			scheme:    "http",
+			org:       "",
+			repoName:  "",
+			errorText: "unsupported scheme: http",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.rawURL, func(t *testing.T) {
 			got, err := ParseGitURL(test.rawURL)
-			assert.NoError(t, err)
+			if test.errorText == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, test.errorText, err.Error())
+				return
+			}
 
 			assert.Equal(t, test.scheme, got.Scheme)
 			assert.Equal(t, test.org, got.Organisation)


### PR DESCRIPTION
This fixes a panic, and adds some security paranoia while we are at it.

## Previous Behavior (http)

`go run . update http://stromberg.org/`


```
panic: runtime error: index out of range [2] with length 2

goroutine 1 [running]:
github.com/wolfi-dev/wolfictl/pkg/git.ParseGitURL({0x16b40b86d, 0x15})
	/Users/t/src/wolfictl/pkg/git/git.go:119 +0x58c
github.com/wolfi-dev/wolfictl/pkg/git.GetGitAuth({0x16b40b86d, 0x15})
	/Users/t/src/wolfictl/pkg/git/git.go:28 +0x8c
```

## Previous Behavior (https)

`go run . update https://apache.googlesource.com/abdera`
 
```
panic: runtime error: index out of range [2] with length 2

goroutine 1 [running]:
github.com/wolfi-dev/wolfictl/pkg/git.ParseGitURL({0x16bac385c, 0x26})
	/Users/t/src/wolfictl/pkg/git/git.go:119 +0x58c
github.com/wolfi-dev/wolfictl/pkg/git.GetGitAuth({0x16bac385c, 0x26})
	/Users/t/src/wolfictl/pkg/git/git.go:28 +0x8c
```

## New Behavior (http)

`go run . update http://stromberg.org/`

```
Error: creating updates: failed to get git auth: failed to parse git URL "http://stromberg.org/": unsupported scheme: http
2024/05/14 18:02:41 INFO error during command execution: creating updates: failed to get git auth: failed to parse git URL "http://stromberg.org/": unsupported scheme: http
exit status 1
```

## New Behavior (https)

`go run . update https://apache.googlesource.com/abdera`


```
2024/05/14 18:04:36 WARN host "apache.googlesource.com" is not github.com, not using GITHUB_TOKEN for authentication
Counting objects: 8741, done
Finding sources: 100% (8741/8741)
Total 8741 (delta 3933), reused 7362 (delta 3933)
found 0 packages
2024/05/14 18:04:39 INFO 2024/05/14 18:04:39 wolfictl update: no package updates
```
