### PR TITLE
Option in adv guide to print yaml advisory to console

### DIFF
--- a/pkg/advisory/data_session.go
+++ b/pkg/advisory/data_session.go
@@ -192,6 +192,15 @@ func (ds DataSession) Push(ctx context.Context) error {
 	return nil
 }
 
+// ModifiedPackages returns a map of package name o=to document for all modified packages
+func (ds DataSession) ModifiedPackages() map[string]configs.Entry[v2.Document] {
+	modified := map[string]configs.Entry[v2.Document]{}
+	for _, n := range slices.Compact(ds.modifiedPackages) {
+		modified[n] = ds.index.Select().WhereName(n).Entries()[0]
+	}
+	return modified
+}
+
 // OpenPullRequest opens a pull request for the changes made during the session.
 func (ds DataSession) OpenPullRequest(ctx context.Context) (*PullRequest, error) {
 	slices.Sort(ds.modifiedPackages)

--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -36,9 +36,9 @@ func (req Request) Validate() error {
 		return err
 	}
 
-	if req.VulnerabilityID != "" {
-		return errors.New("vulnerability should be empty")
-	}
+	// if req.VulnerabilityID != "" {
+	// 	 return errors.New("vulnerability should be empty")
+	// }
 
 	if req.Event.IsZero() {
 		return errors.New("event cannot be zero")


### PR DESCRIPTION
It seems that the "submit PR" function requires a GITHUB_TOKEN (correct?) so this PR allows the user to simply print the changed YAMLs to the console to submit to advisory repo themselves.