### PR TITLE
Removing fixed-version-present-and-first logic and test

### DIFF
--- a/pkg/advisory/validate_test.go
+++ b/pkg/advisory/validate_test.go
@@ -286,18 +286,6 @@ func TestValidate(t *testing.T) {
 					shouldBeValid: false,
 				},
 				{
-					name: "fixed-version-present-and-first", // which is not allowed
-					apkindex: &apk.APKIndex{
-						Packages: []*apk.Package{
-							{
-								Name:    "ko",
-								Version: "1.0.0-r2",
-							},
-						},
-					},
-					shouldBeValid: false,
-				},
-				{
 					name: "fixed-version-present-and-not-first",
 					apkindex: &apk.APKIndex{
 						Packages: []*apk.Package{


### PR DESCRIPTION
As per conversation with @luhring, We agree that the stringent rule of the fixed version of a package can not be the first version should be relaxed and addressed more methodically moving forward. An example of where this is in the instance where validation is recommending to change previously valid fix version tags [to 'false-positive-determination'](https://github.com/chainguard-dev/enterprise-advisories/actions/runs/10622587699/job/29447212893#step:7:27) due to the commit history being lost when the package file was deleted and remade. 