### PR TITLE
feat(sbom): detect angularjs from minified files

### DIFF
--- a/pkg/sbom/catalogers/angularjs.go
+++ b/pkg/sbom/catalogers/angularjs.go
@@ -1,0 +1,95 @@
+package catalogers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/cpe"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+const JSFilePkg = "js-file"
+
+var (
+	angularCopyrightNotice = regexp.MustCompile(`/\*
+ AngularJS (v\d+(\.\d+)*)
+ \(c\) .*
+ License: MIT
+\*/`)
+)
+
+// AngularJS is a cataloger for AngularJS (https://angularjs.org/) and its
+// related packages found in standalone minified JS files.
+type AngularJS struct{}
+
+func (a AngularJS) Name() string {
+	return "angularjs-cataloger"
+}
+
+func (a AngularJS) Catalog(_ context.Context, resolver file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
+	locations, err := resolver.FilesByGlob("**/angular*.min.js")
+	if err != nil {
+		return nil, nil, fmt.Errorf("finding minified js files: %w", err)
+	}
+
+	var pkgs []pkg.Package
+	for _, l := range locations {
+		filename := path.Base(l.Path())
+		packageName := strings.TrimSuffix(filename, ".min.js")
+
+		rc, err := resolver.FileContentsByLocation(l)
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting file contents: %w", err)
+		}
+
+		buf, err := io.ReadAll(rc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading file contents: %w", err)
+		}
+		rc.Close()
+
+		matches := angularCopyrightNotice.FindStringSubmatch(string(buf))
+		if len(matches) < 2 {
+			continue
+		}
+
+		version := matches[1]
+
+		trimmedVersion := strings.TrimPrefix(version, "v")
+		cpeValue, err := cpe.New(fmt.Sprintf("cpe:2.3:a:angularjs:%s:%s:*:*:*:*:node.js:*:*", packageName, trimmedVersion), cpe.Source("wolfictl"))
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating CPE: %w", err)
+		}
+
+		p := a.newPackageFromJSFile(packageName, version, "MIT", l, cpeValue)
+		pkgs = append(pkgs, p)
+	}
+
+	return pkgs, nil, nil
+}
+
+var AngularJSReference = pkgcataloging.CatalogerReference{
+	Cataloger:     AngularJS{},
+	AlwaysEnabled: true,
+}
+
+func (a AngularJS) newPackageFromJSFile(name, version, license string, l file.Location, cpeValue cpe.CPE) pkg.Package {
+	return pkg.Package{
+		Name:      name,
+		Version:   version,
+		FoundBy:   a.Name(),
+		Locations: file.NewLocationSet(l),
+		Licenses:  pkg.NewLicenseSet(pkg.NewLicense(license)),
+		Language:  pkg.JavaScript,
+		Type:      JSFilePkg,
+		CPEs:      []cpe.CPE{cpeValue},
+		PURL:      "", // TODO: Figure out a suitable value.
+	}
+}

--- a/pkg/sbom/catalogers/angularjs_test.go
+++ b/pkg/sbom/catalogers/angularjs_test.go
@@ -1,0 +1,74 @@
+package catalogers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anchore/syft/syft/cpe"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAngularJS_Catalog(t *testing.T) {
+	c := AngularJS{}
+
+	resolver := file.NewMockResolverForPaths(
+		"testdata/angular.min.js",
+		"testdata/angular-resource.min.js",
+	)
+
+	packages, relationships, err := c.Catalog(context.Background(), resolver)
+	if err != nil {
+		t.Fatalf("Catalog returned an error: %+v", err)
+	}
+
+	if len(relationships) != 0 {
+		t.Errorf("didn't expect any relationships to be found: %+v", relationships)
+	}
+
+	expectedPackages := []pkg.Package{
+		{
+			Name:      "angular",
+			Version:   "v1.8.0",
+			Type:      JSFilePkg,
+			FoundBy:   "angularjs-cataloger",
+			Locations: file.NewLocationSet(file.NewLocation("testdata/angular.min.js")),
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("MIT")),
+			Language:  pkg.JavaScript,
+			CPEs: []cpe.CPE{{
+				Attributes: cpe.Attributes{
+					Part:     "a",
+					Vendor:   "angularjs",
+					Product:  "angular",
+					Version:  "1.8.0",
+					TargetSW: "node.js",
+				},
+				Source: "wolfictl",
+			}},
+		},
+		{
+			Name:      "angular-resource",
+			Version:   "v1.8.0",
+			FoundBy:   "angularjs-cataloger",
+			Locations: file.NewLocationSet(file.NewLocation("testdata/angular-resource.min.js")),
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("MIT")),
+			Language:  pkg.JavaScript,
+			Type:      JSFilePkg,
+			CPEs: []cpe.CPE{{
+				Attributes: cpe.Attributes{
+					Part:     "a",
+					Vendor:   "angularjs",
+					Product:  "angular-resource",
+					Version:  "1.8.0",
+					TargetSW: "node.js",
+				},
+				Source: "wolfictl",
+			}},
+		},
+	}
+
+	assert.Equalf(t, len(expectedPackages), len(packages), "unexpected number of packages found: %d", len(packages))
+
+	assert.Equal(t, expectedPackages, packages)
+}

