### PR TITLE
elastic build: override toleration rather than append for gvisor

### DIFF
--- a/pkg/private/bundle/bundle.go
+++ b/pkg/private/bundle/bundle.go
@@ -409,13 +409,18 @@ func Podspec(task Task, ref name.Reference, arch, mFamily, sa, ns string, gvisor
 	}
 
 	if gvisor {
-		t = append(t, corev1.Toleration{
+		// Override the default, so we dont consider normal bundle-builder
+		t = []corev1.Toleration{{
 			Effect:   "NoSchedule",
 			Key:      "chainguard.dev/runner",
 			Operator: "Equal",
 			Value:    "gvisor-builder",
-		})
-		nodeSelector["chainguard.dev/sandbox"] = "gvisor"
+		}, {
+			Effect:   "NoSchedule",
+			Key:      "sandbox.gke.io/runtime",
+			Operator: "Equal",
+			Value:    "gvisor",
+		}}
 	}
 
 	mf := mFamily


### PR DESCRIPTION
when we appended toleration previously, we gave it a choice to choose either `bundle-builder` or `gvisor-builder`
if we override, we force it to run on `gvisor-builder`

this remove the need for node selector

examining the taints on the node, there was a gvisor one we needed to add tolerations for

```
Taints:             chainguard.dev/runner=gvisor-builder:NoSchedule
                    sandbox.gke.io/runtime=gvisor:NoSchedule
                    DeletionCandidateOfClusterAutoscaler=1719031907:PreferNoSchedule
```