### PR TITLE
check so-name: fix error with apk index URL

### DIFF
--- a/pkg/cli/check_so_name.go
+++ b/pkg/cli/check_so_name.go
@@ -25,6 +25,7 @@ func SoName() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get APK packages from URL %s: %w", apkIndexURL, err)
 			}
+			o.ApkIndexURL = apkIndexURL
 
 			// get a list of new package names that have recently been built
 			newPackages, err := checks.GetNewPackages(packageListFile)


### PR DESCRIPTION
This was refactored out in https://github.com/wolfi-dev/wolfictl/pull/1296 and wasn't populated with the flag value, so all checks were failing.