### PR TITLE
Improve error message for duplicate package names

### DIFF
--- a/pkg/dag/graph.go
+++ b/pkg/dag/graph.go
@@ -935,6 +935,9 @@ func (g Graph) Targets() (*Graph, error) { //nolint:gocyclo
 	for name, configs := range g.packages.configs {
 		for _, cfg := range configs {
 			if cfg.pkg == name {
+				if got, ok := pathByName[name]; ok {
+					return nil, fmt.Errorf("duplicate package: %q exists in both %q and %q", name, got, cfg.Path)
+				}
 				pathByName[name] = cfg.Path
 			}
 		}


### PR DESCRIPTION
This happens often with version streams that have packages with the exact same name, so my assumption that a given package belongs to a single origin is wrong. The existing error message complains about cycles in the graph, which is misleading.