### PR TITLE
fix github-actions directory for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,9 @@ version: 2
 updates:
   # workflows
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  # actions
-  - package-ecosystem: "github-actions"
-    directory: "/actions"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
```
Dependabot requires a .yml to evaluate your GitHub Actions dependencies. It had expected to find one at the path: /actions/<anything>.yml.
```