### PR TITLE
build: Show dep graph in errors

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -681,7 +681,7 @@ func (t *task) start(ctx context.Context) {
 
 	for _, dep := range t.deps {
 		if err := dep.wait(); err != nil {
-			t.err = err
+			t.err = fmt.Errorf("waiting on %s: %w", dep.pkg, err)
 			return
 		}
 	}


### PR DESCRIPTION
This makes it clearer that a build failed because its dependency failed.