### PR TITLE
Remove print from ReadAllPackagesFromRepo.

### DIFF
--- a/pkg/melange/melange.go
+++ b/pkg/melange/melange.go
@@ -151,7 +151,6 @@ func ReadAllPackagesFromRepo(ctx context.Context, dir string) (map[string]*Packa
 			NoLint:   nolint,
 		}
 	}
-	fmt.Printf("found %[1]d packages\n", len(p))
 	return p, nil
 }
 


### PR DESCRIPTION
This func is commonly pulled in to other utilities. Printing to stdout can taint output. This doesn't seem like a critical log line, so instead of moving to stderr, remove the line completely.