### PR TITLE
build: Re-sign, re-index, & upload bundle results

### DIFF
--- a/pkg/internal/bundle/bundle.go
+++ b/pkg/internal/bundle/bundle.go
@@ -47,7 +47,7 @@ melange build {{.File}} \
 {{ range .Flags }} {{.}} \
 {{end}}
 
-tar -czvf packages.tar.gz ./packages
+tar -C packages -czvf packages.tar.gz .
 
 # TODO: Content-Type
 curl --upload-file packages.tar.gz -H "Content-Type: application/octet-stream" $PACKAGES_UPLOAD_URL

--- a/pkg/tar/untar.go
+++ b/pkg/tar/untar.go
@@ -54,16 +54,9 @@ func Untar(src io.Reader, dst string) error {
 			if err != nil {
 				return err
 			}
-			// copy over contents in chunks for security reasons
-			// G110: Potential DoS vulnerability via decompression bomb
-			for {
-				_, err := io.CopyN(fileToWrite, tr, 1024)
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
+
+			if _, err := io.CopyN(fileToWrite, tr, header.Size); err != nil {
+				return err
 			}
 
 			if err := fileToWrite.Close(); err != nil {


### PR DESCRIPTION
Instead of just comparing hashes of bundle results, wolfictl build will now re-sign APKs with the signing key, regenerate each APKINDEX, and uploading both to a bucket given by --destination-bucket.