### PR TITLE
Use filepath.WalkDir instead of filepath.Walk

### DIFF
--- a/pkg/checks/diff.go
+++ b/pkg/checks/diff.go
@@ -144,7 +144,7 @@ type diffResult struct {
 func diffDirectories(dir1, dir2 string) (diffResult, error) {
 	result := diffResult{}
 
-	err := filepath.Walk(dir1, func(path1 string, info1 os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir1, func(path1 string, info1 os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ func diffDirectories(dir1, dir2 string) (diffResult, error) {
 		return diffResult{}, err
 	}
 
-	err = filepath.Walk(dir2, func(path2 string, info2 os.FileInfo, err error) error {
+	err = filepath.WalkDir(dir2, func(path2 string, info2 os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/checks/so_name.go
+++ b/pkg/checks/so_name.go
@@ -146,7 +146,7 @@ func (o *SoNameOptions) getSonameFiles(dir string) ([]string, error) {
 	reg := regexp.MustCompile(`\.so.(\d+\.)?(\d+\.)?(\*|\d+)`)
 
 	var fileList []string
-	err := filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/melange/melange.go
+++ b/pkg/melange/melange.go
@@ -94,7 +94,7 @@ func ReadAllPackagesFromRepo(ctx context.Context, dir string) (map[string]*Packa
 	p := make(map[string]*Packages)
 
 	var fileList []string
-	err := filepath.Walk(dir, func(path string, fi os.FileInfo, _ error) error {
+	err := filepath.WalkDir(dir, func(path string, fi os.DirEntry, _ error) error {
 		if fi == nil {
 			return fmt.Errorf("%s does not exist", dir)
 		}


### PR DESCRIPTION
I noticed that we're using `filepath.Walk` in a few places when running `wolfictl check diff`. This PR swaps to `WalkDir` instead since `WalkDir` is [more efficient](https://cs.opensource.google/go/go/+/refs/tags/go1.22.5:src/path/filepath/path.go;l=553-554) than `Walk`.

`make test` passes with these changes and the hope is that it helps somewhat with long-running diffs for numerous files as seen here with Keycloak: https://github.com/wolfi-dev/os/actions/runs/10009779412/job/27673386164?pr=24126

If there's a reason we need `Walk` that I'm not aware of please feel free to point that out!