### PR TITLE
fix(adv/guide): let err bubble to user

### DIFF
--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -258,6 +258,10 @@ func cmdAdvisoryGuide() *cobra.Command {
 
 					vaPicker = vaPickerCtrlC.Unwrap()
 				}
+				if vaPicker.Error != nil {
+					return fmt.Errorf("vulnerability picker error: %w", vaPicker.Error)
+				}
+
 				vaPicked := vaPicker.Picked()
 				if vaPicked == nil {
 					// The user selected a custom action that quit the picker. Nothing was picked.


### PR DESCRIPTION
Previously, impactful problems (e.g. we couldn't push the users changes to GitHub so we just deleted them) were getting swallowed as we unpacked the bubbletea model, so the app exited `0` with no explanation.