### PR TITLE
make go bump cleanup optional

### DIFF
--- a/pkg/update/deps/cleanup.go
+++ b/pkg/update/deps/cleanup.go
@@ -111,7 +111,7 @@ func cleanupGoBumpPipelineDeps(p *config.Pipeline, tempDir string, tidy bool) er
 	// moving things around. Skip doing go/bump clean ups, instead
 	// of erroring out creating an update.
 	if errors.Is(err, fs.ErrNotExist) {
-		log.Printf("Failed to locate go.mod, go/bump cleanups skipped")
+		log.Printf("failed to locate go.mod, go/bump cleanups skipped")
 		return nil
 	}
 	if err != nil {

--- a/pkg/update/deps/cleanup.go
+++ b/pkg/update/deps/cleanup.go
@@ -46,7 +46,7 @@ func gitCheckout(p *config.Pipeline, dir string, mutations map[string]string) er
 		Depth:             1,
 	}
 
-	log.Printf("cloning sources from %s tag %s into a temporary directory '%s', this may take a while", repoValue, dir, evaluatedTag)
+	log.Printf("cloning sources from %s tag %s into a temporary directory '%s', this may take a while", repoValue, evaluatedTag, dir)
 
 	maxRetries := 3
 	r := &git.Repository{}


### PR DESCRIPTION
- **update: skip go/bump tidy without go.mod**
  Sometimes package do odd things (manual git checkouts, git reset,
  moving files about, patching them). When wolfictl update attemps to
  update them, sometimes go/bump cleanups are not possible as go.mod is
  not there after a plain git clone.
  
  Instead of generating package update issue, still open a pull request
  with version update. This issue was causing failure to update
  cilium-1.15 like so:
  
  > error cleaning up go/bump deps: unable to parse the go mod file with error: open /tmp/wolfibump3236022626/envoy/go.mod: no such file or directory
  
  With this change in place a PR is still opened for package version &
  expected-commit update.
  
  See example of old cilium failure to update prior to this change xnox/os#2 and https://github.com/xnox/os/pull/3/commits/ab232054a1b961a776db4b8288af299adc638370 with this change.
  
  In Wolfi itself there have been 21 issues like that
  https://github.com/wolfi-dev/os/issues?q=error+cleaning+up+go%2Fbump+deps
  (opened and closed) delying package upgrades.
  
- **update: fix cloning log message, incorrect order of variables**  