### PR TITLE
bundle: Switch to --upload-file for curling data

### DIFF
--- a/pkg/internal/bundle/bundle.go
+++ b/pkg/internal/bundle/bundle.go
@@ -50,7 +50,7 @@ melange build {{.File}} \
 tar -czvf packages.tar.gz ./packages
 
 # TODO: Content-Type
-curl -X PUT --data-binary @packages.tar.gz -H "Content-Type: application/octet-stream" $PACKAGES_UPLOAD_URL
+curl --upload-file packages.tar.gz -H "Content-Type: application/octet-stream" $PACKAGES_UPLOAD_URL
 
 sha256sum packages.tar.gz
 sha256sum packages.tar.gz | cut -d' ' -f1 > /dev/termination-log


### PR DESCRIPTION
Apparently --binary-data buffers everything into memory.