### PR TITLE
fix(scan): use correct CPE for GitLab components

### DIFF
--- a/pkg/sbom/cpe.go
+++ b/pkg/sbom/cpe.go
@@ -47,6 +47,13 @@ func generateWfnAttributesForAPK(p pkgInfo) *wfn.Attributes {
 		return &attr
 	}
 
+	if strings.HasPrefix(name, "gitlab-") {
+		attr.Vendor = "gitlab"
+		attr.Product = "gitlab"
+
+		return &attr
+	}
+
 	return nil
 }
 

--- a/pkg/sbom/cpe.go
+++ b/pkg/sbom/cpe.go
@@ -50,6 +50,7 @@ func generateWfnAttributesForAPK(p pkgInfo) *wfn.Attributes {
 	if strings.HasPrefix(name, "gitlab-") {
 		attr.Vendor = "gitlab"
 		attr.Product = "gitlab"
+		attr.SWEdition = "community"
 
 		return &attr
 	}


### PR DESCRIPTION
We've been missing CVEs in GitLab. For NVD data, GitLab has a CPE of: `cpe:2.3:a:gitlab:gitlab:*:*:*:*:*:*:*:* `.

Syft has been generating lots of CPEs for GitLab components, but they're never correct. For example:

```json
        {
          "cpe": "cpe:2.3:a:gitlab_logger:gitlab-logger:17.4.0-r2:*:*:*:*:*:*:*",
          "source": "syft-generated"
        },
        {
          "cpe": "cpe:2.3:a:gitlab_logger:gitlab_logger:17.4.0-r2:*:*:*:*:*:*:*",
          "source": "syft-generated"
        },
        {
          "cpe": "cpe:2.3:a:gitlab:gitlab-logger-17.4:17.4.0-r2:*:*:*:*:*:*:*",
          "source": "syft-generated"
        },
        {
          "cpe": "cpe:2.3:a:gitlab:gitlab_logger_17.4:17.4.0-r2:*:*:*:*:*:*:*",
          "source": "syft-generated"
        },
        {
          "cpe": "cpe:2.3:a:gitlab:gitlab-logger:17.4.0-r2:*:*:*:*:*:*:*",
          "source": "syft-generated"
        },
        {
          "cpe": "cpe:2.3:a:gitlab:gitlab_logger:17.4.0-r2:*:*:*:*:*:*:*",
          "source": "syft-generated"
        }
```

This PR sets the GitLab CPE explicitly when the APK package name is prefixed by `gitlab-`.

For reference, here are the packages (including subpackage) currently defined in Wolfi with that prefix:

```console
$ wolfictl ls --subpackages | grep '^gitlab-'
Auto-detected distro: Wolfi

gitlab-cng-17.4
gitlab-cfssl-self-sign-scripts-17.4
gitlab-container-registry-scripts-17.4
gitlab-exporter-scripts-17.4
gitlab-geo-logcursor-scripts-17.4
gitlab-gitaly-scripts-17.4
gitlab-mailroom-scripts-17.4
gitlab-pages-scripts-17.4
gitlab-rails-scripts-17.4
gitlab-shell-scripts-17.4
gitlab-sidekiq-scripts-17.4
gitlab-webservice-scripts-17.4
gitlab-workhorse-scripts-17.4
gitlab-toolbox-scripts-17.4
gitlab-shell-scripts-compat-17.4
gitlab-base-17.4
gitlab-webservice-config-17.4
gitlab-certificates-17.4
gitlab-container-registry-17.4
gitlab-container-registry-compat-17.4
gitlab-elasticsearch-indexer-17.4
gitlab-elasticsearch-indexer-compat-17.4
gitlab-exporter-17.4
gitlab-logger-17.4
gitlab-logger-compat-17.4
gitlab-mailroom-17.4
gitlab-shell-17.4
gitlab-kas-17.4
gitlab-agent-17.4
gitlab-pages-17.4
gitlab-pages-compat-17.4
gitlab-runner-17.4
gitlab-runner-helper-17.4
gitlab-runner-oci-entrypoint-17.4
gitlab-runner-helper-oci-entrypoint-17.4
gitlab-runner-helper-compat-17.4
gitlab-docker-machine-17.4
````

### Impact on scanning

⚠️  This change introduces a nontrivial set of net new results during vulnerability scanning.

Here's an example using an enterprise package:

#### Before

```console
$ wolfictl scan -D ./gitlab-base-17.1-17.1.2-r10.apk
🔎 Scanning "./gitlab-base-17.1-17.1.2-r10.apk"
✅ No vulnerabilities found
```

#### After

```console
$ wolfictl scan -D ./gitlab-base-17.1-17.1.2-r10.apk
🔎 Scanning "./gitlab-base-17.1-17.1.2-r10.apk"
└── 📄 /.PKGINFO
        📦 gitlab-base-17.1 17.1.2-r10 (apk)
            Low CVE-2024-0231
            Critical CVE-2024-2743
            High CVE-2024-2800
            High CVE-2024-3035
            Medium CVE-2024-3114
            Medium CVE-2024-3127
            Medium CVE-2024-3958
            Medium CVE-2024-4099
            Medium CVE-2024-4207
            Medium CVE-2024-4210
            Low CVE-2024-4278
            Medium CVE-2024-4283
            Medium CVE-2024-4472
            Critical CVE-2024-45409
            Medium CVE-2024-4612
            High CVE-2024-4660
            Medium CVE-2024-4784
            Medium CVE-2024-5067
            Medium CVE-2024-5423
            Medium CVE-2024-5435
            High CVE-2024-6329
            Medium CVE-2024-6389
            Low CVE-2024-6446
            Medium CVE-2024-6502
            High CVE-2024-6678
            Medium CVE-2024-6685
            Medium CVE-2024-7047
            Medium CVE-2024-7057
            Medium CVE-2024-7060
            Medium CVE-2024-7091
            Medium CVE-2024-7110
            Medium CVE-2024-7554
            Medium CVE-2024-7610
            Medium CVE-2024-8041
            High CVE-2024-8124
            High CVE-2024-8631
            Medium CVE-2024-8635
            High CVE-2024-8640
            High CVE-2024-8641
            High CVE-2024-8754
            Medium CVE-2024-8974
```
