### PR TITLE
linter: add test-disabled-reason

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -457,6 +457,21 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			},
 		},
 		{
+			Name:        "test-disabled-reason",
+			Description: "packages with test disabled should have a reason",
+			// TODO: Change to SeverityError when current packages are compliant.
+			Severity: SeverityWarning,
+			LintFunc: func(c config.Configuration) error {
+				if c.Test != nil && c.Test.Enabled {
+					return nil
+				}
+				if c.Test != nil && !c.Test.Enabled && c.Test.ExcludeReason != "" {
+					return nil
+				}
+				return fmt.Errorf("test is disabled but no reason is provided")
+			},
+		},
+		{
 			Name:        "valid-update-schedule",
 			Description: "update schedule config should contain a valid period",
 			Severity:    SeverityError,

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -416,6 +416,24 @@ func TestLinter_Rules(t *testing.T) {
 			matches: 1,
 		},
 		{
+			file:        "test-disabled.yaml",
+			minSeverity: SeverityInfo,
+			want: EvalResult{
+				File: "test-disabled",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "test-disabled-reason",
+							Severity: SeverityWarning,
+						},
+						Error: fmt.Errorf("[test-disabled-reason]: test is disabled but no reason is provided (WARNING)"),
+					},
+				},
+			},
+			wantErr: false,
+			matches: 1,
+		},
+		{
 			file:        "valid-update-schedule.yaml",
 			minSeverity: SeverityWarning,
 			want: EvalResult{

--- a/pkg/lint/testdata/files/test-disabled.yaml
+++ b/pkg/lint/testdata/files/test-disabled.yaml
@@ -1,0 +1,28 @@
+package:
+  name: update-disabled
+  version: 1.0.0
+  epoch: 0
+  description: A valid package
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+environment:
+  contents:
+    packages:
+      - foo
+      - bar
+      - baz
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/foo/bar/baz.tar.gz
+      expected-sha512: 6d8e828fa406518b4b3f55b0e5f62bbd5cf25cb5782d1884b9d5eaf61fb0614deaacad4236ab7420fa5b3868c79df226ae1aa5193bb136c556aa52853eeca553
+  - runs: |
+      go build .
+test:
+  enabled: false
+update:
+  enabled: true


### PR DESCRIPTION
Checks to make sure that there's a reason attached whenever test are disabled.

Blocked by: https://github.com/chainguard-dev/melange/pull/1521