### PR TITLE
Lint fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
 golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;\
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0 ;\
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2 ;\
 
 .PHONY: fmt
 fmt: ## Format all go files

--- a/pkg/cli/internal/wrapped/wrapped.go
+++ b/pkg/cli/internal/wrapped/wrapped.go
@@ -87,7 +87,16 @@ var (
 )
 
 func getTerminalWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	fd := os.Stdout.Fd()
+
+	// Check if the conversion is safe
+	if fd > uintptr(int(^uint(0)>>1)) {
+		// file descriptor too large to convert to int safely
+		return fallbackLineLength
+	}
+
+	//nolint:gosec // The file descriptor is checked above
+	w, _, err := term.GetSize(int(fd))
 	if err != nil {
 		return fallbackLineLength
 	}

--- a/pkg/tar/untar.go
+++ b/pkg/tar/untar.go
@@ -50,7 +50,16 @@ func Untar(src io.Reader, dst string) error {
 			if err := os.MkdirAll(filepath.Dir(target), os.ModePerm); err != nil {
 				return err
 			}
-			fileToWrite, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+
+			mode := header.Mode
+
+			// Check if mode is within the range of a uint32
+			if mode < 0 || mode > int64(^uint32(0)) {
+				return fmt.Errorf("file mode out of range: %d", mode)
+			}
+
+			//nolint:gosec // mode is checked above
+			fileToWrite, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(mode))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
New `gosec` findings coming up — this addresses them.

This also bumps the version of `golangci-lint` used in `make lint`.