### PR TITLE
fix: command errors are errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"os/signal"
 
+	"github.com/chainguard-dev/clog"
 	"github.com/wolfi-dev/wolfictl/pkg/cli"
 )
 
 func main() {
-	if err := mainE(context.Background()); err != nil {
-		log.Fatalf("error during command execution: %v", err)
+	ctx := context.Background()
+	if err := mainE(ctx); err != nil {
+		clog.FromContext(ctx).Error(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -12,8 +12,7 @@ import (
 func main() {
 	ctx := context.Background()
 	if err := mainE(ctx); err != nil {
-		clog.FromContext(ctx).Error(err.Error())
-		os.Exit(1)
+		clog.FromContext(ctx).Fatal(err.Error())
 	}
 }
 


### PR DESCRIPTION
We've been logging command errors as "INFO" with a verbose prefix and it's been bothering me!

#### Before

```console
$ go run . adv ls --vuln blahasflkj               
2024/05/20 20:27:18 INFO error during command execution: no advisories repo dir specified, and distro auto-detection failed: directory is not a distro (packages) or advisories repository
```

#### After

```console
$ go run . adv ls --vuln blahasflkj
2024/05/20 20:31:11 ERRO no advisories repo dir specified, and distro auto-detection failed: directory is not a distro (packages) or advisories repository
```