### PR TITLE
Disable AllowMainModulePseudoVersionComparison by default

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -262,7 +262,7 @@ func createMatchers(useCPEs bool) []matcher.Matcher {
 			Golang: golang.MatcherConfig{
 				UseCPEs:                                useCPEs,
 				AlwaysUseCPEForStdlib:                  true,
-				AllowMainModulePseudoVersionComparison: true,
+				AllowMainModulePseudoVersionComparison: false,
 			},
 			Java: java.MatcherConfig{
 				ExternalSearchConfig: java.ExternalSearchConfig{


### PR DESCRIPTION
To match Grype default behaviour, we need to set AllowMainModulePseudoVersionComparison to `false`.