### PR TITLE
fix(sbom,scan): find openssl CVEs for FIPS provider

### DIFF
--- a/pkg/sbom/cpe.go
+++ b/pkg/sbom/cpe.go
@@ -121,6 +121,10 @@ var pkgNameToWfnAttributes = map[string]wfn.Attributes{
 		Vendor:  "oracle",
 		Product: "openjdk",
 	},
+	"openssl-provider-fips": {
+		Vendor:  "openssl",
+		Product: "openssl",
+	},
 	"php": {
 		Vendor:  "php",
 		Product: "php",


### PR DESCRIPTION
Ensures we find openssl CVEs for the FIPS provider by explicitly setting the package CPE.

#### Before

```console
$ wolfictl scan -D ./openssl-provider-fips-3.0.9-r1.apk
🔎 Scanning "./openssl-provider-fips-3.0.9-r1.apk"
✅ No vulnerabilities found
```

#### After

```console
$ wolfictl scan -D ./openssl-provider-fips-3.0.9-r1.apk
🔎 Scanning "./openssl-provider-fips-3.0.9-r1.apk"
└── 📄 /.PKGINFO
        📦 openssl-provider-fips 3.0.9-r1 (apk)
            Medium CVE-2023-2975
            Medium CVE-2023-3817
            High CVE-2023-4807
            High CVE-2023-5363
            Medium CVE-2023-5678
            Medium CVE-2023-6129
            Unknown CVE-2023-6237
            Medium CVE-2024-0727
            Unknown CVE-2024-2511
            Medium CVE-2024-4603
            Critical CVE-2024-5535
            High CVE-2024-6119
```