### PR TITLE
export Path method on configs Entry

### DIFF
--- a/pkg/configs/entry.go
+++ b/pkg/configs/entry.go
@@ -19,7 +19,7 @@ type Entry[T Configuration] interface {
 	yamlASTRoot() *yaml.Node
 
 	// Path returns the path of the configuration file that underlies this index entry.
-	getPath() string
+	Path() string
 
 	// Update applies the given entryUpdater to the entry.
 	Update(ctx context.Context, updater EntryUpdater[T]) error
@@ -48,7 +48,7 @@ func (e entry[T]) yamlASTRoot() *yaml.Node {
 	return e.yamlRoot
 }
 
-func (e entry[T]) getPath() string {
+func (e entry[T]) Path() string {
 	return e.path
 }
 

--- a/pkg/configs/index.go
+++ b/pkg/configs/index.go
@@ -203,7 +203,7 @@ func (i *Index[T]) update(ctx context.Context, entry Entry[T], entryUpdater Entr
 	}
 
 	id := entry.id()
-	err = i.processAndUpdate(ctx, entry.getPath(), i.byID[id])
+	err = i.processAndUpdate(ctx, entry.Path(), i.byID[id])
 	if err != nil {
 		return fmt.Errorf("unable to process and update index entry for %q: %w", id, err)
 	}
@@ -299,7 +299,7 @@ func (i *Index[T]) updateAtIndex(e *entry[T], entryIndex int) {
 	i.cfgs[entryIndex] = e.cfg
 	i.byID[e.id()] = entryIndex
 	i.byName[(*e.Configuration()).Name()] = entryIndex
-	i.byPath[e.getPath()] = entryIndex
+	i.byPath[e.Path()] = entryIndex
 }
 
 func (i *Index[T]) entry(idx int) Entry[T] {

--- a/pkg/configs/selection.go
+++ b/pkg/configs/selection.go
@@ -33,7 +33,7 @@ func (s Selection[T]) WhereName(name string) Selection[T] {
 // path match the given parameter.
 func (s Selection[T]) WhereFilePath(p string) Selection[T] {
 	return s.Where(func(e Entry[T]) bool {
-		return p == e.getPath()
+		return p == e.Path()
 	})
 }
 

--- a/pkg/configs/yaml.go
+++ b/pkg/configs/yaml.go
@@ -30,15 +30,15 @@ func NewYAMLUpdateFunc[T Configuration](yamlASTMutater YAMLASTMutater[T]) EntryU
 			return err
 		}
 
-		file, err := i.fsys.OpenAsWritable(e.getPath())
+		file, err := i.fsys.OpenAsWritable(e.Path())
 		if err != nil {
-			return fmt.Errorf("unable to update %q: %w", e.getPath(), err)
+			return fmt.Errorf("unable to update %q: %w", e.Path(), err)
 		}
 		defer file.Close()
 
-		err = i.fsys.Truncate(e.getPath(), 0)
+		err = i.fsys.Truncate(e.Path(), 0)
 		if err != nil {
-			return fmt.Errorf("unable to update %q: %w", e.getPath(), err)
+			return fmt.Errorf("unable to update %q: %w", e.Path(), err)
 		}
 
 		encoder := formatted.NewEncoder(file).AutomaticConfig()


### PR DESCRIPTION
Consumers of a `configs.Entry` need an easy way to access the file path that backs any given configuration document.

This also helps make it easier to implement features like in #1034.

cc: @Dentrax 