### PR TITLE
Consider subpackage runtime deps for graph

### DIFF
--- a/pkg/cli/dot.go
+++ b/pkg/cli/dot.go
@@ -64,6 +64,11 @@ Open browser to explore crane's deps recursively, only showing a minimum subgrap
 				return fmt.Errorf("building graph: %w", err)
 			}
 
+			g, err = g.Targets()
+			if err != nil {
+				return fmt.Errorf("targets: %w", err)
+			}
+
 			amap, err := g.Graph.AdjacencyMap()
 			if err != nil {
 				return err

--- a/pkg/dag/graph_test.go
+++ b/pkg/dag/graph_test.go
@@ -161,7 +161,7 @@ func TestNewGraph(t *testing.T) {
 			// the external dependencies should be dangling, i.e. unresolved
 			for _, dep := range externalDeps {
 				assert.Contains(t, deps, dep)
-				assert.Equal(t, deps[dep].Source, PackageHash(conf))
+				assert.Equal(t, deps[dep].Source, PackageHash(conf), "for %s", dep)
 				assert.Equal(t, deps[dep].Target, dep)
 				vertex, err := graph.Graph.Vertex(dep)
 				require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestNewGraph(t *testing.T) {
 			// the internal dependencies should be resolved
 			for _, dep := range internalDeps {
 				assert.Contains(t, deps, dep)
-				assert.Equal(t, deps[dep].Source, PackageHash(conf))
+				assert.Equal(t, deps[dep].Source, PackageHash(conf), "for %s", dep)
 				assert.Equal(t, deps[dep].Target, dep)
 				vertex, err := graph.Graph.Vertex(dep)
 				require.NoError(t, err)
@@ -281,6 +281,7 @@ func TestTargets(t *testing.T) {
 		"two:4.5.6-r1@local":   {"one:1.2.3-r1@local"},
 		"three:4.5.6-r1@local": {"two:4.5.6-r1@local"},
 	}
+
 	// the direct dependencies from environment.contents.packages should be dangling, i.e. unresolved
 	for k, want := range expectedDeps {
 		got, ok := amap[k]
@@ -292,6 +293,6 @@ func TestTargets(t *testing.T) {
 		}
 
 		keys := maps.Keys(got)
-		assert.ElementsMatch(t, want, keys)
+		assert.ElementsMatch(t, want, keys, "unexpected dependencies for %s", k)
 	}
 }

--- a/pkg/dag/testdata/duplicate/one-dupl.yaml
+++ b/pkg/dag/testdata/duplicate/one-dupl.yaml
@@ -27,16 +27,11 @@ pipeline:
 
 subpackages:
   - name: one-sub1
-    dependencies:
-      runtime:
-        - gettext-static
     description: one static
   - name: one-sub2
     pipeline:
       - uses: one
     dependencies:
-      runtime:
-        - bzip2-dev
       provides:
         - one-subp-provides-implicit
         - one-subp-provides-explicit=10.10.11

--- a/pkg/dag/testdata/multiple/one.yaml
+++ b/pkg/dag/testdata/multiple/one.yaml
@@ -27,17 +27,12 @@ pipeline:
 
 subpackages:
   - name: one-sub1
-    dependencies:
-      runtime:
-        - gettext-static
     description: one static
   - name: one-sub2
     pipeline:
       - runs: |
           echo "Hello, world!"
     dependencies:
-      runtime:
-        - bzip2-dev
       provides:
         - one-subp-provides-implicit
         - one-subp-provides-explicit=10.10.11


### PR DESCRIPTION
We were only looking at main package runtime deps when constructing the dependency graph, which meant we missed a lot of edges that were very important.