### PR TITLE
Indent JSON for OSV and improve tests

### DIFF
--- a/pkg/advisory/osv.go
+++ b/pkg/advisory/osv.go
@@ -1,19 +1,18 @@
 package advisory
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/google/osv-scanner/pkg/models"
+	"github.com/samber/lo"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 )
@@ -39,7 +38,7 @@ const OSVEcosystem = "Chainguard"
 // BuildOSVDataset produces an OSV dataset from Chainguard advisory data, using
 // the given set of options.
 func BuildOSVDataset(_ context.Context, opts OSVOptions) error {
-	osvExport := make(map[string]models.Vulnerability)
+	advisoryIDsToModels := make(map[string]models.Vulnerability)
 	ecosystem := models.Ecosystem(opts.Ecosystem)
 
 	for _, index := range opts.AdvisoryDocIndices {
@@ -105,7 +104,7 @@ func BuildOSVDataset(_ context.Context, opts OSVOptions) error {
 						continue
 					}
 
-					entry, ok := osvExport[adv.ID]
+					entry, ok := advisoryIDsToModels[adv.ID]
 					if ok {
 						// check if there is a CGA duplicate across different packages
 						for i := range entry.Affected {
@@ -118,7 +117,7 @@ func BuildOSVDataset(_ context.Context, opts OSVOptions) error {
 						if updatedTime.After(entry.Modified) {
 							entry.Modified = updatedTime
 						}
-						osvExport[adv.ID] = entry
+						advisoryIDsToModels[adv.ID] = entry
 					} else {
 						// new entry
 						aliases := []string{adv.ID}
@@ -132,35 +131,29 @@ func BuildOSVDataset(_ context.Context, opts OSVOptions) error {
 							temp.Modified = updatedTime
 						}
 
-						osvExport[adv.ID] = temp
+						advisoryIDsToModels[adv.ID] = temp
 					}
 				}
 			}
 		}
 	}
 
