### PR TITLE
upgrade lipgloss

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
-          version: v1.59.0
+          version: v1.59

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
-          version: v1.58
+          version: v1.59.0

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
 golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;\
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.1 ;\
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0 ;\
 
 .PHONY: fmt
 fmt: ## Format all go files

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/chainguard-dev/yam v0.0.7
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.3
-	github.com/charmbracelet/lipgloss v0.10.1-0.20240413172830-d0be07ea6b9c
+	github.com/charmbracelet/lipgloss v0.11.0
 	github.com/charmbracelet/log v0.4.0
 	github.com/cli/browser v1.3.0
 	github.com/cli/go-gh/v2 v2.9.0
@@ -112,7 +112,6 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/chainguard-dev/go-pkgconfig v0.0.0-20240404163941-6351b37b2a10 // indirect
 	github.com/charmbracelet/x/ansi v0.1.1 // indirect
-	github.com/charmbracelet/x/exp/term v0.0.0-20240522154747-75cd6ffa5c81 // indirect
 	github.com/charmbracelet/x/input v0.1.0 // indirect
 	github.com/charmbracelet/x/term v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.1.0 // indirect
@@ -128,6 +127,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containerd/ttrpc v1.2.4 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
+	github.com/creack/pty v1.1.21 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deitch/magic v0.0.0-20230404182410-1ff89d7342da // indirect

--- a/go.sum
+++ b/go.sum
@@ -326,14 +326,12 @@ github.com/charmbracelet/bubbles v0.18.0 h1:PYv1A036luoBGroX6VWjQIE9Syf2Wby2oOl/
 github.com/charmbracelet/bubbles v0.18.0/go.mod h1:08qhZhtIwzgrtBjAcJnij1t1H0ZRjwHyGsy6AL11PSw=
 github.com/charmbracelet/bubbletea v0.26.3 h1:iXyGvI+FfOWqkB2V07m1DF3xxQijxjY2j8PqiXYqasg=
 github.com/charmbracelet/bubbletea v0.26.3/go.mod h1:bpZHfDHTYJC5g+FBK+ptJRCQotRC+Dhh3AoMxa/2+3Q=
-github.com/charmbracelet/lipgloss v0.10.1-0.20240413172830-d0be07ea6b9c h1:0FwZb0wTiyalb8QQlILWyIuh3nF5wok6j9D9oUQwfQY=
-github.com/charmbracelet/lipgloss v0.10.1-0.20240413172830-d0be07ea6b9c/go.mod h1:EPP2QJ0ectp3zo6gx9f8oJGq8keirqPJ3XpYEI8wrrs=
+github.com/charmbracelet/lipgloss v0.11.0 h1:UoAcbQ6Qml8hDwSWs0Y1cB5TEQuZkDPH/ZqwWWYTG4g=
+github.com/charmbracelet/lipgloss v0.11.0/go.mod h1:1UdRTH9gYgpcdNN5oBtjbu/IzNKtzVtb7sqN1t9LNn8=
 github.com/charmbracelet/log v0.4.0 h1:G9bQAcx8rWA2T3pWvx7YtPTPwgqpk7D68BX21IRW8ZM=
 github.com/charmbracelet/log v0.4.0/go.mod h1:63bXt/djrizTec0l11H20t8FDSvA4CRZJ1KH22MdptM=
 github.com/charmbracelet/x/ansi v0.1.1 h1:CGAduulr6egay/YVbGc8Hsu8deMg1xZ/bkaXTPi1JDk=
 github.com/charmbracelet/x/ansi v0.1.1/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
