### PR TITLE
build: improve logging

### DIFF
--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -453,7 +453,7 @@ func (t *task) addBundle(ctx context.Context, srcfs fstest.MapFS, built map[stri
 
 		// See if we already have the package indexed.
 		if _, ok := t.cfg.exists[arch][apkFile]; ok {
-			log.Infof("Skipping %s/%s, already indexed", arch, apkFile)
+			log.Debugf("Skipping %s/%s, already indexed", arch, apkFile)
 			continue
 		}
 

--- a/pkg/private/bundle/bundle.go
+++ b/pkg/private/bundle/bundle.go
@@ -84,14 +84,14 @@ melange build $1 \
  --gcplog \
  --source-dir $2 \
 {{ range .Flags }} {{.}} \
-{{ end }}
+{{ end }} || echo "build failed" > /dev/termination-log
 
 melange test $1 \
  --gcplog \
  --source-dir $2 \
  --test-package-append wolfi-base \
 {{ range .TestFlags }} {{.}} \
-{{ end }}
+{{ end }} || echo "test failed" > /dev/termination-log
 
 tar -C packages -czvf packages.tar.gz .
 


### PR DESCRIPTION
- embue logs with `pkg`, `pkgver` and `arch`
- attempt to surface build/test failures using termination logs -- if this is successful we can add more useful context here in the future
- move some spammy things to log.Debugf