### PR TITLE
lint: require non-empty license tag

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -399,11 +399,10 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				for _, c := range config.Package.Copyright {
-					// TODO(jason): make these errors
 					if c.License == "" {
-						log.Println("license is missing")
-						return nil
+						return fmt.Errorf("license is missing")
 					}
+					// TODO(jason): make this one error
 					if valid, _ := spdxexp.ValidateLicenses([]string{c.License}); !valid {
 						log.Printf("license %q is not valid SPDX license", c.License)
 						return nil


### PR DESCRIPTION
All melange files that I can access have non-empty license tags, so
this is safe to start enforcing.

There are a few that have invalid licenses, so enforcing that has to
wait a bit.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
