### PR TITLE
Enhance scriptability of advisory `create` and `update` commands

### DIFF
--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -94,7 +94,7 @@ func resolveTimestamp(ts string) (v2.Timestamp, error) {
 }
 
 type advisoryRequestParams struct {
-	packageName, vuln, eventType, truePositiveNote, falsePositiveNote, falsePositiveType, timestamp, fixedVersion string
+	packageName, vuln, eventType, truePositiveNote, falsePositiveNote, falsePositiveType, timestamp, fixedVersion, note string
 }
 
 func (p *advisoryRequestParams) addFlags(cmd *cobra.Command) {
@@ -102,8 +102,11 @@ func (p *advisoryRequestParams) addFlags(cmd *cobra.Command) {
 	addVulnFlag(&p.vuln, cmd)
 
 	cmd.Flags().StringVarP(&p.eventType, "type", "t", "", fmt.Sprintf("type of event [%s]", strings.Join(v2.EventTypes, ", ")))
+	cmd.Flags().StringVar(&p.note, "note", "", "prose explanation to attach to the event data (can be used with any event type)")
 	cmd.Flags().StringVar(&p.truePositiveNote, "tp-note", "", "prose explanation of the true positive (used only for true positives)")
+	_ = cmd.Flags().MarkDeprecated("tp-note", "use --note instead") //nolint:errcheck
 	cmd.Flags().StringVar(&p.falsePositiveNote, "fp-note", "", "prose explanation of the false positive (used only for false positives)")
+	_ = cmd.Flags().MarkDeprecated("fp-note", "use --note instead") //nolint:errcheck
 	cmd.Flags().StringVar(&p.falsePositiveType, "fp-type", "", fmt.Sprintf("type of false positive [%s]", strings.Join(v2.FPTypes, ", ")))
 	cmd.Flags().StringVar(&p.timestamp, "timestamp", "now", "timestamp of the event (RFC3339 format)")
 	cmd.Flags().StringVar(&p.fixedVersion, "fixed-version", "", "package version where fix was applied (used only for 'fixed' event type)")
@@ -132,6 +135,9 @@ func (p *advisoryRequestParams) advisoryRequest() (advisory.Request, error) {
 		}
 	}
 
+	// For now, introduce p.note as a fallback value for event-specific notes. Then
+	// in the future, we could deprecate and remove the event-specific note flags.
+
 	switch req.Event.Type {
 	case v2.EventTypeFixed:
 		req.Event.Data = v2.Fixed{
@@ -139,14 +145,37 @@ func (p *advisoryRequestParams) advisoryRequest() (advisory.Request, error) {
 		}
 
 	case v2.EventTypeFalsePositiveDetermination:
+		note := p.falsePositiveNote
+		if note == "" {
+			note = p.note
+		}
 		req.Event.Data = v2.FalsePositiveDetermination{
 			Type: p.falsePositiveType,
-			Note: p.falsePositiveNote,
+			Note: note,
 		}
 
 	case v2.EventTypeTruePositiveDetermination:
+		note := p.truePositiveNote
+		if note == "" {
+			note = p.note
+		}
 		req.Event.Data = v2.TruePositiveDetermination{
-			Note: p.truePositiveNote,
+			Note: note,
+		}
+
+	case v2.EventTypeAnalysisNotPlanned:
+		req.Event.Data = v2.AnalysisNotPlanned{
+			Note: p.note,
+		}
+
+	case v2.EventTypeFixNotPlanned:
+		req.Event.Data = v2.FixNotPlanned{
+			Note: p.note,
+		}
+
+	case v2.EventTypePendingUpstreamFix:
+		req.Event.Data = v2.PendingUpstreamFix{
+			Note: p.note,
 		}
 	}
 

--- a/pkg/cli/advisory_create.go
+++ b/pkg/cli/advisory_create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/apk/client"
@@ -48,19 +49,44 @@ newly created advisory and any other advisories for the same package.`,
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Get initial values for distro-related parameters.
 			archs := p.archs
 			packageRepositoryURL := p.packageRepositoryURL
 			distroRepoDir := resolveDistroDir(p.distroRepoDir)
 			advisoriesRepoDir := resolveAdvisoriesDirInput(p.advisoriesRepoDir)
-			if distroRepoDir == "" || advisoriesRepoDir == "" {
-				if p.doNotDetectDistro {
-					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified")
-				}
 
+			// If we're not using auto-detection, we need to fail fast on any missing
+			// parameter values.
+			if p.doNotDetectDistro {
+				var missingParamWarnings []string
+
+				if distroRepoDir == "" {
+					missingParamWarnings = append(missingParamWarnings, fmt.Sprintf("  - distro repository directory (specify using --%s)", flagNameDistroRepoDir))
+				}
+				if advisoriesRepoDir == "" {
+					missingParamWarnings = append(missingParamWarnings, fmt.Sprintf("  - advisories repository directory (specify using --%s)", flagNameAdvisoriesRepoDir))
+				}
+				if packageRepositoryURL == "" {
+					missingParamWarnings = append(missingParamWarnings, fmt.Sprintf("  - package repository URL (specify using --%s)", flagNamePackageRepoURL))
+				}
+				if len(missingParamWarnings) > 0 {
+					return fmt.Errorf(
+						"one or more distro configuration values was left unspecified and couldn't be automatically resolved because distro auto-detection was disabled by user:\n%v",
+						strings.Join(missingParamWarnings, "\n"),
+					)
+				}
+			}
+
+			// If we made it this far, we either have all the values, or we'll be able to
+			// use auto-detection to resolve the rest.
+
+			if distroRepoDir == "" || advisoriesRepoDir == "" || packageRepositoryURL == "" {
 				d, err := distro.Detect()
 				if err != nil {
 					return fmt.Errorf("distro repo dir and/or advisories repo dir was left unspecified, and distro auto-detection failed: %w", err)
 				}
+
+				// Replace only the values that are still empty.
 
 				if len(archs) == 0 {
 					archs = d.Absolute.SupportedArchitectures
@@ -70,8 +96,14 @@ newly created advisory and any other advisories for the same package.`,
 					packageRepositoryURL = d.Absolute.APKRepositoryURL
 				}
 
-				distroRepoDir = d.Local.PackagesRepo.Dir
-				advisoriesRepoDir = d.Local.AdvisoriesRepo.Dir
+				if distroRepoDir == "" {
+					distroRepoDir = d.Local.PackagesRepo.Dir
+				}
+
+				if advisoriesRepoDir == "" {
+					advisoriesRepoDir = d.Local.AdvisoriesRepo.Dir
+				}
+
 				_, _ = fmt.Fprint(os.Stderr, renderDetectedDistro(d))
 			}
 


### PR DESCRIPTION
## Note field

This adds a new `--note` flag that can be used to specify the `note` field of the new advisory event, for any event type that needs a note specified. This proposes that `--note` could eventually replace event-type-specific flags like `--fp-note` and `--tp-note`.

The following event types are now supported with `--note`: `pending-upstream-fix`, `analysis-not-planned`, `fix-not-planned`. For true and false positives, the type-specific flag takes priority over `--note`.

These type-specific flags have also been deprecated and will be removed in a future release.

## Disabling distro auto-detection

Previously, when distro auto-detection was disabled explicitly via the CLI flag, the `packageRepositoryURL` value wasn't checked ahead of time, so bogus requests were made for the APKINDEX and an opaque error was reported to the user.

Now, if distro auto-detection is disabled, all required values are checked individually, and any missing values (that won't be filled in because of said disabling) are reported to the user in an error.

Also, if auto-detection is not disabled, missing values are now filled in.