### PR TITLE
Several linting improvements

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.61 # Please keep this in sync with the Makefile!
+          version: v1.62 # Please keep this in sync with the Makefile!

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.61
+          version: v1.61 # Please keep this in sync with the Makefile!

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ log-%:
 
 .PHONY: lint
 lint: checkfmt golangci-lint ## Run linters and checks like golangci-lint
-	$(GOLANGCI_LINT_BIN) run -n
+	$(GOLANGCI_LINT_BIN) run
 
 .PHONY: test
 test: integration ## Run go test

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ golangci-lint:
 	set -e ;\
 
 	# Please keep the installed version in sync with .github/workflows/golangci-lint.yaml
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 ;\
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0 ;\
 
 .PHONY: fmt
 fmt: ## Format all go files

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,9 @@ GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
 golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;\
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2 ;\
+
+	# Please keep the installed version in sync with .github/workflows/golangci-lint.yaml
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 ;\
 
 .PHONY: fmt
 fmt: ## Format all go files

--- a/pkg/advisory/export.go
+++ b/pkg/advisory/export.go
@@ -45,25 +45,25 @@ func ExportCSV(opts ExportOptions) (io.Reader, error) {
 					switch event.Type {
 					case v2.EventTypeTruePositiveDetermination:
 						if event.Data != nil {
-							note = event.Data.(v2.TruePositiveDetermination).Note
+							note = event.Data.(v2.TruePositiveDetermination).Note //nolint:errcheck // We're confident in this type assertion
 						}
 
 					case v2.EventTypeFalsePositiveDetermination:
-						fp, _ := event.Data.(v2.FalsePositiveDetermination) //nolint:errcheck
+						fp, _ := event.Data.(v2.FalsePositiveDetermination) //nolint:errcheck // We're confident in this type assertion
 						falsePositiveType = fp.Type
 						note = fp.Note
 
 					case v2.EventTypeFixed:
-						fixedVersion = event.Data.(v2.Fixed).FixedVersion
+						fixedVersion = event.Data.(v2.Fixed).FixedVersion //nolint:errcheck // We're confident in this type assertion
 
 					case v2.EventTypeFixNotPlanned:
-						note = event.Data.(v2.FixNotPlanned).Note
+						note = event.Data.(v2.FixNotPlanned).Note //nolint:errcheck // We're confident in this type assertion
 
 					case v2.EventTypeAnalysisNotPlanned:
-						note = event.Data.(v2.AnalysisNotPlanned).Note
+						note = event.Data.(v2.AnalysisNotPlanned).Note //nolint:errcheck // We're confident in this type assertion
 
 					case v2.EventTypePendingUpstreamFix:
-						note = event.Data.(v2.PendingUpstreamFix).Note
+						note = event.Data.(v2.PendingUpstreamFix).Note //nolint:errcheck // We're confident in this type assertion
 					}
 
 					row := []string{

--- a/pkg/advisory/secdb.go
+++ b/pkg/advisory/secdb.go
@@ -66,7 +66,7 @@ func BuildSecurityDatabase(ctx context.Context, opts BuildSecurityDatabaseOption
 				addVulnToPkgVersion := func(vulnID string) {
 					switch latest.Type {
 					case v2.EventTypeFixed:
-						version := latest.Data.(v2.Fixed).FixedVersion
+						version := latest.Data.(v2.Fixed).FixedVersion //nolint:errcheck // We're confident in this type assertion
 						secfixes[version] = append(secfixes[version], vulnID)
 						sort.Strings(secfixes[version])
 					case v2.EventTypeFalsePositiveDetermination:

--- a/pkg/cli/components/interview/interview.go
+++ b/pkg/cli/components/interview/interview.go
@@ -108,7 +108,7 @@ func (m Model[T]) updateForMessage(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Update the state.
 	var nextQuestion *question.Question[T]
 	var err error
-	m.state, nextQuestion, err = m.stack[m.stackTopIndex()].Answer.(question.MessageOnly[T])(m.state)
+	m.state, nextQuestion, err = m.stack[m.stackTopIndex()].Answer.(question.MessageOnly[T])(m.state) //nolint:errcheck // We're confident in this type assertion
 	if err != nil {
 		if errors.Is(err, question.ErrTerminate) {
 			// Exit the interview without a resulting state.
@@ -151,12 +151,12 @@ func (m Model[T]) updateForTextInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			// The user has submitted a text answer.
 			// Update the state.
-			val := m.answerComponentStackTop().(textinput.Model).Inner.Value()
+			val := m.answerComponentStackTop().(textinput.Model).Inner.Value() //nolint:errcheck // We're confident in this type assertion
 
 			// Update the state.
 			var nextQuestion *question.Question[T]
 			var err error
-			m.state, nextQuestion, err = m.stack[m.stackTopIndex()].Answer.(question.AcceptText[T])(m.state, val)
+			m.state, nextQuestion, err = m.stack[m.stackTopIndex()].Answer.(question.AcceptText[T])(m.state, val) //nolint:errcheck // We're confident in this type assertion
 			if err != nil {
 				if errors.Is(err, question.ErrTerminate) {
 					// Exit the interview without a resulting state.

--- a/pkg/cli/dot.go
+++ b/pkg/cli/dot.go
@@ -276,7 +276,7 @@ Open browser to explore crane's deps recursively, only showing a minimum subgrap
 				})
 
 				g.Go(func() error {
-					return open.Run(fmt.Sprintf("http://localhost:%d", l.Addr().(*net.TCPAddr).Port))
+					return open.Run(fmt.Sprintf("http://localhost:%d", l.Addr().(*net.TCPAddr).Port)) //nolint:errcheck // We're confident in this type assertion
 				})
 
 				g.Go(func() error {


### PR DESCRIPTION
This PR addresses a handful of items with regarding to how we **lint** the project:

1. It's really important to have parity between local dev checks and CI checks. Our `make lint` target was using a different version of golangci-lint than our CI was, and thus you couldn't anticipate CI's results by using `make lint`. This brings them into parity.
2. Bumps golangci-lint to the most recent version, v1.62.
3. Removes the `-n` flag from the `make lint` execution of `golangci-lint`, which was suppressing existing lint errors. The suppressed errors were coming from the `errcheck` linter, calling out type assertions without an explicit check (i.e. with `..., ok := something.(some_type)`).