### PR TITLE
dont flag git updates as errors

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -389,13 +389,13 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 		},
 		{
 			Name:        "git-checkout-must-use-github-updates",
-			Description: "when using git-checkout, must use github updates so we can get the expected-commit",
+			Description: "when using git-checkout, must use github/git updates so we can get the expected-commit",
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				for _, p := range config.Pipeline {
 					if p.Uses == gitCheckout && strings.HasPrefix(p.With["repository"], "https://github.com/") {
-						if config.Update.Enabled && config.Update.GitHubMonitor == nil {
-							return fmt.Errorf("configure update.github when using git-checkout")
+						if config.Update.Enabled && config.Update.GitHubMonitor == nil && config.Update.GitMonitor == nil {
+							return fmt.Errorf("configure update.github/update.git when using git-checkout")
 						}
 					}
 				}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -335,7 +335,7 @@ func TestLinter_Rules(t *testing.T) {
 							Name:     "git-checkout-must-use-github-updates",
 							Severity: SeverityError,
 						},
-						Error: fmt.Errorf("[git-checkout-must-use-github-updates]: configure update.github when using git-checkout (ERROR)"),
+						Error: fmt.Errorf("[git-checkout-must-use-github-updates]: configure update.github/update.git when using git-checkout (ERROR)"),
 					},
 				},
 			},


### PR DESCRIPTION
the  lint checks are [failing](https://github.com/chainguard-dev/enterprise-packages/actions/runs/10679086822/job/29601804690) for update sections with git monitors 

```
update:
  enabled: true
  ignore-regex-patterns:
    - sdks/
    - '-RC'
  git:
    strip-prefix: v
```


