### PR TITLE
fix(log): correct int32 bounds checking

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 
 	"github.com/chainguard-dev/clog/slag"
@@ -20,7 +21,7 @@ func New() *cobra.Command {
 		Short:             "A CLI helper for developing Wolfi",
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			// Ensure level is within the int32 range
-			if int(level) < int(^int32(0)+1) || int(level) > int(int32(^uint32(0)>>1)) {
+			if int(level) < math.MinInt32 || int(level) > math.MaxInt32 {
 				return fmt.Errorf("log level out of range: %d", level)
 			}
 


### PR DESCRIPTION
Fixes #1208.

We'll be able to remove this bit of code altogether once we update to a new version of charm log.

#### Before

```console
$ go run . adv alias find --log-level debug CVE-2024-1111
2024/09/25 08:23:02 ERROR log level out of range: -4
exit status 1
```

#### After

```console
$ go run . adv alias find --log-level debug CVE-2024-1111
Aliases for CVE-2024-1111:
  - GHSA-9m6f-83hx-8wwr
```

_Note there is no DEBUG-level logging for `wolfictl adv alias find`._