### PR TITLE
Fix exec.LookPath for malcontent

### DIFF
--- a/pkg/checks/diff.go
+++ b/pkg/checks/diff.go
@@ -100,7 +100,7 @@ func (o *DiffOptions) Diff() error {
 
 	// If malcontent is on the path, then run it to get a capability diff.
 	var result []byte
-	if path, err := exec.LookPath("malcontent"); err == nil {
+	if path, err := exec.LookPath("mal"); err == nil {
 		o.Logger.Printf("starting bincapz for %d packages", len(newPackages))
 		// --min-file-level=3 filters out lower-risk changes in lower-risk files.
 		//


### PR DESCRIPTION
This PR corrects the `exec.LookPath` when looking for `malcontent` which is installed as `mal` in the SDK image:
```
/ # mal --help
NAME:
   malcontent - Detect malicious program behaviors

USAGE:
   mal <flags> [diff, scan] <path>

VERSION:
   v1.0.1

COMMANDS:
   analyze  fully interrogate a path
   diff     scan and diff two paths
   scan     tersely scan a path and return findings of the highest severity
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --all                      Ignore nothing within a provided scan path (default: false)
   --err-first-miss           Exit with error if scan source has no matching capabilities (default: false)
   --err-first-hit            Exit with error if scan source has matching capabilities (default: false)
   --format value             Output format (json, markdown, simple, terminal, yaml) (default: "auto")
   --ignore-self              Ignore the malcontent binary (default: true)
   --ignore-tags value        Rule tags to ignore
   --include-data-files       Include files that are detected as non-program (binary or source) files (default: false)
   --jobs value, -j value     Concurrently scan files within target scan paths (default: 12)
   --min-file-level value     Obsoleted by --min-file-risk (default: -1)
   --min-file-risk value      Only show results for files which meet the given risk level (any, low, medium, high, critical) (default: "low")
   --min-level value          Obsoleted by --min-risk (default: -1)
   --min-risk value           Only show results which meet the given risk level (any, low, medium, high, critical) (default: "low")
   --output value, -o value   Write output to specified file instead of stdout
   --profile, -p              Generate profile and trace files (default: false)
   --quantity-increases-risk  Increase file risk score based on behavior quantity (default: true)
   --stats, -s                Show scan statistics (default: false)
   --third-party              Include third-party rules which may have licensing restrictions (default: true)
   --verbose                  Emit verbose logging messages to stderr (default: false)
   --help, -h                 show help
   --version, -v              print the version
```

This is required for updating the SDK image digest in wolfi-dev/os.