### PR TITLE
fix(adv)!: untangle advisory request ID expectations

### DIFF
--- a/pkg/advisory/create.go
+++ b/pkg/advisory/create.go
@@ -21,7 +21,12 @@ type CreateOptions struct {
 func Create(ctx context.Context, req Request, opts CreateOptions) error {
 	err := req.Validate()
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid request: %w", err)
+	}
+
+	// In addition, validate that the request's AdvisoryID is empty.
+	if req.AdvisoryID != "" {
+		return fmt.Errorf("advisory ID must be empty for creating a new advisory, got %q", req.AdvisoryID)
 	}
 
 	documents := opts.AdvisoryDocs.Select().WhereName(req.Package)

--- a/pkg/advisory/create_test.go
+++ b/pkg/advisory/create_test.go
@@ -168,8 +168,8 @@ func TestCreate(t *testing.T) {
 		{
 			name: "no events",
 			req: Request{
-				Package:         "brotli",
-				VulnerabilityID: "CGA-xoxo-xoxo-xoxo",
+				Package:    "brotli",
+				AdvisoryID: "CGA-xoxo-xoxo-xoxo",
 			},
 			wantErr: true,
 		},

--- a/pkg/advisory/data_session.go
+++ b/pkg/advisory/data_session.go
@@ -148,7 +148,7 @@ func (ds *DataSession) Append(ctx context.Context, req Request) error {
 		return ds.Create(ctx, req)
 	}
 
-	if _, exists := packageSelection.Configurations()[0].Advisories.GetByVulnerability(req.VulnerabilityID); !exists {
+	if _, exists := packageSelection.Configurations()[0].Advisories.GetByAnyVulnerability(req.VulnerabilityIDs()...); !exists {
 		return ds.Create(ctx, req)
 	}
 
@@ -233,7 +233,7 @@ func (ds DataSession) commit(_ context.Context, req Request, operation string) e
 		"%s: %s advisory %s",
 		req.Package,
 		operation,
-		req.VulnerabilityID,
+		req.AdvisoryID,
 	)
 
 	wt, err := ds.repo.Worktree()

--- a/pkg/advisory/discover.go
+++ b/pkg/advisory/discover.go
@@ -105,10 +105,9 @@ func (opts DiscoverOptions) discoverMatchesForPackage(ctx context.Context, pkg s
 	for i := range matches {
 		match := matches[i]
 		err := Create(ctx, Request{
-			Package:         pkg,
-			VulnerabilityID: match.Vulnerability.ID,
-			Aliases:         nil,
-			Event:           advisoryEventForNewDiscovery(match),
+			Package: pkg,
+			Aliases: []string{match.Vulnerability.ID},
+			Event:   advisoryEventForNewDiscovery(match),
 		}, CreateOptions{opts.AdvisoryDocs})
 		if err != nil {
 			return err

--- a/pkg/advisory/testdata/create/advisories/brotli.advisories.yaml
+++ b/pkg/advisory/testdata/create/advisories/brotli.advisories.yaml
@@ -4,7 +4,7 @@ package:
   name: brotli
 
 advisories:
-  - id: CGA-xoxo-xoxo-xoxo
+  - id: CGA-xxxx-xxxx-xxxx
     aliases:
       - CVE-2020-8927
     events:

--- a/pkg/advisory/update.go
+++ b/pkg/advisory/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
@@ -15,9 +16,16 @@ type UpdateOptions struct {
 	AdvisoryDocs *configs.Index[v2.Document]
 }
 
-// Update adds a new event to an existing advisory (named by the vuln parameter)
-// in the document at the provided path.
+// Update adds a new event to an existing advisory in the document at the
+// provided path. If the request's AdvisoryID is set, the advisory with that ID
+// is updated. Otherwise, the first advisory found for the package with the one
+// of the provided aliases is updated.
 func Update(ctx context.Context, req Request, opts UpdateOptions) error {
+	err := req.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid request: %w", err)
+	}
+
 	documents := opts.AdvisoryDocs.Select().WhereName(req.Package)
 	if count := documents.Len(); count != 1 {
 		return fmt.Errorf("cannot update advisory: found %d advisory documents for package %q", count, req.Package)
@@ -26,16 +34,30 @@ func Update(ctx context.Context, req Request, opts UpdateOptions) error {
 	u := v2.NewAdvisoriesSectionUpdater(func(doc v2.Document) (v2.Advisories, error) {
 		advisories := doc.Advisories
 
+		// If the request specifies the advisory ID, that takes priority. Otherwise, use
+		// the aliases to find the advisory.
+
 		var adv v2.Advisory
 		var ok bool
-		for _, alias := range req.Aliases {
-			adv, ok = advisories.GetByVulnerability(alias)
+		if req.AdvisoryID != "" {
+			// Exact match on advisory ID!
+
+			adv, ok = advisories.Get(req.AdvisoryID)
 			if !ok {
-				return nil, fmt.Errorf("advisory %q does not exist", alias)
+				return nil, fmt.Errorf("advisory %q does not exist", req.AdvisoryID)
+			}
+		} else {
+			// Try to find the advisory by its aliases.
+
+			adv, ok = advisories.GetByAnyVulnerability(req.Aliases...)
+			if !ok {
+				return nil, fmt.Errorf("advisory with alias(es) %q does not exist", strings.Join(req.Aliases, ", "))
 			}
 		}
 
+		adv = adv.MergeInAliases(req.Aliases...)
 		adv.Events = append(adv.Events, req.Event)
+
 		advisories = advisories.Update(adv.ID, adv)
 
 		// Ensure the package's advisory list is sorted before returning it.
@@ -43,7 +65,7 @@ func Update(ctx context.Context, req Request, opts UpdateOptions) error {
 
 		return advisories, nil
 	})
-	err := documents.Update(ctx, u)
+	err = documents.Update(ctx, u)
 	if err != nil {
 		return fmt.Errorf("unable to add entry for advisory %q in %q: %w", req.Aliases[0], req.Package, err)
 	}

--- a/pkg/advisory/update_test.go
+++ b/pkg/advisory/update_test.go
@@ -81,9 +81,9 @@ func TestUpdate(t *testing.T) {
 		{
 			name: "updating existing advisory using the CGA ID",
 			req: Request{
-				Package:         "brotli",
-				VulnerabilityID: "CGA-xoxo-xoxo-xoxo",
-				Aliases:         []string{"CVE-2020-8927"},
+				Package:    "brotli",
+				AdvisoryID: "CGA-xxxx-xxxx-xxxx",
+				Aliases:    []string{"CVE-2020-8927"},
 				Event: v2.Event{
 					Timestamp: testTime,
 					Type:      v2.EventTypeDetection,

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
 	"github.com/wolfi-dev/wolfictl/pkg/internal"
 	"github.com/wolfi-dev/wolfictl/pkg/versions"
+	"github.com/wolfi-dev/wolfictl/pkg/vuln"
 )
 
 const (
@@ -113,13 +114,20 @@ func (p *advisoryRequestParams) advisoryRequest() (advisory.Request, error) {
 	}
 
 	req := advisory.Request{
-		Package:         p.packageName,
-		VulnerabilityID: p.vuln,
+		Package: p.packageName,
 		Event: v2.Event{
 			Timestamp: timestamp,
 			Type:      p.eventType,
 			Data:      nil,
 		},
+	}
+
+	if p.vuln != "" {
+		if vuln.RegexCGA.MatchString(p.vuln) {
+			req.AdvisoryID = p.vuln
+		} else {
+			req.Aliases = []string{p.vuln}
+		}
 	}
 
 	switch req.Event.Type {

--- a/pkg/cli/advisory_alias_find.go
+++ b/pkg/cli/advisory_alias_find.go
@@ -46,7 +46,7 @@ hyperlinked to the relevant webpage from the upstream data source.
 			for i, arg := range args {
 				aliases, err := findAliases(cmd.Context(), af, arg)
 				if err != nil {
-					return fmt.Errorf("unable to find aliases for vulnerability %q: %w", arg, err)
+					return fmt.Errorf("finding aliases for %q: %w", arg, err)
 				}
 
 				fmt.Printf("Aliases for %s:\n", hyperlinkVulnerabilityID(arg))

--- a/pkg/cli/advisory_guide_graph.go
+++ b/pkg/cli/advisory_guide_graph.go
@@ -17,8 +17,8 @@ func cmdAdvisoryGuideGraph() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			sampleReq := advisory.Request{
-				Package:         "foo",
-				VulnerabilityID: "CVE-2024-12345",
+				Package:    "foo",
+				AdvisoryID: "CGA-xxxx-xxxx-xxxx",
 			}
 
 			dot, err := graph.Dot(cmd.Context(), question.IsFalsePositive, sampleReq)

--- a/pkg/cli/advisory_update.go
+++ b/pkg/cli/advisory_update.go
@@ -113,7 +113,7 @@ required fields are missing.`,
 					var vulnerabilities []string
 					for _, cfg := range advisoryCfgs.Select().WhereName(packageName).Configurations() {
 						vulns := lo.FlatMap(cfg.Advisories, func(adv v2.Advisory, _ int) []string {
-							return adv.Aliases
+							return adv.VulnerabilityIDs()
 						})
 						sort.Strings(vulns)
 						vulnerabilities = append(vulnerabilities, vulns...)

--- a/pkg/cli/components/advisory/prompt/model.go
+++ b/pkg/cli/components/advisory/prompt/model.go
@@ -60,8 +60,6 @@ func (m Model) newPackageFieldConfig() field.TextFieldConfiguration {
 	}
 }
 
-var validCVEID = field.TextValidationRule(vuln.ValidateID)
-
 func (m Model) newVulnerabilityFieldConfig() field.TextFieldConfiguration {
 	allowedValues := m.allowedVulnerabilitiesFunc(m.Request.Package)
 
@@ -75,7 +73,7 @@ func (m Model) newVulnerabilityFieldConfig() field.TextFieldConfiguration {
 		EmptyValueHelpMsg: "Provide a valid vulnerability ID.",
 		ValidationRules: []field.TextValidationRule{
 			field.NotEmpty,
-			validCVEID,
+			vuln.ValidateID,
 		},
 		AllowedValues: allowedValues,
 	}
@@ -284,7 +282,7 @@ func (m Model) addMissingFields() (Model, bool) {
 		return m, true
 	}
 
-	if len(m.Request.Aliases) == 0 {
+	if len(m.Request.VulnerabilityIDs()) == 0 {
 		f := field.NewTextField(m.newVulnerabilityFieldConfig())
 		m.fields = append(m.fields, f)
 		return m, true

--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -75,6 +75,30 @@ func (adv Advisory) Resolved() bool {
 	}
 }
 
+// MergeInAliases adds the input aliases to the advisory's list of aliases and
+// returns the updated Advisory. The list of aliases is sorted and duplicates
+// are removed.
+func (adv Advisory) MergeInAliases(aliases ...string) Advisory {
+	adv.Aliases = append(adv.Aliases, aliases...)
+	slices.Sort(adv.Aliases)
+	adv.Aliases = slices.Compact(adv.Aliases)
+
+	return adv
+}
+
+// VulnerabilityIDs returns the list of vulnerability IDs for the advisory. This
+// is a combination of the advisory's ID and its aliases.
+func (adv Advisory) VulnerabilityIDs() []string {
+	ids := slices.Clone(adv.Aliases)
+
+	if adv.ID != "" {
+		ids = append(ids, adv.ID)
+	}
+
+	slices.Sort(ids)
+	return slices.Compact(ids)
+}
+
 // ResolvedAtVersion returns true if the advisory indicates that the
 // vulnerability does not affect the distro package at the given package
 // version, or that no further investigation is planned.

--- a/pkg/configs/advisory/v2/document.go
+++ b/pkg/configs/advisory/v2/document.go
@@ -161,6 +161,36 @@ func (advs Advisories) GetByVulnerability(id string) (Advisory, bool) {
 	return Advisory{}, false
 }
 
+// GetByAnyVulnerability returns the first advisory that references any of the
+// given vulnerability IDs as its advisory ID or as one of the advisory's
+// aliases. This allows the caller to look up a particular advisory of interest
+// if the caller knows the underlying vulnerability by multiple IDs (e.g. both a
+// CVE ID and a GHSA ID), and the advisory itself has recorded at least one of
+// those IDs.
+//
+// If such an advisory does not exist in the collection, the second return value
+// will be false; otherwise it will be true.
+func (advs Advisories) GetByAnyVulnerability(ids ...string) (Advisory, bool) {
+	for _, adv := range advs {
+		for _, id := range ids {
+			if adv.ID == id {
+				return adv, true
+			}
+
+			for _, alias := range adv.Aliases {
+				if alias == id {
+					return adv, true
+				}
+			}
+		}
+	}
+
+	return Advisory{}, false
+}
+
+// Update returns a new Advisories slice with the advisory with the given ID
+// replaced with the given advisory. If no advisory with the given ID exists in
+// the slice, the original slice is returned.
 func (advs Advisories) Update(id string, advisory Advisory) Advisories {
 	for i, adv := range advs {
 		if adv.ID == id {


### PR DESCRIPTION
The advisory request API has been straightened out, following the introduction of CGA IDs. The `VulnerabilityID` field has been renamed to `AdvisoryID` to clarify its intent (that it **must** be one of our `CGA-...` IDs, not a CVE ID or GHSA ID). It can be set during advisory update operations in order to specify an advisory by CGA ID, otherwise the aliases of the request are used. For create operations, the `AdvisoryID` field must be empty, since CGA IDs will be generated on the fly. This fixes #1086.

Additionally (but relatedly), alias resolution is now allowed to fail during the `guide` command. This fixes #1083.

This also resolves an issue where the user specified a vulnerability with the `-V` flag on either the `create` or `update` command and was still prompted for the vulnerability again.

cc: @cpanato @hectorj2f in case this impacts any consuming code. Happy to walk through how to update code accordingly if it's not obvious!