-	keys := make([]string, 0, len(osvExport))
-	for k := range osvExport {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	ids := lo.Keys(advisoryIDsToModels)
+	sort.Strings(ids)
 
-	all := []models.Vulnerability{}
-	for _, k := range keys {
-		// for the all.json we just need the id and modified date
-		temp := models.Vulnerability{
-			ID:       osvExport[k].ID,
-			Modified: osvExport[k].Modified,
-		}
-		all = append(all, temp)
+	// write the all.json ("the index") and individual advisory files
 
-		buf := &bytes.Buffer{}
-		enc := json.NewEncoder(buf)
-		// enc.SetIndent("", "  ")
-		err := enc.Encode(osvExport[k])
-		if err != nil {
-			return fmt.Errorf("encoding OSV advisory %q to JSON: %w", k, err)
+	var indexEntries []models.Vulnerability
+
+	for _, id := range ids {
+		advisoryModel := advisoryIDsToModels[id]
+
+		// for the all.json, we just need the id and modified date
+		indexEntry := models.Vulnerability{
+			ID:       advisoryModel.ID,
+			Modified: advisoryModel.Modified,
 		}
+		indexEntries = append(indexEntries, indexEntry)
 
 		// TODO(luhring): This should probably be moved to a test. But it's also failing
 		//  for a separate reason, which is that we're using the "wolfi" ecosystem, which
@@ -168,32 +161,35 @@ func BuildOSVDataset(_ context.Context, opts OSVOptions) error {
 		//  "chainguard" ecosystem upstream.
 		//
 		// err = schema.Validate(result) if err != nil {
-		// 	log.Fatalf("failed to validate OSV JSON Schema for %s: %v", k, err)
+		// 	log.Fatalf("failed to validate OSV JSON Schema for %s: %v", id, err)
 		// }
 
-		filepath := path.Join(opts.OutputDirectory, fmt.Sprintf("%s.json", k))
-		osvFile, err := os.Create(filepath)
+		advisoryFilepath := filepath.Join(opts.OutputDirectory, fmt.Sprintf("%s.json", id))
+		advisoryFile, err := os.Create(advisoryFilepath)
 		if err != nil {
-			return fmt.Errorf("creating file for OSV advisory %q: %w", k, err)
+			return fmt.Errorf("creating file for OSV advisory %q: %w", id, err)
 		}
 
-		// TODO: remove, this is just to make the test pass by stripping the final \n
-		r := io.LimitReader(buf, int64(buf.Len()-1))
-		_, err = io.Copy(osvFile, r)
+		enc := json.NewEncoder(advisoryFile)
+		enc.SetIndent("", "  ")
+		err = enc.Encode(advisoryModel)
 		if err != nil {
-			return fmt.Errorf("writing OSV advisory %q: %w", k, err)
+			return fmt.Errorf("encoding OSV advisory %q to JSON: %w", id, err)
 		}
 	}
 
-	allData, err := json.Marshal(all)
+	const indexFileName = "all.json"
+	indexFilepath := filepath.Join(opts.OutputDirectory, indexFileName)
+	indexFile, err := os.Create(indexFilepath)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("creating file for OSV index: %w", err)
 	}
 
-	filepath := path.Join(opts.OutputDirectory, "all.json")
-	err = os.WriteFile(filepath, allData, 0o644)
+	enc := json.NewEncoder(indexFile)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(indexEntries)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("encoding OSV index to JSON: %w", err)
 	}
 
 	return nil

--- a/pkg/advisory/testdata/osv/expected/CGA-37qj-pjrf-fmrw.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-37qj-pjrf-fmrw.json
@@ -1,1 +1,30 @@
-{"modified":"2022-09-15T02:40:18Z","id":"CGA-37qj-pjrf-fmrw","aliases":["CGA-37qj-pjrf-fmrw","CVE-2020-8927"],"affected":[{"package":{"ecosystem":"wolfi","name":"brotli","purl":"pkg:apk/wolfi/brotli"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"1.0.9-r0"}]}]}]}
+{
+  "modified": "2022-09-15T02:40:18Z",
+  "id": "CGA-37qj-pjrf-fmrw",
+  "aliases": [
+    "CGA-37qj-pjrf-fmrw",
+    "CVE-2020-8927"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "brotli",
+        "purl": "pkg:apk/wolfi/brotli"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.9-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-4j8r-gcwr-9w6v.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-4j8r-gcwr-9w6v.json
@@ -1,1 +1,30 @@
-{"modified":"2023-05-04T14:34:34Z","id":"CGA-4j8r-gcwr-9w6v","aliases":["CGA-4j8r-gcwr-9w6v","GHSA-232p-vwff-86mp"],"affected":[{"package":{"ecosystem":"wolfi","name":"ko","purl":"pkg:apk/wolfi/ko"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"0.13.0-r3"}]}]}]}
+{
+  "modified": "2023-05-04T14:34:34Z",
+  "id": "CGA-4j8r-gcwr-9w6v",
+  "aliases": [
+    "CGA-4j8r-gcwr-9w6v",
+    "GHSA-232p-vwff-86mp"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "ko",
+        "purl": "pkg:apk/wolfi/ko"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.13.0-r3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-4wr7-3v5h-hr26.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-4wr7-3v5h-hr26.json
@@ -1,1 +1,30 @@
-{"modified":"2023-05-04T14:34:34Z","id":"CGA-4wr7-3v5h-hr26","aliases":["CGA-4wr7-3v5h-hr26","GHSA-2h5h-59f5-c5x9"],"affected":[{"package":{"ecosystem":"wolfi","name":"ko","purl":"pkg:apk/wolfi/ko"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"0.13.0-r3"}]}]}]}
+{
+  "modified": "2023-05-04T14:34:34Z",
+  "id": "CGA-4wr7-3v5h-hr26",
+  "aliases": [
+    "CGA-4wr7-3v5h-hr26",
+    "GHSA-2h5h-59f5-c5x9"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "ko",
+        "purl": "pkg:apk/wolfi/ko"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.13.0-r3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-5f5c-53mg-6p2v.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-5f5c-53mg-6p2v.json
@@ -1,1 +1,30 @@
-{"modified":"2023-05-04T14:34:34Z","id":"CGA-5f5c-53mg-6p2v","aliases":["CGA-5f5c-53mg-6p2v","GHSA-33pg-m6jh-5237"],"affected":[{"package":{"ecosystem":"wolfi","name":"ko","purl":"pkg:apk/wolfi/ko"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"0.13.0-r3"}]}]}]}
+{
+  "modified": "2023-05-04T14:34:34Z",
+  "id": "CGA-5f5c-53mg-6p2v",
+  "aliases": [
+    "CGA-5f5c-53mg-6p2v",
+    "GHSA-33pg-m6jh-5237"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "ko",
+        "purl": "pkg:apk/wolfi/ko"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.13.0-r3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-5g25-7735-97mh.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-5g25-7735-97mh.json
@@ -1,1 +1,30 @@
-{"modified":"2023-03-23T09:31:00Z","id":"CGA-5g25-7735-97mh","aliases":["CGA-5g25-7735-97mh","CVE-2023-0464"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.1.0-r1"}]}]}]}
+{
+  "modified": "2023-03-23T09:31:00Z",
+  "id": "CGA-5g25-7735-97mh",
+  "aliases": [
+    "CGA-5g25-7735-97mh",
+    "CVE-2023-0464"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.1.0-r1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-5x4g-4gp8-3frx.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-5x4g-4gp8-3frx.json
@@ -1,1 +1,30 @@
-{"modified":"2022-11-01T16:49:56Z","id":"CGA-5x4g-4gp8-3frx","aliases":["CGA-5x4g-4gp8-3frx","CVE-2022-3602"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.7-r0"}]}]}]}
+{
+  "modified": "2022-11-01T16:49:56Z",
+  "id": "CGA-5x4g-4gp8-3frx",
+  "aliases": [
+    "CGA-5x4g-4gp8-3frx",
+    "CVE-2022-3602"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.7-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-6mjr-v678-c6gm.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-6mjr-v678-c6gm.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:50:17Z","id":"CGA-6mjr-v678-c6gm","aliases":["CGA-6mjr-v678-c6gm","CVE-2022-4450"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:50:17Z",
+  "id": "CGA-6mjr-v678-c6gm",
+  "aliases": [
+    "CGA-6mjr-v678-c6gm",
+    "CVE-2022-4450"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-7jpc-77v9-8xwj.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-7jpc-77v9-8xwj.json
@@ -1,1 +1,30 @@
-{"modified":"2023-04-20T16:29:24Z","id":"CGA-7jpc-77v9-8xwj","aliases":["CGA-7jpc-77v9-8xwj","CVE-2023-1255"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.1.0-r5"}]}]}]}
+{
+  "modified": "2023-04-20T16:29:24Z",
+  "id": "CGA-7jpc-77v9-8xwj",
+  "aliases": [
+    "CGA-7jpc-77v9-8xwj",
+    "CVE-2023-1255"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.1.0-r5"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-7p3g-p2r2-p42c.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-7p3g-p2r2-p42c.json
@@ -1,1 +1,30 @@
-{"modified":"2022-12-22T17:26:45Z","id":"CGA-7p3g-p2r2-p42c","aliases":["CGA-7p3g-p2r2-p42c","CVE-2022-3996"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.7-r1"}]}]}]}
+{
+  "modified": "2022-12-22T17:26:45Z",
+  "id": "CGA-7p3g-p2r2-p42c",
+  "aliases": [
+    "CGA-7p3g-p2r2-p42c",
+    "CVE-2022-3996"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.7-r1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-7w75-jqq5-8pj3.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-7w75-jqq5-8pj3.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:50:00Z","id":"CGA-7w75-jqq5-8pj3","aliases":["CGA-7w75-jqq5-8pj3","CVE-2022-4203"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:50:00Z",
+  "id": "CGA-7w75-jqq5-8pj3",
+  "aliases": [
+    "CGA-7w75-jqq5-8pj3",
+    "CVE-2022-4203"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-c6mv-x33h-2rw7.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-c6mv-x33h-2rw7.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:50:39Z","id":"CGA-c6mv-x33h-2rw7","aliases":["CGA-c6mv-x33h-2rw7","CVE-2023-0217"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:50:39Z",
+  "id": "CGA-c6mv-x33h-2rw7",
+  "aliases": [
+    "CGA-c6mv-x33h-2rw7",
+    "CVE-2023-0217"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-fc7r-gjw8-c4xp.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-fc7r-gjw8-c4xp.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:50:53Z","id":"CGA-fc7r-gjw8-c4xp","aliases":["CGA-fc7r-gjw8-c4xp","CVE-2023-0401"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:50:53Z",
+  "id": "CGA-fc7r-gjw8-c4xp",
+  "aliases": [
+    "CGA-fc7r-gjw8-c4xp",
+    "CVE-2023-0401"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-fpww-5q32-3pf7.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-fpww-5q32-3pf7.json
@@ -1,1 +1,30 @@
-{"modified":"2023-05-04T14:34:34Z","id":"CGA-fpww-5q32-3pf7","aliases":["CGA-fpww-5q32-3pf7","GHSA-hw7c-3rfg-p46j"],"affected":[{"package":{"ecosystem":"wolfi","name":"ko","purl":"pkg:apk/wolfi/ko"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"0.13.0-r3"}]}]}]}
+{
+  "modified": "2023-05-04T14:34:34Z",
+  "id": "CGA-fpww-5q32-3pf7",
+  "aliases": [
+    "CGA-fpww-5q32-3pf7",
+    "GHSA-hw7c-3rfg-p46j"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "ko",
+        "purl": "pkg:apk/wolfi/ko"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.13.0-r3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-fv8r-8vjj-mgx6.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-fv8r-8vjj-mgx6.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:49:30Z","id":"CGA-fv8r-8vjj-mgx6","aliases":["CGA-fv8r-8vjj-mgx6","CVE-2023-0286"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:49:30Z",
+  "id": "CGA-fv8r-8vjj-mgx6",
+  "aliases": [
+    "CGA-fv8r-8vjj-mgx6",
+    "CVE-2023-0286"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-gg4h-ppqq-vf35.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-gg4h-ppqq-vf35.json
@@ -1,1 +1,30 @@
-{"modified":"2023-05-04T14:34:34Z","id":"CGA-gg4h-ppqq-vf35","aliases":["CGA-gg4h-ppqq-vf35","GHSA-6wrf-mxfj-pf5p"],"affected":[{"package":{"ecosystem":"wolfi","name":"ko","purl":"pkg:apk/wolfi/ko"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"0.13.0-r3"}]}]}]}
+{
+  "modified": "2023-05-04T14:34:34Z",
+  "id": "CGA-gg4h-ppqq-vf35",
+  "aliases": [
+    "CGA-gg4h-ppqq-vf35",
+    "GHSA-6wrf-mxfj-pf5p"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "ko",
+        "purl": "pkg:apk/wolfi/ko"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.13.0-r3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-grqc-5h6x-rch8.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-grqc-5h6x-rch8.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:50:29Z","id":"CGA-grqc-5h6x-rch8","aliases":["CGA-grqc-5h6x-rch8","CVE-2023-0216"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:50:29Z",
+  "id": "CGA-grqc-5h6x-rch8",
+  "aliases": [
+    "CGA-grqc-5h6x-rch8",
+    "CVE-2023-0216"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-gwv4-h62f-5frj.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-gwv4-h62f-5frj.json
@@ -1,1 +1,30 @@
-{"modified":"2022-11-01T16:49:56Z","id":"CGA-gwv4-h62f-5frj","aliases":["CGA-gwv4-h62f-5frj","CVE-2022-3358"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.7-r0"}]}]}]}
+{
+  "modified": "2022-11-01T16:49:56Z",
+  "id": "CGA-gwv4-h62f-5frj",
+  "aliases": [
+    "CGA-gwv4-h62f-5frj",
+    "CVE-2022-3358"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.7-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-j59r-vcf2-x9p7.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-j59r-vcf2-x9p7.json
@@ -1,1 +1,30 @@
-{"modified":"2022-11-01T16:49:56Z","id":"CGA-j59r-vcf2-x9p7","aliases":["CGA-j59r-vcf2-x9p7","CVE-2022-3786"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.7-r0"}]}]}]}
+{
+  "modified": "2022-11-01T16:49:56Z",
+  "id": "CGA-j59r-vcf2-x9p7",
+  "aliases": [
+    "CGA-j59r-vcf2-x9p7",
+    "CVE-2022-3786"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.7-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-mm7m-x6cw-5fg4.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-mm7m-x6cw-5fg4.json
@@ -1,1 +1,33 @@
-{"modified":"2023-04-08T16:32:54Z","id":"CGA-mm7m-x6cw-5fg4","aliases":["CGA-mm7m-x6cw-5fg4","CVE-2023-0466"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"0"}],"database_specific":{"false_positive":true}}]}]}
+{
+  "modified": "2023-04-08T16:32:54Z",
+  "id": "CGA-mm7m-x6cw-5fg4",
+  "aliases": [
+    "CGA-mm7m-x6cw-5fg4",
+    "CVE-2023-0466"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0"
+            }
+          ],
+          "database_specific": {
+            "false_positive": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-mpmv-pqf6-j3w9.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-mpmv-pqf6-j3w9.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:50:08Z","id":"CGA-mpmv-pqf6-j3w9","aliases":["CGA-mpmv-pqf6-j3w9","CVE-2023-0215"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:50:08Z",
+  "id": "CGA-mpmv-pqf6-j3w9",
+  "aliases": [
+    "CGA-mpmv-pqf6-j3w9",
+    "CVE-2023-0215"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-mpp5-xvx9-xj5q.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-mpp5-xvx9-xj5q.json
@@ -1,1 +1,30 @@
-{"modified":"2023-02-07T16:49:50Z","id":"CGA-mpp5-xvx9-xj5q","aliases":["CGA-mpp5-xvx9-xj5q","CVE-2022-4304"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.0.8-r0"}]}]}]}
+{
+  "modified": "2023-02-07T16:49:50Z",
+  "id": "CGA-mpp5-xvx9-xj5q",
+  "aliases": [
+    "CGA-mpp5-xvx9-xj5q",
+    "CVE-2022-4304"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.8-r0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/CGA-vj68-6p3f-8xmr.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-vj68-6p3f-8xmr.json
@@ -1,1 +1,30 @@
-{"modified":"2023-03-28T14:54:27Z","id":"CGA-vj68-6p3f-8xmr","aliases":["CGA-vj68-6p3f-8xmr","CVE-2023-0465"],"affected":[{"package":{"ecosystem":"wolfi","name":"openssl","purl":"pkg:apk/wolfi/openssl"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"3.1.0-r2"}]}]}]}
+{
+  "modified": "2023-03-28T14:54:27Z",
+  "id": "CGA-vj68-6p3f-8xmr",
+  "aliases": [
+    "CGA-vj68-6p3f-8xmr",
+    "CVE-2023-0465"
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "wolfi",
+        "name": "openssl",
+        "purl": "pkg:apk/wolfi/openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.1.0-r2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/advisory/testdata/osv/expected/all.json
+++ b/pkg/advisory/testdata/osv/expected/all.json
@@ -1,1 +1,90 @@
-[{"modified":"2022-09-15T02:40:18Z","id":"CGA-37qj-pjrf-fmrw"},{"modified":"2023-05-04T14:34:34Z","id":"CGA-4j8r-gcwr-9w6v"},{"modified":"2023-05-04T14:34:34Z","id":"CGA-4wr7-3v5h-hr26"},{"modified":"2023-05-04T14:34:34Z","id":"CGA-5f5c-53mg-6p2v"},{"modified":"2023-03-23T09:31:00Z","id":"CGA-5g25-7735-97mh"},{"modified":"2022-11-01T16:49:56Z","id":"CGA-5x4g-4gp8-3frx"},{"modified":"2023-02-07T16:50:17Z","id":"CGA-6mjr-v678-c6gm"},{"modified":"2023-04-20T16:29:24Z","id":"CGA-7jpc-77v9-8xwj"},{"modified":"2022-12-22T17:26:45Z","id":"CGA-7p3g-p2r2-p42c"},{"modified":"2023-02-07T16:50:00Z","id":"CGA-7w75-jqq5-8pj3"},{"modified":"2023-02-07T16:50:39Z","id":"CGA-c6mv-x33h-2rw7"},{"modified":"2023-02-07T16:50:53Z","id":"CGA-fc7r-gjw8-c4xp"},{"modified":"2023-05-04T14:34:34Z","id":"CGA-fpww-5q32-3pf7"},{"modified":"2023-02-07T16:49:30Z","id":"CGA-fv8r-8vjj-mgx6"},{"modified":"2023-05-04T14:34:34Z","id":"CGA-gg4h-ppqq-vf35"},{"modified":"2023-02-07T16:50:29Z","id":"CGA-grqc-5h6x-rch8"},{"modified":"2022-11-01T16:49:56Z","id":"CGA-gwv4-h62f-5frj"},{"modified":"2022-11-01T16:49:56Z","id":"CGA-j59r-vcf2-x9p7"},{"modified":"2023-04-08T16:32:54Z","id":"CGA-mm7m-x6cw-5fg4"},{"modified":"2023-02-07T16:50:08Z","id":"CGA-mpmv-pqf6-j3w9"},{"modified":"2023-02-07T16:49:50Z","id":"CGA-mpp5-xvx9-xj5q"},{"modified":"2023-03-28T14:54:27Z","id":"CGA-vj68-6p3f-8xmr"}]
+[
+  {
+    "modified": "2022-09-15T02:40:18Z",
+    "id": "CGA-37qj-pjrf-fmrw"
+  },
+  {
+    "modified": "2023-05-04T14:34:34Z",
+    "id": "CGA-4j8r-gcwr-9w6v"
+  },
+  {
+    "modified": "2023-05-04T14:34:34Z",
+    "id": "CGA-4wr7-3v5h-hr26"
+  },
+  {
+    "modified": "2023-05-04T14:34:34Z",
+    "id": "CGA-5f5c-53mg-6p2v"
+  },
+  {
+    "modified": "2023-03-23T09:31:00Z",
+    "id": "CGA-5g25-7735-97mh"
+  },
+  {
+    "modified": "2022-11-01T16:49:56Z",
+    "id": "CGA-5x4g-4gp8-3frx"
+  },
+  {
+    "modified": "2023-02-07T16:50:17Z",
+    "id": "CGA-6mjr-v678-c6gm"
+  },
+  {
+    "modified": "2023-04-20T16:29:24Z",
+    "id": "CGA-7jpc-77v9-8xwj"
+  },
+  {
+    "modified": "2022-12-22T17:26:45Z",
+    "id": "CGA-7p3g-p2r2-p42c"
+  },
+  {
+    "modified": "2023-02-07T16:50:00Z",
+    "id": "CGA-7w75-jqq5-8pj3"
+  },
+  {
+    "modified": "2023-02-07T16:50:39Z",
+    "id": "CGA-c6mv-x33h-2rw7"
+  },
+  {
+    "modified": "2023-02-07T16:50:53Z",
+    "id": "CGA-fc7r-gjw8-c4xp"
+  },
+  {
+    "modified": "2023-05-04T14:34:34Z",
+    "id": "CGA-fpww-5q32-3pf7"
+  },
+  {
+    "modified": "2023-02-07T16:49:30Z",
+    "id": "CGA-fv8r-8vjj-mgx6"
+  },
+  {
+    "modified": "2023-05-04T14:34:34Z",
+    "id": "CGA-gg4h-ppqq-vf35"
+  },
+  {
+    "modified": "2023-02-07T16:50:29Z",
+    "id": "CGA-grqc-5h6x-rch8"
+  },
+  {
+    "modified": "2022-11-01T16:49:56Z",
+    "id": "CGA-gwv4-h62f-5frj"
+  },
+  {
+    "modified": "2022-11-01T16:49:56Z",
+    "id": "CGA-j59r-vcf2-x9p7"
+  },
+  {
+    "modified": "2023-04-08T16:32:54Z",
+    "id": "CGA-mm7m-x6cw-5fg4"
+  },
+  {
+    "modified": "2023-02-07T16:50:08Z",
+    "id": "CGA-mpmv-pqf6-j3w9"
+  },
+  {
+    "modified": "2023-02-07T16:49:50Z",
+    "id": "CGA-mpp5-xvx9-xj5q"
+  },
+  {
+    "modified": "2023-03-28T14:54:27Z",
+    "id": "CGA-vj68-6p3f-8xmr"
+  }
+]


### PR DESCRIPTION
Most of this PR is just adjusting the OSV JSON files to be multiline and indented. The main motivation for this was making it easier to see diffs in testing, and to make diffs easier to understand when they're introduced by PRs. But I implemented this by just changing how we format our OSV JSON always.

If this seems bad for some reason, please let me know, and we can discuss making the indented-form for testing only and not how we encode actual OSV data. cc: @cpanato 

This adds an `-update` flag to the OSV tests to make it easier to update the golden files when needed.

This also refactors some of the OSV build implementation and its test.