### PR TITLE
Parse configs in parallel in NewPackages

### DIFF
--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -39,7 +39,7 @@ func cmdText() *cobra.Command {
 				return err
 			}
 
-			return text(*g, pkgs, arch, textType(t), os.Stdout)
+			return text(g, pkgs, arch, textType(t), os.Stdout)
 		},
 	}
 	text.Flags().StringVarP(&dir, "dir", "d", ".", "directory to search for melange configs")
@@ -69,7 +69,7 @@ var textTypes = []textType{
 	typePackageNameAndVersion,
 }
 
-func text(g dag.Graph, pkgs *dag.Packages, arch string, t textType, w io.Writer) error {
+func text(g *dag.Graph, pkgs *dag.Packages, arch string, t textType, w io.Writer) error {
 	filtered, err := g.Filter(dag.FilterLocal())
 	if err != nil {
 		return err


### PR DESCRIPTION
This shaves off about a second for a lot of wolfictl commands when run against wolfi with a reasonably sized machine.

There's more we can do but this is an easy win.

Before:
```
make list-yaml  5.01s user 0.43s system 98% cpu 5.545 total
```

After:
```
make list-yaml  5.41s user 0.73s system 145% cpu 4.230 total
```