### PR TITLE
add minimum severity to linter

### DIFF
--- a/pkg/cli/lint.go
+++ b/pkg/cli/lint.go
@@ -12,6 +12,7 @@ type lintOptions struct {
 	args      []string
 	list      bool
 	skipRules []string
+	severity  string
 }
 
 func cmdLint() *cobra.Command {
@@ -31,6 +32,7 @@ func cmdLint() *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&o.list, "list", "l", false, "prints the all of available rules and exits")
 	cmd.Flags().StringArrayVarP(&o.skipRules, "skip-rule", "", []string{}, "list of rules to skip")
+	cmd.Flags().StringVarP(&o.severity, "severity", "s", "warning", "minimum severity level to report (error, warning, info)")
 
 	cmd.AddCommand(cmdLintYam())
 
@@ -47,7 +49,14 @@ func (o lintOptions) LintCmd(ctx context.Context) error {
 	}
 
 	// Run the linter.
-	result, err := linter.Lint(ctx)
+	minSeverity := lint.SeverityWarning
+	switch {
+	case o.severity == "error", o.severity == "ERROR":
+		minSeverity = lint.SeverityError
+	case o.severity == "info", o.severity == "INFO":
+		minSeverity = lint.SeverityInfo
+	}
+	result, err := linter.Lint(ctx, minSeverity)
 	if err != nil {
 		return err
 	}

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -92,7 +92,7 @@ func TestLinter_Dir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			l := newTestLinterWithDir(tt.path)
-			got, err := l.Lint(ctx)
+			got, err := l.Lint(ctx, SeverityWarning)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Lint() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -337,7 +337,7 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				re := regexp.MustCompile(`# CHECK-WHEN-VERSION-CHANGES: (.+)`)
-				var checkString = func(s string) error {
+				checkString := func(s string) error {
 					match := re.FindStringSubmatch(s)
 					if len(match) == 0 {
 						return nil
@@ -408,6 +408,25 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 					}
 				}
 				return nil
+			},
+		},
+		{
+			Name:        "valid-package-or-subpackage-test",
+			Description: "every package should have a valid main or subpackage test",
+			Severity:    SeverityInfo,
+			LintFunc: func(c config.Configuration) error {
+				if len(c.Test.Pipeline) > 0 {
+					// Main package has at least one test
+					return nil
+				}
+
+				for _, sp := range c.Subpackages {
+					if len(sp.Test.Pipeline) > 0 {
+						// A subpackage has at least one test
+						return nil
+					}
+				}
+				return fmt.Errorf("no main package or subpackage test found")
 			},
 		},
 	}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -12,13 +12,16 @@ import (
 
 func TestLinter_Rules(t *testing.T) {
 	tests := []struct {
-		name    string
-		file    string
-		want    EvalResult
-		wantErr bool
+		name        string
+		file        string
+		minSeverity Severity
+		matches     int
+		want        EvalResult
+		wantErr     bool
 	}{
 		{
-			file: "missing-copyright.yaml",
+			file:        "missing-copyright.yaml",
+			minSeverity: SeverityInfo,
 			want: EvalResult{
 				File: "missing-copyright",
 				Errors: EvalRuleErrors{
@@ -32,9 +35,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "forbidden-repository.yaml",
+			file:        "forbidden-repository.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "forbidden-repository",
 				Errors: EvalRuleErrors{
@@ -48,9 +53,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "forbidden-repository-tagged.yaml",
+			file:        "forbidden-repository-tagged.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "forbidden-repository-tagged",
 				Errors: EvalRuleErrors{
@@ -64,9 +71,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "forbidden-keyring.yaml",
+			file:        "forbidden-keyring.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "forbidden-keyring",
 				Errors: EvalRuleErrors{
@@ -80,9 +89,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "wrong-pipeline-fetch-uri.yaml",
+			file:        "wrong-pipeline-fetch-uri.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "wrong-pipeline-fetch-uri",
 				Errors: EvalRuleErrors{
@@ -96,9 +107,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "idn-homograph-attack.yaml",
+			file:        "idn-homograph-attack.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "idn-homograph-attack",
 				Errors: EvalRuleErrors{
@@ -112,9 +125,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "wrong-pipeline-fetch-digest.yaml",
+			file:        "wrong-pipeline-fetch-digest.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "wrong-pipeline-fetch-digest",
 				Errors: EvalRuleErrors{
@@ -128,9 +143,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "duplicated-package.yaml",
+			file:        "duplicated-package.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "duplicated-package",
 				Errors: EvalRuleErrors{
@@ -144,9 +161,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "bad-template-var.yaml",
+			file:        "bad-template-var.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "bad-template-var",
 				Errors: EvalRuleErrors{
@@ -160,9 +179,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "bad-version.yaml",
+			file:        "bad-version.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "bad-version",
 				Errors: EvalRuleErrors{
@@ -175,9 +196,11 @@ func TestLinter_Rules(t *testing.T) {
 					},
 				},
 			},
+			matches: 1,
 		},
 		{
-			file: "wrong-pipeline-git-checkout-commit.yaml",
+			file:        "wrong-pipeline-git-checkout-commit.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "wrong-pipeline-git-checkout-commit",
 				Errors: EvalRuleErrors{
@@ -191,9 +214,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "missing-pipeline-git-checkout-commit.yaml",
+			file:        "missing-pipeline-git-checkout-commit.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "missing-pipeline-git-checkout-commit",
 				Errors: EvalRuleErrors{
@@ -207,9 +232,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "wrong-pipeline-git-checkout-tag.yaml",
+			file:        "wrong-pipeline-git-checkout-tag.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "wrong-pipeline-git-checkout-tag",
 				Errors: EvalRuleErrors{
@@ -223,9 +250,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "nolint.yaml",
+			file:        "nolint.yaml",
+			minSeverity: SeverityInfo,
 			want: EvalResult{
 				File: "nolint",
 				Errors: EvalRuleErrors{
@@ -239,9 +268,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "no-epoch.yaml",
+			file:        "no-epoch.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "no-epoch",
 				Errors: EvalRuleErrors{
@@ -255,9 +286,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "check-version-matches.yaml",
+			file:        "check-version-matches.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "check-version-matches",
 				Errors: EvalRuleErrors{
@@ -271,9 +304,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "check-subpipeline-version-matches.yaml",
+			file:        "check-subpipeline-version-matches.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "check-version-matches",
 				Errors: EvalRuleErrors{
@@ -287,9 +322,11 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
 		},
 		{
-			file: "missing-github-update-git-checkout.yaml",
+			file:        "missing-github-update-git-checkout.yaml",
+			minSeverity: SeverityWarning,
 			want: EvalResult{
 				File: "missing-github-update-git-checkout",
 				Errors: EvalRuleErrors{
@@ -303,6 +340,62 @@ func TestLinter_Rules(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			matches: 1,
+		},
+		{
+			file:        "no-main-test.yaml",
+			minSeverity: SeverityInfo,
+			want: EvalResult{
+				File: "no-main-test",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "valid-package-or-subpackage-test",
+							Severity: SeverityInfo,
+						},
+						Error: fmt.Errorf("[valid-package-or-subpackage-test]: no main package or subpackage test found (INFO)"),
+					},
+				},
+			},
+			wantErr: false,
+			matches: 1,
+		},
+		{
+			// Validate rule is not triggered when min severity < rule severity
+			file:        "no-main-test.yaml",
+			minSeverity: SeverityWarning,
+			want: EvalResult{
+				File: "no-main-test",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "valid-package-or-subpackage-test",
+							Severity: SeverityInfo,
+						},
+						Error: fmt.Errorf("[valid-package-or-subpackage-test]: no main package or subpackage test found (INFO)"),
+					},
+				},
+			},
+			wantErr: false,
+			matches: 0,
+		},
+		{
+			file:        "has-subpackage-test.yaml",
+			minSeverity: SeverityInfo,
+			want: EvalResult{
+				File: "has-subpackage-test",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "valid-package-or-subpackage-test",
+							Severity: SeverityInfo,
+						},
+						Error: fmt.Errorf("[valid-package-or-subpackage-test]: no main package or subpackage test found (INFO)"),
+					},
+				},
+			},
+			wantErr: false,
+			matches: 0,
 		},
 	}
 
@@ -310,14 +403,18 @@ func TestLinter_Rules(t *testing.T) {
 		t.Run(tt.file, func(t *testing.T) {
 			ctx := context.Background()
 			l := newTestLinterWithFile(tt.file)
-			got, err := l.Lint(ctx)
+			got, err := l.Lint(ctx, tt.minSeverity)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Lint() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			// Always should be a single element array.
-			require.Len(t, got, 1)
+			require.Len(t, got, tt.matches)
+
+			if tt.matches == 0 {
+				return
+			}
 
 			g := got[0]
 

--- a/pkg/lint/testdata/files/has-subpackage-test.yaml
+++ b/pkg/lint/testdata/files/has-subpackage-test.yaml
@@ -1,0 +1,23 @@
+package:
+  name: has-subpackage-test
+  version: 1.0.0
+  epoch: 0
+  description: "a package with a subpackage test"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/missing-copyright/${{package.version}}.tar.gz
+      expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+
+subpackages:
+  - name: subpackage
+    description: "a package with an out of date comment"
+    test:
+      pipeline:
+        - runs: "echo 'test'"

--- a/pkg/lint/testdata/files/no-main-test.yaml
+++ b/pkg/lint/testdata/files/no-main-test.yaml
@@ -1,15 +1,16 @@
 package:
-  name: missing-copyright
+  name: no-main-test
   version: 1.0.0
   epoch: 0
-  description: "a package with no copyright"
+  description: "a package with no main test"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
 
 pipeline:
   - uses: fetch
     with:
       uri: https://test.com/missing-copyright/${{package.version}}.tar.gz
       expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
-
-test:
-  pipeline:
-    - runs: "echo 'test'"

--- a/pkg/lint/testdata/files/nolint.yaml
+++ b/pkg/lint/testdata/files/nolint.yaml
@@ -11,3 +11,7 @@ environment:
       - foo
       - bar
       - foo
+
+test:
+  pipeline:
+    - runs: "echo 'test'"

--- a/pkg/lint/types.go
+++ b/pkg/lint/types.go
@@ -12,13 +12,22 @@ type Function func(config.Configuration) error
 // ConditionFunc is a function that checks if a rule should be executed.
 type ConditionFunc func() bool
 
-// Severity is the severity of a rule.
-type Severity string
+// Severity is the severity level of a rule.
+type Severity struct {
+	Name  string
+	Value int
+}
 
 const (
-	SeverityError   Severity = "ERROR"
-	SeverityWarning Severity = "WARNING"
-	SeverityInfo    Severity = "INFO"
+	SeverityErrorLevel = iota
+	SeverityWarningLevel
+	SeverityInfoLevel
+)
+
+var (
+	SeverityError   = Severity{"ERROR", SeverityErrorLevel}
+	SeverityWarning = Severity{"WARNING", SeverityWarningLevel}
+	SeverityInfo    = Severity{"INFO", SeverityInfoLevel}
 )
 
 // Rule represents a linter rule.


### PR DESCRIPTION
adds a `minimum-severity` to the existing linter.

The new behavior allows for configuring the minimum severity tolerance that will flag an error (non-zero exit code) on a lint.

The default setting is to flag on `warning` and `error`, ignoring (but still logging) `info` severities.

To accommodate the new default behavior, the existing `INFO` rules are changed to `WARN`. The only one of these that's modified is the copyright header rule.

Finally, this adds a new `INFO` rule that enforces tests exist. The idea here is to make this a non-blocking lint rule.