--- a/pkg/sbom/catalogers/testdata/angular-resource.min.js
+++ b/pkg/sbom/catalogers/testdata/angular-resource.min.js
@@ -1,0 +1,28 @@
+/*
+The MIT License
+Copyright (c) 2010-2015 Google, Inc. http://angularjs.org
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+/*
+ AngularJS v1.8.0
+ (c) 2010-2020 Google, Inc. http://angularjs.org
+ License: MIT
+*/
+(function (T, a) {
+    'use strict';
+
+    function

--- a/pkg/sbom/catalogers/testdata/angular.min.js
+++ b/pkg/sbom/catalogers/testdata/angular.min.js
@@ -1,0 +1,30 @@
+/*
+The MIT License
+Copyright (c) 2010-2015 Google, Inc. http://angularjs.org
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+/*
+ AngularJS v1.8.0
+ (c) 2010-2020 Google, Inc. http://angularjs.org
+ License: MIT
+*/
+(function (z) {
+    'use strict';
+
+    function ve(a) {
+        if (D(a)) w(a.objectMaxDepth) && (Xb.objectMaxDepth = Yb(a.objectMaxDepth) ? a.objectMaxDepth : NaN), w(a.urlErrorParamsEnabled) && Ga(a.urlErrorParamsEnabled) && (Xb.urlErrorParamsEnabled = a.urlErrorParamsEnabled); else return Xb
+    }

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -25,6 +25,7 @@ import (
 	"github.com/anchore/syft/syft/source/directorysource"
 	"github.com/chainguard-dev/clog"
 	"github.com/package-url/packageurl-go"
+	"github.com/wolfi-dev/wolfictl/pkg/sbom/catalogers"
 	"github.com/wolfi-dev/wolfictl/pkg/tar"
 )
 
@@ -103,6 +104,8 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 		).WithRemovals(
 			"sbom",
 		),
+	).WithCatalogers(
+		catalogers.AngularJSReference,
 	)
 
 	createdSBOM, err := syft.CreateSBOM(ctx, src, cfg)


### PR DESCRIPTION
This PR adds a custom Syft cataloger to wolfictl. The new cataloger is designed to find instances of AngularJS (the deprecated project) in singular JS files, where there's limited "package" metadata available.

This new cataloger helps us find vulnerabilities that we're otherwise not detecting.

Once we're happy with the SCA strategy here, we can consider upstream-ing the cataloger to Syft, too.

Example:

```console
$ wolfictl scan ~/tmp/solr-9.6.1-r0.apk --disable-sbom-cache
🔎 Scanning "/Users/dan/tmp/solr-9.6.1-r0.apk"
└── 📄 /usr/share/java/solr/server/solr-webapp/webapp/libs/angular.min.js
        📦 angular v1.8.0 (js-file)
            Medium CVE-2021-4231
            High CVE-2022-25844
            Medium CVE-2022-25869
            Medium CVE-2023-26116
            Medium CVE-2023-26117
            Medium CVE-2023-26118
            High CVE-2024-21490
            Medium CVE-2023-26117 GHSA-2qqx-w9hr-q5gx
            Medium CVE-2023-26116 GHSA-2vrf-hf26-jrp5
            High CVE-2024-21490 GHSA-4w4v-5hc9-xrr2
            Medium CVE-2022-25844 GHSA-m2h2-264f-f486
            Medium CVE-2022-25869 GHSA-prc3-vjfx-vhm9
            Medium CVE-2023-26118 GHSA-qwqh-hm9m-p5hr
```