### PR TITLE
test: move Cleanup tests to integration tier

### DIFF
--- a/pkg/update/deps/cleanup_test.go
+++ b/pkg/update/deps/cleanup_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package deps
 
 import (


### PR DESCRIPTION
We've started segmenting our Go tests into 2 tiers: `unit` and `integration`. This helps us maintain a fast feedback loop for the majority of tests, while ensuring we still have the longer-running tests passing before PRs are merged.

This PR reclassifies the tests in `pkg/update/deps/cleanup_test.go` as "integration" since they do extensive I/O and take a long time to run.

**Before:**

This file's tests alone took up ~70% of the entire unit test suite's run length.

```
--- PASS: TestCleanupDeps (22.07s)
```

**After:**

The **_entire_** unit test suite (see `make unit`) runs in just **~6 seconds**, and closer to ~1 second when using Go's test cache.

cc: @jonjohnsonjr 