### PR TITLE
feat(sbom,scan): better CPE coverage for APK packages

### DIFF
--- a/pkg/sbom/cpe.go
+++ b/pkg/sbom/cpe.go
@@ -1,0 +1,136 @@
+package sbom
+
+import (
+	"strings"
+
+	"github.com/facebookincubator/nvdtools/wfn"
+)
+
+// generateWfnAttributesForAPK generates a CPE for an APK package. If the package is
+// not recognized, this function will return nil.
+func generateWfnAttributesForAPK(p pkgInfo) *wfn.Attributes {
+	name := p.Origin
+	version := trimAPKVersionEpoch(p.PkgVer)
+
+	// Give first priority to our maintained list of CPE mappings by APK package
+	// name.
+
+	attr := wfn.Attributes{
+		Part:    "a",
+		Version: version,
+	}
+
+	if w, ok := pkgNameToWfnAttributes[name]; ok {
+		attr.Vendor = w.Vendor
+		attr.Product = w.Product
+
+		return &attr
+	}
+
+	// TODO: This is a workaround for Syft not coming up with this CPE for OpenJDK
+	// 	packages. Some thought would be needed on the "right" way to implement this
+	// 	upstream, but it's more obvious how we can address this in wolfictl for our
+	// 	purposes.
+	//
+	//  Potentially related: https://github.com/anchore/syft/issues/2422
+	if strings.HasPrefix(name, "openjdk-") {
+		attr.Vendor = "oracle"
+		attr.Product = "jdk"
+
+		return &attr
+	}
+
+	if strings.HasPrefix(name, "dotnet-") {
+		attr.Vendor = "microsoft"
+		attr.Product = ".net"
+
+		return &attr
+	}
+
+	return nil
+}
+
+func trimAPKVersionEpoch(version string) string {
+	// An epoch is denoted with a suffix of "-rN", where N is a number. We want to
+	// remove this suffix from the version.
+	if idx := strings.LastIndex(version, "-r"); idx != -1 {
+		return version[:idx]
+	}
+
+	return version
+}
+
+// pkgNameToWfnAttributes is a set of known mappings from package name to WFN
+// attributes. This is used to generate CPEs for APK packages.
+//
+// Please keep this list sorted alphabetically!
+var pkgNameToWfnAttributes = map[string]wfn.Attributes{
+	"bind": {
+		Vendor:  "isc",
+		Product: "bind",
+	},
+	"binutils": {
+		Vendor:  "gnu",
+		Product: "binutils",
+	},
+	"cortex": {
+		Vendor:  "linuxfoundation",
+		Product: "cortex",
+	},
+	"curl": {
+		Vendor:  "haxx",
+		Product: "curl",
+	},
+	"envoy": {
+		Vendor:  "envoyproxy",
+		Product: "envoy",
+	},
+	"exim": {
+		Vendor:  "exim",
+		Product: "exim",
+	},
+	"flex": {
+		Vendor:  "flex_project",
+		Product: "flex",
+	},
+	"gcc": {
+		Vendor:  "gnu",
+		Product: "gcc",
+	},
+	"git": {
+		Vendor:  "git-scm",
+		Product: "git",
+	},
+	"jenkins": {
+		Vendor:  "jenkins",
+		Product: "jenkins",
+	},
+	"libtasn1": {
+		Vendor:  "gnu",
+		Product: "libtasn1",
+	},
+	"memcached": {
+		Vendor:  "memcached",
+		Product: "memcached",
+	},
+	"ncurses": {
+		Vendor:  "gnu",
+		Product: "ncurses",
+	},
+	"openjdk": {
+		Vendor:  "oracle",
+		Product: "openjdk",
+	},
+	"php": {
+		Vendor:  "php",
+		Product: "php",
+	},
+	"redis": {
+		Vendor:  "redis",
+		Product: "redis",
+	},
+	"vault": {
+		Vendor:  "hashicorp",
+		Product: "vault",
+	},
+}

--- a/pkg/sbom/testdata/goldenfiles/aarch64/jenkins-2.461-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/jenkins-2.461-r0.apk.syft.json
@@ -95816,8 +95816,8 @@
       "language": "",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:jenkins:jenkins:2.461-r0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:jenkins:jenkins:2.461:*:*:*:*:*:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:apk/wolfi/jenkins@2.461-r0?arch=aarch64&origin=jenkins",

--- a/pkg/sbom/testdata/goldenfiles/aarch64/openjdk-21-21.0.3-r3.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/openjdk-21-21.0.3-r3.apk.syft.json
@@ -24,7 +24,7 @@
       "language": "",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:oracle:jdk:21.0.3-r3:*:*:*:*:*:*:*",
+          "cpe": "cpe:2.3:a:oracle:jdk:21.0.3:*:*:*:*:*:*:*",
           "source": "wolfictl"
         }
       ],

--- a/pkg/sbom/testdata/goldenfiles/x86_64/jenkins-2.461-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/jenkins-2.461-r0.apk.syft.json
@@ -95816,8 +95816,8 @@
       "language": "",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:jenkins:jenkins:2.461-r0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:jenkins:jenkins:2.461:*:*:*:*:*:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:apk/wolfi/jenkins@2.461-r0?arch=x86_64&origin=jenkins",

--- a/pkg/sbom/testdata/goldenfiles/x86_64/openjdk-21-21.0.3-r3.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/openjdk-21-21.0.3-r3.apk.syft.json
@@ -24,7 +24,7 @@
       "language": "",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:oracle:jdk:21.0.3-r3:*:*:*:*:*:*:*",
+          "cpe": "cpe:2.3:a:oracle:jdk:21.0.3:*:*:*:*:*:*:*",
           "source": "wolfictl"
         }
       ],


### PR DESCRIPTION
This imports the CPE mappings we had used in the NVD API detector mechanism, and extends the list with net new mappings as well. This helps us avoid depending too much on the Syft (non-dictionary) CPE generation mechanism, which tends to miss valid matches altogether.

The goal here is to further reduce our false negatives by ensuring more precise CPEs are used for APK package matching when possible.

### Before

```console
$ wolfictl sbom -D ./x86_64/libtasn1-4.19.0-r3.apk -o syft-json | jq '.artifacts[0].cpes'
[
  {
    "cpe": "cpe:2.3:a:libtasn1:libtasn1:4.19.0-r3:*:*:*:*:*:*:*",
    "source": "syft-generated"
  },
  {
    "cpe": "cpe:2.3:a:libtasn1:libtasn:4.19.0-r3:*:*:*:*:*:*:*",
    "source": "syft-generated"
  },
  {
    "cpe": "cpe:2.3:a:libtasn:libtasn1:4.19.0-r3:*:*:*:*:*:*:*",
    "source": "syft-generated"
  },
  {
    "cpe": "cpe:2.3:a:libtasn:libtasn:4.19.0-r3:*:*:*:*:*:*:*",
    "source": "syft-generated"
  }
]
```

☝️ These are *all* wrong. 😟 

### After

```console
$ wolfictl sbom -D ./x86_64/libtasn1-4.19.0-r3.apk -o syft-json | jq '.artifacts[0].cpes'
[
  {
    "cpe": "cpe:2.3:a:gnu:libtasn1:4.19.0:*:*:*:*:*:*:*",
    "source": "wolfictl"
  }
]
```

☝️ This one is right. 😌 