### PR TITLE
bundles: Handle multiple builds (best-effort)

### DIFF
--- a/pkg/private/bundle/bundle.go
+++ b/pkg/private/bundle/bundle.go
@@ -434,6 +434,7 @@ func Podspec(task Task, ref name.Reference, arch, mFamily, sa, ns string, anns m
 				"app.kubernetes.io/component":     task.Package,
 				"melange.chainguard.dev/arch":     goarch,
 				"melange.chainguard.dev/package":  task.Package,
+				"melange.chainguard.dev/version":  fmt.Sprintf("%s-r%d", task.Version, task.Epoch),
 				"melange.chainguard.dev/build-id": task.BuildID.String(),
 			},
 			Annotations: map[string]string{},


### PR DESCRIPTION
If a pod has already been scheduled for a given APK, we'll just watch it instead of creating a duplicate pod. This avoids duplicating ongoing builds. Every controller that is watching a pod will still attempt to upload it, which gives us some resilience re: failed controllers, but requires the APK repo to handle concurrent uploads gracefully.