### PR TITLE
text: Improve err for missing packages

### DIFF
--- a/pkg/dag/graph.go
+++ b/pkg/dag/graph.go
@@ -384,6 +384,12 @@ func (g *Graph) addAppropriatePackageFromResolver(resolverKey string, c Package,
 			pkgs = append(pkgs, pkg)
 			matchList = append(matchList, PackageHash(pkg))
 		}
+
+		// Couldn't find any candidates for this package, exit early.
+		if len(matchList) == 0 {
+			return nil, fmt.Errorf("no matches for %q", dep)
+		}
+
 		var (
 			allPkgs = strings.Join(matchList, " ")
 			attrs   = map[string]string{


### PR DESCRIPTION
If we try to resolve a dependency that just doesn't exist in any of our sources, we currently get a horribly misleading error mentioning cycles that doesn't actually make any sense.

This makes sure we have some candidates first.