### PR TITLE
Drop gcp client-go plugin

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -45,8 +45,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // pull in GCP auth
-
 	"github.com/wolfi-dev/wolfictl/pkg/dag"
 	"github.com/wolfi-dev/wolfictl/pkg/internal/bundle"
 )


### PR DESCRIPTION
This definitely shouldn't be doing anything given that all it does it return an error.

https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/gcp/gcp_stub.go