### PR TITLE
refactor: introduce general tree output rendering

### DIFF
--- a/pkg/cli/components/scanfindings/scanfindings.go
+++ b/pkg/cli/components/scanfindings/scanfindings.go
@@ -1,0 +1,103 @@
+package scanfindings
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/tree"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/vulnid"
+	"github.com/wolfi-dev/wolfictl/pkg/scan"
+)
+
+const noVulnerabilitiesFound = "✅ No vulnerabilities found"
+
+var (
+	styleSubtle = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
+
+	styleNegligible = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
+	styleLow        = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ff00"))
+	styleMedium     = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffff00"))
+	styleHigh       = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff9900"))
+	styleCritical   = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff0000"))
+)
+
+func renderSeverity(severity string) string {
+	switch severity {
+	case "Negligible":
+		return styleNegligible.Render(severity)
+	case "Low":
+		return styleLow.Render(severity)
+	case "Medium":
+		return styleMedium.Render(severity)
+	case "High":
+		return styleHigh.Render(severity)
+	case "Critical":
+		return styleCritical.Render(severity)
+	default:
+		return severity
+	}
+}
+
+func renderVulnerabilityID(vuln scan.Vulnerability) string {
+	var cveID string
+
+	for _, alias := range vuln.Aliases {
+		if strings.HasPrefix(alias, "CVE-") {
+			cveID = alias
+			break
+		}
+	}
+
+	if cveID == "" {
+		return vulnid.Hyperlink(vuln.ID)
+	}
+
+	return fmt.Sprintf(
+		"%s %s",
+		vulnid.Hyperlink(cveID),
+
+		styleSubtle.Render(vulnid.Hyperlink(vuln.ID)),
+	)
+}
+
+func renderFixedIn(vuln scan.Vulnerability) string {
+	if vuln.FixedVersion == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(" fixed in %s", vuln.FixedVersion)
+}
+
+func Render(findings []scan.Finding) (string, error) {
+	if len(findings) == 0 {
+		return noVulnerabilitiesFound, nil
+	}
+
+	sort.Stable(scan.Findings(findings))
+
+	t, err := tree.New(findings, func(f scan.Finding) []string {
+		return []string{
+			"",
+			fmt.Sprintf("📄 %s", f.Package.Location),
+			fmt.Sprintf(
+				"📦 %s %s %s",
+				f.Package.Name,
+				f.Package.Version,
+				styleSubtle.Render("("+f.Package.Type+")"),
+			),
+			fmt.Sprintf(
+				"%s %s%s",
+				renderSeverity(f.Vulnerability.Severity),
+				renderVulnerabilityID(f.Vulnerability),
+				renderFixedIn(f.Vulnerability),
+			),
+		}
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return t.Render(), nil
+}

--- a/pkg/cli/components/tree/tree.go
+++ b/pkg/cli/components/tree/tree.go
@@ -1,0 +1,193 @@
+package tree
+
+import (
+	"errors"
+	"strings"
+)
+
+// New returns a new Tree instance that's ready to be rendered.
+//
+// It takes two parameters: leaves and renderFunc. The resulting tree will have
+// one leaf per element in the leaves slice, and each leaf's ancestors are
+// inferred from the slice returned by the renderFunc. When the tree is
+// rendered, the renderFunc is called once per leaf, and it's expected to return
+// a slice of strings, each of which are rendered versions of the leaf's
+// ancestors and the leaf itself.
+//
+// For example, let's say we use a leaves slice of []string{"ABC", "ABD", "BCD"}
+// and a renderFunc implementation that returns a slice of the individual
+// characters from the leaf string. The resulting tree would look like this:
+//
+//		 A
+//		 └─ B
+//			  C
+//			  D
+//		 B
+//		 └─ C
+//	          D
+func New[T any](leaves []T, renderFunc LeafPathPartsRenderFunc[T]) (*Tree[T], error) {
+	if renderFunc == nil {
+		return nil, errors.New("renderFunc is required")
+	}
+
+	return &Tree[T]{
+		leaves:     leaves,
+		renderFunc: renderFunc,
+	}, nil
+}
+
+// LeafPathPartsRenderFunc is a function that takes a leaf and returns a slice
+// of strings. The strings are all the path parts from the root to the leaf.
+// Each string is the rendered version of a path part.
+type LeafPathPartsRenderFunc[T any] func(leaf T) []string
+
+// NewStringSplitRenderFunc returns a LeafPathPartsRenderFunc that splits a
+// string by the given separator.
+//
+// For example, if you use a separator of "/", the render function will split
+// the leaf string by "/" and return the resulting slice.
+func NewStringSplitRenderFunc(sep string) LeafPathPartsRenderFunc[string] {
+	return func(leaf string) []string {
+		return strings.Split(leaf, sep)
+	}
+}
+
+type Tree[T any] struct {
+	leaves     []T
+	renderFunc LeafPathPartsRenderFunc[T]
+}
+
+// Render returns a string rendering of the tree.
+func (t Tree[T]) Render() string {
+	if len(t.leaves) == 0 {
+		return ""
+	}
+
+	// Define a node type to build the tree structure
+	type node struct {
+		value    string
+		children []*node
+	}
+
+	// Function to add a path to the tree, merging consecutive nodes as necessary
+	var addPath func(n *node, path []string)
+	addPath = func(n *node, path []string) {
+		if len(path) == 0 {
+			return
+		}
+
+		var child *node
+		// Check only the last child for merging
+		if len(n.children) > 0 {
+			lastChild := n.children[len(n.children)-1]
+			if lastChild.value == path[0] {
+				child = lastChild
+			}
+		}
+
+		// If the child doesn't exist or isn't the same, create it
+		if child == nil {
+			child = &node{value: path[0]}
+			n.children = append(n.children, child)
+		}
+
+		// Recursively add the rest of the path
+		addPath(child, path[1:])
+	}
+
+	// Root nodes of the tree
+	var roots []*node
+
+	// Build the tree by processing each leaf
+	for _, leaf := range t.leaves {
+		path := t.renderFunc(leaf)
+		if len(path) == 0 {
+			continue
+		}
+
+		// Add the path to the tree
+		var root *node
+		// Check only the last root for merging
+		if len(roots) > 0 {
+			lastRoot := roots[len(roots)-1]
+			if lastRoot.value == path[0] {
+				root = lastRoot
+			}
+		}
+
+		// If the root doesn't exist or isn't the same, create it
+		if root == nil {
+			root = &node{value: path[0]}
+			roots = append(roots, root)
+		}
+
+		// Add the rest of the path to the tree
+		addPath(root, path[1:])
+	}
+
+	// Function to render the tree into a string
+	var renderNode func(n *node, prefix string, level int, isLast bool) string
+	renderNode = func(n *node, prefix string, level int, isLast bool) string {
+		var sb strings.Builder
+
+		indentation := "    " // Adjust indentation as needed
+
+		// Write the node's value with appropriate indentation and prefix
+		switch {
+		case level == 0:
+			if n.value != "" {
+				sb.WriteString(n.value)
+				sb.WriteString("\n")
+			}
+		case level == 1:
+			sb.WriteString(prefix)
+			if isLast {
+				sb.WriteString("└── ")
+			} else {
+				sb.WriteString("├── ")
+			}
+			sb.WriteString(n.value)
+			sb.WriteString("\n")
+		default:
+			sb.WriteString(prefix)
+			sb.WriteString(indentation)
+			sb.WriteString(n.value)
+			sb.WriteString("\n")
+		}
+
+		// Prepare the prefix for child nodes
+		var childPrefix string
+		switch level {
+		case 0:
+			// For root nodes, prefix is empty
+			childPrefix = ""
+
+		case 1:
+			// For immediate children, adjust prefix
+			if isLast {
+				childPrefix = prefix + "    "
+			} else {
+				childPrefix = prefix + "│   "
+			}
+
+		default:
+			// For deeper levels, maintain the current prefix
+			childPrefix = prefix + indentation
+		}
+
+		// Render each child node
+		for i, child := range n.children {
+			sb.WriteString(renderNode(child, childPrefix, level+1, i == len(n.children)-1))
+		}
+
+		return sb.String()
+	}
+
+	// Build the final string by rendering each root node
+	var sb strings.Builder
+	for i, root := range roots {
+		sb.WriteString(renderNode(root, "", 0, i == len(roots)-1))
+	}
+
+	return sb.String()
+}

--- a/pkg/cli/components/tree/tree_test.go
+++ b/pkg/cli/components/tree/tree_test.go
@@ -1,0 +1,71 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTree_Render(t *testing.T) {
+	tests := []struct {
+		name       string
+		leaves     []string
+		renderFunc func(leaf string) []string
+		want       string
+	}{
+		{
+			name:       "empty tree",
+			renderFunc: NewStringSplitRenderFunc(""),
+			want:       "",
+		},
+		{
+			name:       "single leaf",
+			leaves:     []string{"A"},
+			renderFunc: NewStringSplitRenderFunc(""),
+			want:       "A\n",
+		},
+		{
+			name:       "two leaves",
+			leaves:     []string{"A", "B"},
+			renderFunc: NewStringSplitRenderFunc(""),
+			want: `A
+B
+`,
+		},
+		{
+			name:       "two leaves with common prefix",
+			leaves:     []string{"A/B", "A/C"},
+			renderFunc: NewStringSplitRenderFunc("/"),
+			want: `A
+├── B
+└── C
+`,
+		},
+		{
+			name:       "three leaves with common prefix",
+			leaves:     []string{"A/B/C", "A/B/D", "A/C"},
+			renderFunc: NewStringSplitRenderFunc("/"),
+			want: `A
+├── B
+│       C
+│       D
+└── C
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree, err := New(tt.leaves, tt.renderFunc)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			got := tree.Render()
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Render() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/cli/components/vulnid/vulnid.go
+++ b/pkg/cli/components/vulnid/vulnid.go
@@ -1,0 +1,29 @@
+package vulnid
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/savioxavier/termlink"
+)
+
+var termSupportsHyperlinks = termlink.SupportsHyperlinks()
+
+func Hyperlink(id string) string {
+	if !termSupportsHyperlinks {
+		return id
+	}
+
+	switch {
+	case strings.HasPrefix(id, "CVE-"):
+		return termlink.Link(id, fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", id))
+
+	case strings.HasPrefix(id, "GHSA-"):
+		return termlink.Link(id, fmt.Sprintf("https://github.com/advisories/%s", id))
+
+	case strings.HasPrefix(id, "CGA-"):
+		return termlink.Link(id, fmt.Sprintf("https://images.chainguard.dev/security/%s", id))
+	}
+
+	return id
+}

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -25,6 +25,7 @@ import (
 	"github.com/savioxavier/termlink"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/buildlog"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/scanfindings"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
@@ -466,7 +467,11 @@ func (p *scanParams) doScanCommandForSingleInput(
 	findings := result.Findings
 	if p.outputFormat == outputFormatOutline {
 		// Print output immediately
-		fmt.Println(NewFindingsTree(findings).Render())
+		render, err := scanfindings.Render(findings)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Print(render)
 	}
 
 	return result, nil

--- a/pkg/scan/finding.go
+++ b/pkg/scan/finding.go
@@ -19,6 +19,35 @@ type Finding struct {
 	TriageAssessments []TriageAssessment
 }
 
+type Findings []Finding
+
+func (f Findings) Len() int {
+	return len(f)
+}
+
+func (f Findings) Less(i, j int) bool {
+	fi := f[i]
+	fj := f[j]
+
+	if fi.Package.Location != fj.Package.Location {
+		return fi.Package.Location < fj.Package.Location
+	}
+
+	if fi.Package.Name != fj.Package.Name {
+		return fi.Package.Name < fj.Package.Name
+	}
+
+	if fi.Vulnerability.ID != fj.Vulnerability.ID {
+		return fi.Vulnerability.ID < fj.Vulnerability.ID
+	}
+
+	return true
+}
+
+func (f Findings) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
 type Package struct {
 	ID       string
 	Name     string


### PR DESCRIPTION
The mission of this PR is to generalize the tree rendering logic we've used in `wolfictl scan`, `wolfictl sbom`, and other consumers of this code, so that we have a central way to render these trees, and can adjust aspects of rendering as needed for future enhancements.

The updated tree rendering implementation is now used by `wolfictl scan`. (Later we'll also use this for `wolfictl sbom`.) But the old tree rendering is left in place since it is exported and used elsewhere. It will be removed in a follow-up PR.

A guiding principle is that we don't want to export logic directly from the `cli` package. But the `cli/components` package is more appropriate for exporting and reuse.

