### PR TITLE
bundles: Make traces slightly more organized

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	golang.org/x/text v0.15.0
 	golang.org/x/time v0.5.0
 	golang.org/x/vuln v1.1.0
+	google.golang.org/api v0.181.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1
@@ -310,7 +311,6 @@ require (
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/tools v0.21.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
-	google.golang.org/api v0.181.0 // indirect
 	google.golang.org/genproto v0.0.0-20240521202816-d264139d666e // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240521202816-d264139d666e // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240521202816-d264139d666e // indirect


### PR DESCRIPTION
This disables the otelhttp traces that the GCS client was emitting, which are probably useful but don't seem to respect the parent trace context, so they are just top level noise.

This also adds a "start <pkg>" trace to organize the "waiting for <dep>" traces under a reasonable parent instead of the root.