### PR TITLE
Move file-risk-increase flag under diff command

### DIFF
--- a/pkg/checks/diff.go
+++ b/pkg/checks/diff.go
@@ -105,7 +105,7 @@ func (o *DiffOptions) Diff() error {
 		// --min-file-level=3 filters out lower-risk changes in lower-risk files.
 		//
 		// As we get more comfortable with the output, we should decrease this value from 3 (HIGH) to 2 (MEDIUM).
-		cmd := exec.Command(path, "-file-risk-increase=true", "-quantity-increases-risk=false", "-format=markdown", "-min-risk=critical", "diff", dirExistingApk, dirNewApk)
+		cmd := exec.Command(path, "-quantity-increases-risk=false", "-format=markdown", "-min-risk=critical", "diff", "-file-risk-increase=true", dirExistingApk, dirNewApk)
 		result, err = cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("malcontent execution failed with error %w: %s", err, result)


### PR DESCRIPTION
The new file risk flags are flags for the `diff` command rather than global flags:
```
$ go run cmd/mal/mal.go diff -h
NAME:
   malcontent diff - scan and diff two paths

USAGE:
   malcontent diff [command options]

OPTIONS:
   --file-risk-change    Only show diffs when file risk changes (default: false)
   --file-risk-increase  Only show diffs when file risk increases (default: false)
   --help, -h            show help
```