### PR TITLE
fix(scan): panic on nil cleanup

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -214,14 +214,16 @@ wolfictl scan package1 package2 --remote
 			if err != nil {
 				return err
 			}
-			defer func() {
-				if err := cleanup(); err != nil {
-					logger.Error("failed to clean up", "error", err)
-					return
-				}
+			if cleanup != nil {
+				defer func() {
+					if err := cleanup(); err != nil {
+						logger.Error("failed to clean up", "error", err)
+						return
+					}
 
-				logger.Debug("cleaned up after scan")
-			}()
+					logger.Debug("cleaned up after scan")
+				}()
+			}
 
 			scans, inputPathsFailingRequireZero, err := scanEverything(ctx, p, inputs, advisoryDocumentIndex)
 			if err != nil {


### PR DESCRIPTION
With #1184 we started returning a `nil` cleanup function after the scan in some cases.

This PR fixes #1188 by checking for a non-`nil` value in the cleanup function before calling it.