### PR TITLE
Add pip vendor cataloger

### DIFF
--- a/pkg/sbom/catalogers/python.go
+++ b/pkg/sbom/catalogers/python.go
@@ -1,0 +1,87 @@
+package catalogers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/chainguard-dev/clog"
+)
+
+const PipVendorPkg = "pip-vendor-file"
+
+// https://pip.pypa.io/en/stable/development/vendoring-policy/
+type PipVendor struct{}
+
+func (a PipVendor) Name() string {
+	return "pip-vendor-cataloger"
+}
+
+func (a PipVendor) Catalog(ctx context.Context, resolver file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
+	log := clog.FromContext(ctx)
+
+	// e.g. usr/lib/python3.12/site-packages/pip/_vendor/vendor.txt
+	locations, err := resolver.FilesByGlob("**/pip/_vendor/vendor.txt")
+	if err != nil {
+		return nil, nil, fmt.Errorf("finding vendored pip files: %w", err)
+	}
+
+	var pkgs []pkg.Package
+	for _, l := range locations {
+		rc, err := resolver.FileContentsByLocation(l)
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting file contents: %w", err)
+		}
+
+		buf, err := io.ReadAll(rc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading file contents: %w", err)
+		}
+		rc.Close()
+
+		pkgVersions, err := parsePipVendorFile(buf)
+		if err != nil {
+			log.Warnf("parsing vendor.txt file %q: %v", l.Path(), err)
+			continue
+		}
+
+		for p, ver := range pkgVersions {
+			pkgs = append(pkgs, pkg.Package{
+				Name:      p,
+				Version:   ver,
+				FoundBy:   a.Name(),
+				Locations: file.NewLocationSet(l),
+				Language:  pkg.Python,
+				Type:      PipVendorPkg,
+			})
+		}
+	}
+
+	return pkgs, nil, nil
+}
+
+func parsePipVendorFile(buf []byte) (map[string]string, error) {
+	packages := make(map[string]string)
+	lines := strings.Split(string(buf), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.Split(line, "==")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid line: %q", line)
+		}
+		packages[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+	return packages, nil
+}
+
+var PipVendorReference = pkgcataloging.CatalogerReference{
+	Cataloger:     PipVendor{},
+	AlwaysEnabled: true,
+}

--- a/pkg/sbom/catalogers/python_test.go
+++ b/pkg/sbom/catalogers/python_test.go
@@ -1,0 +1,73 @@
+package catalogers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func TestPipVendor(t *testing.T) {
+	want := map[string]string{
+		"CacheControl":      "0.14.0",
+		"distlib":           "0.3.8",
+		"distro":            "1.9.0",
+		"msgpack":           "1.0.8",
+		"packaging":         "24.1",
+		"platformdirs":      "4.2.1",
+		"pyproject-hooks":   "1.0.0",
+		"requests":          "2.32.3",
+		"certifi":           "2024.2.2",
+		"idna":              "3.7",
+		"urllib3":           "1.26.18",
+		"rich":              "13.7.1",
+		"pygments":          "2.17.2",
+		"typing_extensions": "4.11.0",
+		"resolvelib":        "1.0.1",
+		"setuptools":        "69.5.1",
+		"tenacity":          "8.2.3",
+		"tomli":             "2.0.1",
+		"truststore":        "0.9.1",
+	}
+	pkgs, _, err := PipVendor{}.Catalog(context.Background(), file.NewMockResolverForPaths(
+		"testdata/pip/_vendor/vendor.txt",
+		"testdata/bad/pip/_vendor/vendor.txt",
+	))
+	if err != nil {
+		t.Fatalf("failed to catalog: %+v", err)
+	}
+
+	if len(pkgs) != len(want) {
+		t.Fatalf("unexpected package count: %d", len(pkgs))
+	}
+
+	got := map[string]string{}
+
+	for _, p := range pkgs {
+		got[p.Name] = p.Version
+		if p.Name == "" {
+			t.Errorf("missing package name")
+		}
+		if p.Version == "" {
+			t.Errorf("missing package version")
+		}
+		if p.Type != PipVendorPkg {
+			t.Errorf("unexpected package type: %s", p.Type)
+		}
+		if p.Language != pkg.Python {
+			t.Errorf("unexpected package language: %s", p.Language)
+		}
+	}
+
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("missing package: %s==%s", k, v)
+		}
+	}
+	for k, v := range got {
+		if want[k] != v {
+			t.Errorf("extra package: %s==%s", k, v)
+		}
+	}
+}

--- a/pkg/sbom/catalogers/testdata/bad/pip/_vendor/vendor.txt
+++ b/pkg/sbom/catalogers/testdata/bad/pip/_vendor/vendor.txt
@@ -1,0 +1,1 @@
+i want your strongest potions

--- a/pkg/sbom/catalogers/testdata/pip/_vendor/vendor.txt
+++ b/pkg/sbom/catalogers/testdata/pip/_vendor/vendor.txt
@@ -1,0 +1,19 @@
+CacheControl==0.14.0
+distlib==0.3.8
+distro==1.9.0
+msgpack==1.0.8
+packaging==24.1
+platformdirs==4.2.1
+pyproject-hooks==1.0.0
+requests==2.32.3
+    certifi==2024.2.2
+    idna==3.7
+    urllib3==1.26.18
+rich==13.7.1
+    pygments==2.17.2
+    typing_extensions==4.11.0
+resolvelib==1.0.1
+setuptools==69.5.1
+tenacity==8.2.3
+tomli==2.0.1
+truststore==0.9.1

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -106,6 +106,7 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 		),
 	).WithCatalogers(
 		catalogers.AngularJSReference,
+		catalogers.PipVendorReference,
 	)
 
 	createdSBOM, err := syft.CreateSBOM(ctx, src, cfg)


### PR DESCRIPTION
Before:
```
wolfictl scan --disable-sbom-cache ./py3.12-pip-base-24.1.2-r1.apk
🔎 Scanning "./py3.12-pip-base-24.1.2-r1.apk"
✅ No vulnerabilities found
```

After:
```
wolfictl scan --disable-sbom-cache ./py3.12-pip-base-24.1.2-r1.apk
🔎 Scanning "./py3.12-pip-base-24.1.2-r1.apk"
└── 📄 /usr/lib/python3.12/site-packages/pip/_vendor/vendor.txt
        📦 urllib3 1.26.18 (pip-vendor-file)
            Medium CVE-2024-37891
```