### PR TITLE
fix(adv): ensure CGA IDs can be specified as the "vulnerability" in prompts without ending up as an alias

### DIFF
--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -44,26 +44,44 @@ func (req Request) VulnerabilityIDs() []string {
 	return slices.Compact(ids)
 }
 
+var (
+	// ErrEmptyPackage is returned when the Package field is empty.
+	ErrEmptyPackage = errors.New("package cannot be empty")
+
+	// ErrInvalidAdvisoryID is returned when the AdvisoryID field value is not a
+	// valid CGA ID.
+	ErrInvalidAdvisoryID = errors.New("advisory ID must be a valid CGA ID when provided")
+
+	// ErrInvalidVulnerabilityID is returned when an alias is not a valid vulnerability ID.
+	ErrInvalidVulnerabilityID = errors.New("alias must be a valid vulnerability ID")
+
+	// ErrZeroEvent is returned when the Event field is zero.
+	ErrZeroEvent = errors.New("event cannot be zero")
+)
+
 // Validate returns an error if the Request is invalid.
 func (req Request) Validate() error {
 	var errs []error
 
 	if req.Package == "" {
-		errs = append(errs, errors.New("package cannot be empty"))
+		errs = append(errs, ErrEmptyPackage)
 	}
 
 	if err := errors.Join(lo.Map(req.Aliases, func(alias string, _ int) error {
-		return vuln.ValidateID(alias)
+		if err := vuln.ValidateID(alias); err != nil {
+			return fmt.Errorf("%q: %w", alias, ErrInvalidVulnerabilityID)
+		}
+		return nil
 	})...); err != nil {
 		errs = append(errs, err)
 	}
 
 	if req.AdvisoryID != "" && !vuln.RegexCGA.MatchString(req.AdvisoryID) {
-		errs = append(errs, errors.New("advisory ID must be a valid CGA ID when provided"))
+		errs = append(errs, ErrInvalidAdvisoryID)
 	}
 
 	if req.Event.IsZero() {
-		errs = append(errs, errors.New("event cannot be zero"))
+		errs = append(errs, ErrZeroEvent)
 	}
 
 	errs = append(errs, req.Event.Validate())

--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -55,6 +55,9 @@ var (
 	// ErrInvalidVulnerabilityID is returned when an alias is not a valid vulnerability ID.
 	ErrInvalidVulnerabilityID = errors.New("alias must be a valid vulnerability ID")
 
+	// ErrCGAIDAsAlias is returned when a CGA ID is used as an alias.
+	ErrCGAIDAsAlias = errors.New("CGA ID cannot be used as an alias")
+
 	// ErrZeroEvent is returned when the Event field is zero.
 	ErrZeroEvent = errors.New("event cannot be zero")
 )
@@ -68,6 +71,10 @@ func (req Request) Validate() error {
 	}
 
 	if err := errors.Join(lo.Map(req.Aliases, func(alias string, _ int) error {
+		if vuln.RegexCGA.MatchString(alias) {
+			return ErrCGAIDAsAlias
+		}
+
 		if err := vuln.ValidateID(alias); err != nil {
 			return fmt.Errorf("%q: %w", alias, ErrInvalidVulnerabilityID)
 		}

--- a/pkg/advisory/request_test.go
+++ b/pkg/advisory/request_test.go
@@ -17,7 +17,7 @@ func TestRequest_Validate(t *testing.T) {
 			req: Request{
 				Package: "",
 			},
-			errorAssertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+			errorAssertion: func(t assert.TestingT, err error, _ ...interface{}) bool {
 				return assert.ErrorIs(t, err, ErrEmptyPackage)
 			},
 		},
@@ -27,7 +27,7 @@ func TestRequest_Validate(t *testing.T) {
 				Package:    "foo",
 				AdvisoryID: "foo",
 			},
-			errorAssertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+			errorAssertion: func(t assert.TestingT, err error, _ ...interface{}) bool {
 				return assert.ErrorIs(t, err, ErrInvalidAdvisoryID)
 			},
 		},
@@ -37,8 +37,18 @@ func TestRequest_Validate(t *testing.T) {
 				Package: "foo",
 				Aliases: []string{"foo", "bar", "baz"},
 			},
-			errorAssertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+			errorAssertion: func(t assert.TestingT, err error, _ ...interface{}) bool {
 				return assert.ErrorIs(t, err, ErrInvalidVulnerabilityID)
+			},
+		},
+		{
+			name: "CGA ID as alias",
+			req: Request{
+				Package: "foo",
+				Aliases: []string{"CGA-xxxx-xxxx-xxxx"},
+			},
+			errorAssertion: func(t assert.TestingT, err error, _ ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrCGAIDAsAlias)
 			},
 		},
 	}

--- a/pkg/advisory/request_test.go
+++ b/pkg/advisory/request_test.go
@@ -1,0 +1,51 @@
+package advisory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name           string
+		req            Request
+		errorAssertion assert.ErrorAssertionFunc
+	}{
+		{
+			name: "empty package",
+			req: Request{
+				Package: "",
+			},
+			errorAssertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrEmptyPackage)
+			},
+		},
+		{
+			name: "invalid advisory ID",
+			req: Request{
+				Package:    "foo",
+				AdvisoryID: "foo",
+			},
+			errorAssertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrInvalidAdvisoryID)
+			},
+		},
+		{
+			name: "alias with invalid vulnerability ID",
+			req: Request{
+				Package: "foo",
+				Aliases: []string{"foo", "bar", "baz"},
+			},
+			errorAssertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrInvalidVulnerabilityID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errorAssertion(t, tt.req.Validate())
+		})
+	}
+}

--- a/pkg/cli/components/advisory/prompt/model.go
+++ b/pkg/cli/components/advisory/prompt/model.go
@@ -67,6 +67,10 @@ func (m Model) newVulnerabilityFieldConfig() field.TextFieldConfiguration {
 		ID:     fieldIDVulnerability,
 		Prompt: "Vulnerability: ",
 		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
+			if vuln.RegexCGA.MatchString(value) {
+				req.AdvisoryID = value
+				return req
+			}
 			req.Aliases = append(req.Aliases, value)
 			return req
 		},


### PR DESCRIPTION
This PR adds validation to ensure CGA IDs can't be used as aliases, and it fixes an issue with the interactive prompts where the `Vulnerability: ` prompt value was being stored as an alias.