-github.com/charmbracelet/x/exp/term v0.0.0-20240522154747-75cd6ffa5c81 h1:NSoVu7Vso7dDHltLoVe2s9yL4rC5EJ2LLCf2sMqL4rk=
-github.com/charmbracelet/x/exp/term v0.0.0-20240522154747-75cd6ffa5c81/go.mod h1:YBotIGhfoWhHDlnUpJMkjebGV2pdGRCn1Y4/Nk/vVcU=
 github.com/charmbracelet/x/input v0.1.0 h1:TEsGSfZYQyOtp+STIjyBq6tpRaorH0qpwZUj8DavAhQ=
 github.com/charmbracelet/x/input v0.1.0/go.mod h1:ZZwaBxPF7IG8gWWzPUVqHEtWhc1+HXJPNuerJGRGZ28=
 github.com/charmbracelet/x/term v0.1.1 h1:3cosVAiPOig+EV4X9U+3LDgtwwAoEzJjNdwbXDjF6yI=

--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -534,7 +534,7 @@ var (
 		return fmt.Sprintf(
 			notADistroDirectoryMessageFormat,
 			styles.Bold().Render(cwd),
-			styles.Bold().Copy().Italic(true).Render("is"),
+			styles.Bold().Italic(true).Render("is"),
 		)
 	}
 

--- a/pkg/cli/components/accept/accept.go
+++ b/pkg/cli/components/accept/accept.go
@@ -42,6 +42,6 @@ var (
 )
 
 var (
-	styleHelpKey         = styles.FaintAccent().Copy().Bold(true)
-	styleHelpExplanation = styles.Faint().Copy()
+	styleHelpKey         = styles.FaintAccent().Bold(true)
+	styleHelpExplanation = styles.Faint()
 )

--- a/pkg/cli/components/advisory/field/text_field.go
+++ b/pkg/cli/components/advisory/field/text_field.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	selectedSuggestionStyle = styles.Accented().Copy().Underline(true)
-	helpKeyStyle            = styles.FaintAccent().Copy().Bold(true)
-	helpExplanationStyle    = styles.Faint().Copy()
+	selectedSuggestionStyle = styles.Accented().Underline(true)
+	helpKeyStyle            = styles.FaintAccent().Bold(true)
+	helpExplanationStyle    = styles.Faint()
 )
 
 const maxSuggestionsDisplayed = 4

--- a/pkg/cli/components/advisory/matchwatcher/model.go
+++ b/pkg/cli/components/advisory/matchwatcher/model.go
@@ -15,8 +15,8 @@ import (
 var _ tea.Model = (*Model)(nil)
 
 var (
-	helpKeyStyle         = styles.FaintAccent().Copy().Bold(true)
-	helpExplanationStyle = styles.Faint().Copy()
+	helpKeyStyle         = styles.FaintAccent().Bold(true)
+	helpExplanationStyle = styles.Faint()
 
 	styleSubtle = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
 

--- a/pkg/cli/components/picker/picker.go
+++ b/pkg/cli/components/picker/picker.go
@@ -209,6 +209,6 @@ var (
 )
 
 var (
-	styleHelpKey         = styles.FaintAccent().Copy().Bold(true)
-	styleHelpExplanation = styles.Faint().Copy()
+	styleHelpKey         = styles.FaintAccent().Bold(true)
+	styleHelpExplanation = styles.Faint()
 )


### PR DESCRIPTION
NB! As interactive styling is affected, somebody who uses those interactive modes should check that all styles/colors/bold are the still correct with these changes.


- **build(deps): bump github.com/charmbracelet/lipgloss**
  Bumps [github.com/charmbracelet/lipgloss](https://github.com/charmbracelet/lipgloss) from 0.10.1-0.20240413172830-d0be07ea6b9c to 0.11.0.
  - [Release notes](https://github.com/charmbracelet/lipgloss/releases)
  - [Commits](https://github.com/charmbracelet/lipgloss/commits/v0.11.0)
  
  ---
  updated-dependencies:
  - dependency-name: github.com/charmbracelet/lipgloss
    dependency-type: direct:production
    update-type: version-update:semver-minor
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>

- **Upgrade golangci-lint to latest**
  Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
  

- **Fix deprecated .Copy() usage of lipgloss styles**
  Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
  