### PR TITLE
bundles: Embed build date epoch in bundles

### DIFF
--- a/pkg/internal/bundle/bundle.go
+++ b/pkg/internal/bundle/bundle.go
@@ -428,6 +428,10 @@ func Podspec(task Task, ref name.Reference, arch, mFamily, sa, ns string) (*core
 			Containers: []corev1.Container{{
 				Name:  "workspace",
 				Image: ref.String(),
+				Env: []corev1.EnvVar{{
+					Name:  "SOURCE_DATE_EPOCH",
+					Value: strconv.FormatInt(task.BuildDateEpoch.Unix(), 10),
+				}},
 				// TODO: Do we need this??
 				// ldconfig is run to prime ld.so.cache for glibc packages which require it.
 				// Command:      []string{"/bin/sh", "-c", "[ -x /sbin/ldconfig ] && /sbin/ldconfig /lib || true\nsleep infinity"},


### PR DESCRIPTION
Originally attempted to do this by just shelling out to git for each file individually. For a small number of recently modified files, this isn't too bad, but for build-the-world builds, this ends up taking a very long time because we have to traverse the commit graph for each melange config, which is 2400 times, and that can take ~1s per file.

Instead, we traverse the commit graph once by shelling out to git and just parsing the output for every changed file per non-merge commit.

This takes about 2s on my machine, whereas doing it once per file took about 20 minutes.