### PR TITLE
Fix Diff test and bincapz usage

### DIFF
--- a/pkg/checks/diff.go
+++ b/pkg/checks/diff.go
@@ -108,7 +108,7 @@ func (o *DiffOptions) Diff() error {
 		cmd := exec.Command(path, "-diff", "-format=markdown", "-min-file-level=3", dirExistingApk, dirNewApk)
 		result, err = cmd.CombinedOutput()
 		if err != nil {
-			return err
+			return fmt.Errorf("bincapz execution failed with error %w: %s", err, result)
 		}
 		o.Logger.Printf("finished bincapz")
 	}

--- a/pkg/checks/diff_test.go
+++ b/pkg/checks/diff_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiff(t *testing.T) {
@@ -16,10 +17,10 @@ func TestDiff(t *testing.T) {
 
 	dir := filepath.Join("testdata", "diff")
 	originalData, err := os.ReadFile(filepath.Join(dir, "test_orig.apk"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	apkIndexData, err := os.ReadFile(filepath.Join(dir, "APKINDEX.tgz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// create a test server to download the test apk from
 	const apkindexEndpoint = "/APKINDEX.tar.gz"
@@ -27,13 +28,13 @@ func TestDiff(t *testing.T) {
 		switch req.URL.Path {
 		case apkindexEndpoint:
 			_, err = rw.Write(apkIndexData)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		case "/test-1.2.3-r0.apk":
 			_, err = rw.Write(originalData)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		case "/test_sub-1.2.3-r0.apk":
 			_, err = rw.Write(originalData)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		default:
 			http.Error(rw, "Not found", http.StatusNotFound)
 		}
@@ -48,12 +49,12 @@ func TestDiff(t *testing.T) {
 		Logger:              log.New(log.Writer(), "test: ", log.LstdFlags|log.Lmsgprefix),
 	}
 	err = diffOpts.Diff()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	diffLogFile := filepath.Join(resultDir, "diff.log")
 
 	actual, err := os.ReadFile(diffLogFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedPackage := `
 Package test:


### PR DESCRIPTION
This test was failing locally and it turns out we were doing some things to make it pretty hard to diagnose:

1. We need to use `require.NoError` instead of `assert.NoError` if any subsequent test steps depend on there not being an error. Otherwise the "real" error gets overwritten with less helpful errors.
2. We had a bare `err` returned after executing `bincapz`, so the failure reason was being swallowed. In this case a new `-min-file-level` flag had been added that wasn't available in the binary in the local environment.

A good follow-up task would be to provide tests that account for the changes in #725, and ideally make the interaction with `bincapz` less side-effectful.