### PR TITLE
feat: add web hyperlinks to CGA IDs

### DIFF
--- a/pkg/cli/advisory_list.go
+++ b/pkg/cli/advisory_list.go
@@ -374,7 +374,7 @@ func (r advisoryListRenderer) String() string {
 		sb.WriteString(stylePkg.Render(row.pkg))
 		sb.WriteString(strings.Repeat(" ", pkgWidth-len(row.pkg)+1))
 
-		sb.WriteString(styleAdvID.Render(row.advID))
+		sb.WriteString(styleAdvID.Render(hyperlinkVulnerabilityID(row.advID)))
 		sb.WriteString(strings.Repeat(" ", advIDWidth-len(row.advID)+1))
 
 		if r.showAliases {

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -959,6 +959,9 @@ func hyperlinkVulnerabilityID(id string) string {
 
 	case strings.HasPrefix(id, "GHSA-"):
 		return termlink.Link(id, fmt.Sprintf("https://github.com/advisories/%s", id))
+
+	case strings.HasPrefix(id, "CGA-"):
+		return termlink.Link(id, fmt.Sprintf("https://images.chainguard.dev/security/%s", id))
 	}
 
 	return id


### PR DESCRIPTION
Adds terminal hyperlinking to CGA IDs — now that we have CGA-specific pages on Chainguard's web console! 🚀 

<img width="921" alt="Screenshot 2024-11-13 at 5 42 47 PM" src="https://github.com/user-attachments/assets/3b6d9f93-787c-4e6b-b5ab-3a0829bfb8a8">
