### PR TITLE
fix(scan): results tree missing newline

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -471,7 +471,7 @@ func (p *scanParams) doScanCommandForSingleInput(
 		if err != nil {
 			return nil, err
 		}
-		fmt.Print(render)
+		fmt.Println(render)
 	}
 
 	return result, nil


### PR DESCRIPTION
This fixes a minor regression caused by #1323