### PR TITLE
lint: require custom, proprietary or valid SPDX license tag

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -2,7 +2,6 @@ package lint
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"regexp"
@@ -399,14 +398,13 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				for _, c := range config.Package.Copyright {
-					// TODO(jason): make these errors
-					if c.License == "" {
-						log.Println("license is missing")
-						return nil
+					switch c.License {
+					// Allow wicked licenses
+					case "custom", "PROPRIETARY":
+						continue
 					}
 					if valid, _ := spdxexp.ValidateLicenses([]string{c.License}); !valid {
-						log.Printf("license %q is not valid SPDX license", c.License)
-						return nil
+						return fmt.Errorf("license %q is not valid SPDX license", c.License)
 					}
 				}
 				return nil


### PR DESCRIPTION
valid-copyright-header already enforces non-empty license.

Quite a few files use "PROPRIETARY" (i.e. Nvidia) or "custom" for
non-spdx standardtised licences. Everything else must be valid from
now on.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
