### PR TITLE
apk cp: support HTTP_AUTH, index from stdin, index from file

### DIFF
--- a/pkg/cli/apk.go
+++ b/pkg/cli/apk.go
@@ -64,7 +64,7 @@ func cmdCp() *cobra.Command {
 					return fmt.Errorf("GET %q: %w", u.Redacted(), err)
 				}
 				if resp.StatusCode >= 400 {
-					return fmt.Errorf("GET %q: status %d", u.Redacted(), resp.StatusCode, resp.Status)
+					return fmt.Errorf("GET %q: status %d: %s", u.Redacted(), resp.StatusCode, resp.Status)
 				}
 				in = resp.Body
 

--- a/pkg/cli/apk.go
+++ b/pkg/cli/apk.go
@@ -24,7 +24,7 @@ func cmdApk() *cobra.Command {
 	return cmd
 }
 
-func cmdCp() *cobra.Command {
+func cmdCp() *cobra.Command { //nolint:gocyclo
 	var latest bool
 	var indexURL, outDir, gcsPath string
 	cmd := &cobra.Command{
@@ -38,10 +38,11 @@ func cmdCp() *cobra.Command {
 
 			var in io.ReadCloser
 			var arch string
-			if indexURL == "-" {
+			switch {
+			case indexURL == "-":
 				in = os.Stdin
 				arch = "x86_64" // TODO: This is hardcoded.
-			} else if strings.HasPrefix(indexURL, "file://") {
+			case strings.HasPrefix(indexURL, "file://"):
 				f, err := os.Open(strings.TrimPrefix(indexURL, "file://"))
 				if err != nil {
 					return fmt.Errorf("opening %q: %w", indexURL, err)
@@ -49,7 +50,7 @@ func cmdCp() *cobra.Command {
 				in = f
 
 				arch = repoURL[strings.LastIndex(repoURL, "/")+1:]
-			} else {
+			default:
 				u, err := url.Parse(indexURL)
 				if err != nil {
 					return fmt.Errorf("parsing %q: %w", indexURL, err)
@@ -59,7 +60,7 @@ func cmdCp() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("GET %q: %w", u.Redacted(), err)
 				}
-				resp, err := http.DefaultClient.Do(req)
+				resp, err := http.DefaultClient.Do(req) //nolint:bodyclose
 				if err != nil {
 					return fmt.Errorf("GET %q: %w", u.Redacted(), err)
 				}

--- a/pkg/cli/apk.go
+++ b/pkg/cli/apk.go
@@ -1,12 +1,12 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,30 +24,6 @@ func cmdApk() *cobra.Command {
 	return cmd
 }
 
-func fetchIndexURL(ctx context.Context, u string) (io.ReadCloser, error) {
-	if u == "-" {
-		return os.Stdin, nil
-	}
-
-	scheme, _, ok := strings.Cut(u, "://")
-	if !ok || !strings.HasPrefix(scheme, "http") {
-		return os.Open(u)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("GET %q: %w", u, err)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("GET %q: status %d", u, resp.StatusCode)
-	}
-	return resp.Body, nil
-}
-
 func cmdCp() *cobra.Command {
 	var latest bool
 	var indexURL, outDir, gcsPath string
@@ -59,14 +35,43 @@ func cmdCp() *cobra.Command {
 			errg, ctx := errgroup.WithContext(cmd.Context())
 
 			repoURL := strings.TrimSuffix(indexURL, "/APKINDEX.tar.gz")
-			arch := repoURL[strings.LastIndex(repoURL, "/")+1:]
 
-			in, err := fetchIndexURL(ctx, indexURL)
-			if err != nil {
-				return fmt.Errorf("fetching %q: %w", indexURL, err)
+			var in io.ReadCloser
+			var arch string
+			if indexURL == "-" {
+				in = os.Stdin
+				arch = "x86_64" // TODO: This is hardcoded.
+			} else if strings.HasPrefix(indexURL, "file://") {
+				f, err := os.Open(strings.TrimPrefix(indexURL, "file://"))
+				if err != nil {
+					return fmt.Errorf("opening %q: %w", indexURL, err)
+				}
+				in = f
+
+				arch = repoURL[strings.LastIndex(repoURL, "/")+1:]
+			} else {
+				u, err := url.Parse(indexURL)
+				if err != nil {
+					return fmt.Errorf("parsing %q: %w", indexURL, err)
+				}
+				addAuth(u)
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+				if err != nil {
+					return fmt.Errorf("GET %q: %w", u.Redacted(), err)
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					return fmt.Errorf("GET %q: %w", u.Redacted(), err)
+				}
+				if resp.StatusCode >= 400 {
+					return fmt.Errorf("GET %q: status %d", u.Redacted(), resp.StatusCode, resp.Status)
+				}
+				in = resp.Body
+
+				arch = repoURL[strings.LastIndex(repoURL, "/")+1:]
 			}
 			defer in.Close()
-			index, err := apk.IndexFromArchive(io.NopCloser(in))
+			index, err := apk.IndexFromArchive(in)
 			if err != nil {
 				return fmt.Errorf("parsing %q: %w", indexURL, err)
 			}
@@ -104,9 +109,13 @@ func cmdCp() *cobra.Command {
 
 					var rc io.ReadCloser
 					if gcsPath == "" {
-						url := fmt.Sprintf("%s/%s", repoURL, pkg.Filename())
-						log.Println("downloading", url)
-						req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+						u, err := url.Parse(fmt.Sprintf("%s/%s", repoURL, pkg.Filename()))
+						if err != nil {
+							return err
+						}
+						addAuth(u)
+						log.Println("downloading", u.Redacted())
+						req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 						if err != nil {
 							return err
 						}
@@ -209,6 +218,16 @@ func cmdCp() *cobra.Command {
 	cmd.Flags().BoolVar(&latest, "latest", true, "copy only the latest version of each package")
 	cmd.Flags().StringVar(&gcsPath, "gcs", "", "copy objects from a GCS bucket")
 	return cmd
+}
+
+func addAuth(u *url.URL) {
+	env := os.Getenv("HTTP_AUTH")
+	parts := strings.Split(env, ":")
+	if len(parts) != 4 || parts[0] != "basic" {
+		return
+	}
+	// parts[1] is the realm, ignore it.
+	u.User = url.UserPassword(parts[2], parts[3])
 }
 
 func onlyLatest(packages []*apk.Package) []*apk.Package {


### PR DESCRIPTION
These now work:

Index from file:

```
$ go run ./ apk cp go-1.22 -i=file://./packages/x86_64/APKINDEX.tar.gz  
2024/05/29 20:30:34 INFO downloading 1 packages for x86_64
2024/05/29 20:30:34 INFO skipping packages/x86_64/go-1.22-1.22.3-r0.apk: already exists
2024/05/29 20:30:38 INFO writing index: packages/x86_64/APKINDEX.tar.gz (3 total packages)
```

Index from stdin:

```
$ cat ./packages/x86_64/APKINDEX.tar.gz| go run ./ apk cp go-1.22 -i=-
2024/05/29 20:29:42 INFO downloading 1 packages for x86_64
2024/05/29 20:29:42 INFO skipping packages/x86_64/go-1.22-1.22.3-r0.apk: already exists
2024/05/29 20:29:46 INFO writing index: packages/x86_64/APKINDEX.tar.gz (3 total packages)
```

Index from HTTP with `apk`-compatible auth:

```
$ HTTP_AUTH=basic::user:pass go run ./ apk cp go-1.22
Error: GET "https://user:xxxxx@packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz": status 401: 401 Unauthorized
2024/05/29 20:31:55 ERRO GET "https://user:xxxxx@packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz": status 401: 401 Unauthorized
exit status 1
```

(Wolfi doesn't support auth atm)