### PR TITLE
set active deadline seconds to pod for elastic build pod

### DIFF
--- a/pkg/private/bundle/bundle.go
+++ b/pkg/private/bundle/bundle.go
@@ -481,6 +481,7 @@ func Podspec(task Task, ref name.Reference, arch, mFamily, sa, ns string, anns m
 					},
 				},
 			},
+			ActiveDeadlineSeconds: ptr.Int64(12 * 60 * 60),
 		},
 	}
 


### PR DESCRIPTION
once the deadline is reached, the pod will be marked as fail and container will be killed

this is to avoid stuck pods hanging around