### PR TITLE
feat(scan): show context from advisory data

### DIFF
--- a/pkg/cli/styles/styles.go
+++ b/pkg/cli/styles/styles.go
@@ -11,6 +11,7 @@ var (
 	faint        = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
 	faintAccent  = lipgloss.NewStyle().Foreground(lipgloss.Color("#aaaaaa"))
 	bold         = lipgloss.NewStyle().Bold(true)
+	italic       = lipgloss.NewStyle().Italic(true)
 
 	accentedLight    = lipgloss.NewStyle().Foreground(lipgloss.Color("#000000"))
 	secondaryLight   = lipgloss.NewStyle().Foreground(lipgloss.Color("#444444"))
@@ -52,4 +53,8 @@ func FaintAccent() lipgloss.Style {
 
 func Bold() lipgloss.Style {
 	return bold
+}
+
+func Italic() lipgloss.Style {
+	return italic
 }

--- a/pkg/configs/advisory/v2/event.go
+++ b/pkg/configs/advisory/v2/event.go
@@ -141,6 +141,38 @@ func (e Event) Validate() error {
 	)
 }
 
+// Note returns the note associated with the event-specific data, if any.
+func (e Event) Note() string {
+	switch e.Type {
+	case EventTypeTruePositiveDetermination:
+		if event, ok := e.Data.(TruePositiveDetermination); ok {
+			return event.Note
+		}
+
+	case EventTypeFalsePositiveDetermination:
+		if event, ok := e.Data.(FalsePositiveDetermination); ok {
+			return event.Note
+		}
+
+	case EventTypeAnalysisNotPlanned:
+		if event, ok := e.Data.(AnalysisNotPlanned); ok {
+			return event.Note
+		}
+
+	case EventTypeFixNotPlanned:
+		if event, ok := e.Data.(FixNotPlanned); ok {
+			return event.Note
+		}
+
+	case EventTypePendingUpstreamFix:
+		if event, ok := e.Data.(PendingUpstreamFix); ok {
+			return event.Note
+		}
+	}
+
+	return ""
+}
+
 func (e Event) validateTimestamp() error {
 	if e.Timestamp.IsZero() {
 		return fmt.Errorf("timestamp must not be zero")

--- a/pkg/scan/finding.go
+++ b/pkg/scan/finding.go
@@ -10,13 +10,17 @@ import (
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/file"
 	"github.com/samber/lo"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 )
 
 // Finding represents a vulnerability finding for a single package.
 type Finding struct {
-	Package           Package
-	Vulnerability     Vulnerability
-	TriageAssessments []TriageAssessment
+	Package       Package
+	Vulnerability Vulnerability
+	Advisory      *v2.Advisory `json:",omitempty"`
+
+	// Deprecated: This field will be removed soon.
+	TriageAssessments []TriageAssessment `json:",omitempty"`
 }
 
 type Findings []Finding
@@ -64,6 +68,7 @@ type Vulnerability struct {
 	FixedVersion string
 }
 
+// Deprecated: This type will be removed soon.
 type TriageAssessment struct {
 	// Source is the name of the source of the triage assessment, e.g.
 	// "govulncheck".

--- a/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -325,8 +307,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -342,8 +323,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -361,8 +341,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "0.19.1-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -378,8 +357,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -395,8 +373,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -412,8 +389,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -431,8 +407,7 @@
           "CVE-2024-24557"
         ],
         "FixedVersion": "0.19.1-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -448,8 +423,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -465,8 +439,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -482,8 +455,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -501,8 +473,7 @@
           "CVE-2024-24787"
         ],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -518,8 +489,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -537,8 +507,7 @@
           "CVE-2024-24788"
         ],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -556,8 +525,7 @@
           "CVE-2024-24789"
         ],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -573,8 +541,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -592,8 +559,7 @@
           "CVE-2024-24790"
         ],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -609,8 +575,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -628,8 +593,7 @@
           "CVE-2023-28840"
         ],
         "FixedVersion": "23.0.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -645,8 +609,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -662,8 +625,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -681,8 +643,7 @@
           "CVE-2023-28841"
         ],
         "FixedVersion": "23.0.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -698,8 +659,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -715,8 +675,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -732,8 +691,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -751,8 +709,7 @@
           "CVE-2023-28842"
         ],
         "FixedVersion": "23.0.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -770,8 +727,7 @@
           "CVE-2023-2253"
         ],
         "FixedVersion": "2.8.2-beta.1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -787,8 +743,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": "23.0.8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -806,8 +761,7 @@
           "CVE-2024-29018"
         ],
         "FixedVersion": "23.0.11"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -823,8 +777,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -842,8 +795,7 @@
           "CVE-2024-24557"
         ],
         "FixedVersion": "24.0.9"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -325,8 +307,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -342,8 +323,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -359,8 +339,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -376,8 +355,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -393,8 +371,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -410,8 +387,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -427,8 +403,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -444,8 +419,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -461,8 +435,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -478,8 +451,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -495,8 +467,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -512,8 +483,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -529,8 +499,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -546,8 +515,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -563,8 +531,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -580,8 +547,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -597,8 +563,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -614,8 +579,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -631,8 +595,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -648,8 +611,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -665,8 +627,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -682,8 +643,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -699,8 +659,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -716,8 +675,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -733,8 +691,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -750,8 +707,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -767,8 +723,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -784,8 +739,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -801,8 +755,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -818,8 +771,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -835,8 +787,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -852,8 +803,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -869,8 +819,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -886,8 +835,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -903,8 +851,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -920,8 +867,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -937,8 +883,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -954,8 +899,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -971,8 +915,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -988,8 +931,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1005,8 +947,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1022,8 +963,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1039,8 +979,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1056,8 +995,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1073,8 +1011,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1090,8 +1027,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1107,8 +1043,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1124,8 +1059,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1141,8 +1075,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1158,8 +1091,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1175,8 +1107,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1192,8 +1123,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1209,8 +1139,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1226,8 +1155,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1243,8 +1171,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1260,8 +1187,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1277,8 +1203,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1294,8 +1219,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1311,8 +1235,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1328,8 +1251,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1345,8 +1267,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1362,8 +1283,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1379,8 +1299,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1396,8 +1315,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1413,8 +1331,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1430,8 +1347,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1447,8 +1363,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1464,8 +1379,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1481,8 +1395,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1498,8 +1411,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1515,8 +1427,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1532,8 +1443,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1549,8 +1459,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1566,8 +1475,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1583,8 +1491,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1600,8 +1507,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1617,8 +1523,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1634,8 +1539,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1651,8 +1555,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1668,8 +1571,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1685,8 +1587,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1702,8 +1603,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1719,8 +1619,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1736,8 +1635,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1753,8 +1651,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1770,8 +1667,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1787,8 +1683,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1804,8 +1699,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1821,8 +1715,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1838,8 +1731,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1855,8 +1747,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1872,8 +1763,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1889,8 +1779,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1906,8 +1795,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1923,8 +1811,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1940,8 +1827,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1957,8 +1843,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1974,8 +1859,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1991,8 +1875,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2008,8 +1891,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2025,8 +1907,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2042,8 +1923,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2059,8 +1939,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2076,8 +1955,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2093,8 +1971,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2110,8 +1987,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2127,8 +2003,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2144,8 +2019,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2161,8 +2035,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2178,8 +2051,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2195,8 +2067,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2212,8 +2083,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2229,8 +2099,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2246,8 +2115,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2265,8 +2133,7 @@
           "CVE-2023-39325"
         ],
         "FixedVersion": "1.21.3-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2282,8 +2149,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2299,8 +2165,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2316,8 +2181,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2333,8 +2197,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2350,8 +2213,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2367,8 +2229,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2384,8 +2245,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2401,8 +2261,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2418,8 +2277,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2435,8 +2293,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2452,8 +2309,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2469,8 +2325,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2486,8 +2341,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2503,8 +2357,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2520,8 +2373,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2537,8 +2389,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2554,8 +2405,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2571,8 +2421,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2588,8 +2437,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2605,8 +2453,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2622,8 +2469,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2639,8 +2485,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2656,8 +2501,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2673,8 +2517,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2690,8 +2533,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2707,8 +2549,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2724,8 +2565,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2741,8 +2581,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2758,8 +2597,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2775,8 +2613,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2792,8 +2629,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2809,8 +2645,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2826,8 +2661,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2843,8 +2677,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2860,8 +2693,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2877,8 +2709,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2894,8 +2725,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2911,8 +2741,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2928,8 +2757,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2945,8 +2773,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2962,8 +2789,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2979,8 +2805,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2996,8 +2821,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3013,8 +2837,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3030,8 +2853,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3047,8 +2869,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3064,8 +2885,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3081,8 +2901,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3098,8 +2917,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3115,8 +2933,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3132,8 +2949,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3149,8 +2965,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3166,8 +2981,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3183,8 +2997,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3200,8 +3013,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3217,8 +3029,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3234,8 +3045,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3251,8 +3061,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3268,8 +3077,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3285,8 +3093,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3302,8 +3109,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3319,8 +3125,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3336,8 +3141,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3353,8 +3157,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3372,8 +3175,7 @@
           "CVE-2023-45283"
         ],
         "FixedVersion": "1.21.5-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3389,8 +3191,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3406,8 +3207,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3423,8 +3223,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3440,8 +3239,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3457,8 +3255,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3474,8 +3271,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3491,8 +3287,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3508,8 +3303,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3525,8 +3319,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3542,8 +3335,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3559,8 +3351,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3576,8 +3367,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3593,8 +3383,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3610,8 +3399,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3627,8 +3415,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3644,8 +3431,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3661,8 +3447,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3678,8 +3463,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3695,8 +3479,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3712,8 +3495,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3729,8 +3511,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3748,8 +3529,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "1.21.9-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3765,8 +3545,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3782,8 +3561,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3799,8 +3577,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3816,8 +3593,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3833,8 +3609,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3850,8 +3625,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3867,8 +3641,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3884,8 +3657,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3901,8 +3673,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3918,8 +3689,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3935,8 +3705,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3952,8 +3721,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3969,8 +3737,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3986,8 +3753,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4003,8 +3769,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4020,8 +3785,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4037,8 +3801,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4054,8 +3817,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4071,8 +3833,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4088,8 +3849,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4105,8 +3865,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4122,8 +3881,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4139,8 +3897,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4156,8 +3913,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4173,8 +3929,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4190,8 +3945,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4207,8 +3961,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4224,8 +3977,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4241,8 +3993,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4258,8 +4009,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4275,8 +4025,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4292,8 +4041,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4309,8 +4057,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4326,8 +4073,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4343,8 +4089,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4360,8 +4105,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4377,8 +4121,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4394,8 +4137,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4411,8 +4153,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4428,8 +4169,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4445,8 +4185,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4462,8 +4201,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4479,8 +4217,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4496,8 +4233,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4513,8 +4249,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4530,8 +4265,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4547,8 +4281,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4564,8 +4297,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4581,8 +4313,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4598,8 +4329,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4615,8 +4345,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4632,8 +4361,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4649,8 +4377,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4666,8 +4393,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4683,8 +4409,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4700,8 +4425,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4717,8 +4441,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4734,8 +4457,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4751,8 +4473,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4768,8 +4489,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4785,8 +4505,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4802,8 +4521,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4819,8 +4537,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4836,8 +4553,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4853,8 +4569,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4870,8 +4585,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4887,8 +4601,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4904,8 +4617,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4921,8 +4633,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4938,8 +4649,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4955,8 +4665,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4972,8 +4681,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4989,8 +4697,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5006,8 +4713,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5023,8 +4729,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5040,8 +4745,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5057,8 +4761,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5074,8 +4777,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5091,8 +4793,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5108,8 +4809,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5125,8 +4825,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5142,8 +4841,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5159,8 +4857,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5176,8 +4873,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5193,8 +4889,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5210,8 +4905,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5227,8 +4921,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5244,8 +4937,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5261,8 +4953,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5278,8 +4969,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5295,8 +4985,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5312,8 +5001,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5329,8 +5017,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5346,8 +5033,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5363,8 +5049,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5380,8 +5065,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5397,8 +5081,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5414,8 +5097,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5431,8 +5113,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5448,8 +5129,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5465,8 +5145,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5482,8 +5161,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5499,8 +5177,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5516,8 +5193,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5533,8 +5209,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5550,8 +5225,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5567,8 +5241,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5584,8 +5257,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5601,8 +5273,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5618,8 +5289,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5635,8 +5305,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5652,8 +5321,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5669,8 +5337,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5686,8 +5353,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5703,8 +5369,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5720,8 +5385,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5737,8 +5401,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5754,8 +5417,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5771,8 +5433,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5788,8 +5449,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5805,8 +5465,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5822,8 +5481,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5839,8 +5497,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5856,8 +5513,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5873,8 +5529,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5890,8 +5545,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5907,8 +5561,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5924,8 +5577,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5941,8 +5593,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5958,8 +5609,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5975,8 +5625,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5994,8 +5643,7 @@
           "CVE-2024-24787"
         ],
         "FixedVersion": "1.21.10-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6011,8 +5659,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6028,8 +5675,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6045,8 +5691,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6062,8 +5707,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6079,8 +5723,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6096,8 +5739,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6113,8 +5755,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6130,8 +5771,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6147,8 +5787,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6164,8 +5803,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6181,8 +5819,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6198,8 +5835,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6215,8 +5851,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6232,8 +5867,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6249,8 +5883,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6266,8 +5899,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6283,8 +5915,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6300,8 +5931,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6317,8 +5947,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6334,8 +5963,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6351,8 +5979,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6370,8 +5997,7 @@
           "CVE-2024-24789"
         ],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6387,8 +6013,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6404,8 +6029,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6421,8 +6045,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6438,8 +6061,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6455,8 +6077,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6472,8 +6093,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6489,8 +6109,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6506,8 +6125,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6523,8 +6141,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6540,8 +6157,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6557,8 +6173,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6574,8 +6189,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6591,8 +6205,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6608,8 +6221,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6625,8 +6237,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6642,8 +6253,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6659,8 +6269,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6676,8 +6285,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6693,8 +6301,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6710,8 +6317,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6727,8 +6333,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6746,8 +6351,7 @@
           "CVE-2024-24790"
         ],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6763,8 +6367,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6780,8 +6383,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6797,8 +6399,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6814,8 +6415,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6831,8 +6431,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6848,8 +6447,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6865,8 +6463,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6882,8 +6479,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6899,8 +6495,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6916,8 +6511,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6933,8 +6527,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6950,8 +6543,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6967,8 +6559,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6984,8 +6575,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7001,8 +6591,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7018,8 +6607,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7035,8 +6623,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7052,8 +6639,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7069,8 +6655,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7086,8 +6671,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7103,8 +6687,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7120,8 +6703,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7137,8 +6719,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.3-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7154,8 +6735,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7171,8 +6751,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.9-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7188,8 +6767,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.10-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7205,8 +6783,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.5-r0"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -325,8 +307,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -342,8 +323,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/openssl-3.3.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/openssl-3.3.0-r0.apk.wolfictl-scan.json
@@ -21,8 +21,7 @@
           "CVE-2023-6237"
         ],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -40,8 +39,7 @@
           "CVE-2024-2511"
         ],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -59,8 +57,7 @@
           "CVE-2024-4603"
         ],
         "FixedVersion": "3.3.0-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -76,8 +73,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -93,8 +89,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.3.0-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -110,8 +105,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -21,8 +21,7 @@
           "CVE-2023-27043"
         ],
         "FixedVersion": "3.11.8-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -38,8 +37,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -55,8 +53,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -74,8 +71,7 @@
           "CVE-2023-6597"
         ],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -93,8 +89,7 @@
           "CVE-2024-0450"
         ],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -110,8 +105,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.11.8-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -127,8 +121,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -144,8 +137,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -163,8 +155,7 @@
           "CVE-2023-5752"
         ],
         "FixedVersion": "23.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -182,8 +173,7 @@
           "CVE-2022-40897"
         ],
         "FixedVersion": "65.5.1"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -327,8 +309,7 @@
           "CVE-2023-39325"
         ],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -344,8 +325,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -363,8 +343,7 @@
           "CVE-2023-3978"
         ],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -380,8 +359,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -399,8 +377,7 @@
           "CVE-2023-44487"
         ],
         "FixedVersion": "1.5.7-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -416,8 +393,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -433,8 +409,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -452,8 +427,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "1.5.7-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -469,8 +443,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -488,8 +461,7 @@
           "CVE-2023-45289"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -505,8 +477,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -524,8 +495,7 @@
           "CVE-2023-45290"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -543,8 +513,7 @@
           "CVE-2023-48795"
         ],
         "FixedVersion": "1.5.7-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -560,8 +529,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -579,8 +547,7 @@
           "CVE-2024-24783"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -596,8 +563,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -615,8 +581,7 @@
           "CVE-2024-24784"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -632,8 +597,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -651,8 +615,7 @@
           "CVE-2024-24785"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -670,8 +633,7 @@
           "CVE-2024-24786"
         ],
         "FixedVersion": "1.5.7-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -687,8 +649,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -704,8 +665,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -723,8 +683,7 @@
           "CVE-2024-24789"
         ],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -740,8 +699,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -759,8 +717,7 @@
           "CVE-2024-24790"
         ],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -778,8 +735,7 @@
           "CVE-2024-3817"
         ],
         "FixedVersion": "1.5.7-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -795,8 +751,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -814,8 +769,7 @@
           "CVE-2023-3978"
         ],
         "FixedVersion": "0.13.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -831,8 +785,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -848,8 +801,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -865,8 +817,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -884,8 +835,7 @@
           "CVE-2023-39325"
         ],
         "FixedVersion": "0.17.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -901,8 +851,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -920,8 +869,7 @@
           "CVE-2023-48795"
         ],
         "FixedVersion": "0.17.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -937,8 +885,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -954,8 +901,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -973,8 +919,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "0.23.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -990,8 +935,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1009,8 +953,7 @@
           "CVE-2024-24786"
         ],
         "FixedVersion": "1.33.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1026,8 +969,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1043,8 +985,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1060,8 +1001,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1079,8 +1019,7 @@
           "CVE-2023-0475"
         ],
         "FixedVersion": "1.7.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1096,8 +1035,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": "1.56.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1113,8 +1051,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1132,8 +1069,7 @@
           "CVE-2024-3817"
         ],
         "FixedVersion": "1.7.4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1149,8 +1085,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1168,8 +1103,7 @@
           "CVE-2023-44487"
         ],
         "FixedVersion": "0.17.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1187,8 +1121,7 @@
           "CVE-2023-44487"
         ],
         "FixedVersion": "1.56.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1204,8 +1137,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1221,8 +1153,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1240,8 +1171,7 @@
           "CVE-2022-41723"
         ],
         "FixedVersion": "0.7.0"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -174,8 +165,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "0.23.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -193,8 +183,7 @@
           "CVE-2024-24786"
         ],
         "FixedVersion": "1.33.0"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -325,8 +307,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -342,8 +323,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -361,8 +341,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "0.19.1-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -378,8 +357,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -395,8 +373,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -412,8 +389,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -431,8 +407,7 @@
           "CVE-2024-24557"
         ],
         "FixedVersion": "0.19.1-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -448,8 +423,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -465,8 +439,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -482,8 +455,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -501,8 +473,7 @@
           "CVE-2024-24787"
         ],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -518,8 +489,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -537,8 +507,7 @@
           "CVE-2024-24788"
         ],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -556,8 +525,7 @@
           "CVE-2024-24789"
         ],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -573,8 +541,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -592,8 +559,7 @@
           "CVE-2024-24790"
         ],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -609,8 +575,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -628,8 +593,7 @@
           "CVE-2023-28840"
         ],
         "FixedVersion": "23.0.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -645,8 +609,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -662,8 +625,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -681,8 +643,7 @@
           "CVE-2023-28841"
         ],
         "FixedVersion": "23.0.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -698,8 +659,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -715,8 +675,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -732,8 +691,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -751,8 +709,7 @@
           "CVE-2023-28842"
         ],
         "FixedVersion": "23.0.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -770,8 +727,7 @@
           "CVE-2023-2253"
         ],
         "FixedVersion": "2.8.2-beta.1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -787,8 +743,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": "23.0.8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -806,8 +761,7 @@
           "CVE-2024-29018"
         ],
         "FixedVersion": "23.0.11"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -823,8 +777,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "0.19.1-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -842,8 +795,7 @@
           "CVE-2024-24557"
         ],
         "FixedVersion": "24.0.9"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -325,8 +307,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -342,8 +323,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -359,8 +339,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -376,8 +355,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -393,8 +371,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -410,8 +387,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -427,8 +403,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -444,8 +419,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -461,8 +435,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -478,8 +451,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -495,8 +467,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -512,8 +483,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -529,8 +499,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -546,8 +515,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -563,8 +531,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -580,8 +547,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -597,8 +563,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -614,8 +579,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -631,8 +595,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -648,8 +611,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -665,8 +627,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -682,8 +643,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -699,8 +659,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -716,8 +675,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -733,8 +691,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -750,8 +707,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -767,8 +723,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -784,8 +739,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -801,8 +755,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -818,8 +771,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -835,8 +787,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -852,8 +803,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -869,8 +819,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -886,8 +835,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -903,8 +851,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -920,8 +867,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -937,8 +883,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -954,8 +899,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -971,8 +915,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -988,8 +931,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1005,8 +947,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1022,8 +963,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1039,8 +979,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1056,8 +995,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1073,8 +1011,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1090,8 +1027,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1107,8 +1043,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1124,8 +1059,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1141,8 +1075,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1158,8 +1091,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1175,8 +1107,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1192,8 +1123,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1209,8 +1139,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1226,8 +1155,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1243,8 +1171,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1260,8 +1187,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1277,8 +1203,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1294,8 +1219,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1311,8 +1235,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1328,8 +1251,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1345,8 +1267,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1362,8 +1283,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1379,8 +1299,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1396,8 +1315,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1413,8 +1331,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1430,8 +1347,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1447,8 +1363,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1464,8 +1379,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1481,8 +1395,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1498,8 +1411,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1515,8 +1427,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1532,8 +1443,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1549,8 +1459,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1566,8 +1475,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1583,8 +1491,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1600,8 +1507,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1617,8 +1523,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1634,8 +1539,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1651,8 +1555,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1668,8 +1571,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1685,8 +1587,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1702,8 +1603,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1719,8 +1619,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1736,8 +1635,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1753,8 +1651,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1770,8 +1667,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1787,8 +1683,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1804,8 +1699,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1821,8 +1715,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1838,8 +1731,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1855,8 +1747,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1872,8 +1763,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1889,8 +1779,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1906,8 +1795,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1923,8 +1811,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1940,8 +1827,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1957,8 +1843,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1974,8 +1859,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1991,8 +1875,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2008,8 +1891,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2025,8 +1907,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2042,8 +1923,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2059,8 +1939,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2076,8 +1955,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2093,8 +1971,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2110,8 +1987,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2127,8 +2003,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2144,8 +2019,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2161,8 +2035,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2178,8 +2051,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2195,8 +2067,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2212,8 +2083,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2229,8 +2099,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2246,8 +2115,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2265,8 +2133,7 @@
           "CVE-2023-39325"
         ],
         "FixedVersion": "1.21.3-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2282,8 +2149,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2299,8 +2165,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2316,8 +2181,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2333,8 +2197,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2350,8 +2213,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2367,8 +2229,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2384,8 +2245,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2401,8 +2261,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2418,8 +2277,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2435,8 +2293,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2452,8 +2309,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2469,8 +2325,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2486,8 +2341,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2503,8 +2357,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2520,8 +2373,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2537,8 +2389,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2554,8 +2405,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2571,8 +2421,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2588,8 +2437,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2605,8 +2453,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2622,8 +2469,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2639,8 +2485,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2656,8 +2501,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2673,8 +2517,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2690,8 +2533,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2707,8 +2549,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2724,8 +2565,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2741,8 +2581,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2758,8 +2597,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2775,8 +2613,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2792,8 +2629,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2809,8 +2645,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2826,8 +2661,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2843,8 +2677,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2860,8 +2693,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2877,8 +2709,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2894,8 +2725,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2911,8 +2741,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2928,8 +2757,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2945,8 +2773,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2962,8 +2789,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2979,8 +2805,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -2996,8 +2821,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3013,8 +2837,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3030,8 +2853,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3047,8 +2869,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3064,8 +2885,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3081,8 +2901,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3098,8 +2917,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3115,8 +2933,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3132,8 +2949,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3149,8 +2965,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3166,8 +2981,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3183,8 +2997,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3200,8 +3013,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3217,8 +3029,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3234,8 +3045,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3251,8 +3061,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3268,8 +3077,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3285,8 +3093,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3302,8 +3109,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3319,8 +3125,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3336,8 +3141,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3353,8 +3157,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3372,8 +3175,7 @@
           "CVE-2023-45283"
         ],
         "FixedVersion": "1.21.5-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3389,8 +3191,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3406,8 +3207,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3423,8 +3223,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3440,8 +3239,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3457,8 +3255,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3474,8 +3271,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3491,8 +3287,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3508,8 +3303,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3525,8 +3319,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3542,8 +3335,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3559,8 +3351,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3576,8 +3367,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3593,8 +3383,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3610,8 +3399,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3627,8 +3415,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3644,8 +3431,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3661,8 +3447,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3678,8 +3463,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3695,8 +3479,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3712,8 +3495,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3729,8 +3511,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3748,8 +3529,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "1.21.9-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3765,8 +3545,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3782,8 +3561,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3799,8 +3577,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3816,8 +3593,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3833,8 +3609,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3850,8 +3625,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3867,8 +3641,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3884,8 +3657,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3901,8 +3673,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3918,8 +3689,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3935,8 +3705,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3952,8 +3721,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3969,8 +3737,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -3986,8 +3753,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4003,8 +3769,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4020,8 +3785,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4037,8 +3801,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4054,8 +3817,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4071,8 +3833,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4088,8 +3849,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4105,8 +3865,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4122,8 +3881,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4139,8 +3897,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4156,8 +3913,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4173,8 +3929,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4190,8 +3945,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4207,8 +3961,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4224,8 +3977,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4241,8 +3993,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4258,8 +4009,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4275,8 +4025,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4292,8 +4041,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4309,8 +4057,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4326,8 +4073,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4343,8 +4089,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4360,8 +4105,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4377,8 +4121,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4394,8 +4137,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4411,8 +4153,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4428,8 +4169,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4445,8 +4185,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4462,8 +4201,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4479,8 +4217,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4496,8 +4233,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4513,8 +4249,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4530,8 +4265,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4547,8 +4281,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4564,8 +4297,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4581,8 +4313,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4598,8 +4329,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4615,8 +4345,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4632,8 +4361,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4649,8 +4377,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4666,8 +4393,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4683,8 +4409,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4700,8 +4425,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4717,8 +4441,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4734,8 +4457,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4751,8 +4473,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4768,8 +4489,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4785,8 +4505,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4802,8 +4521,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4819,8 +4537,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4836,8 +4553,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4853,8 +4569,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4870,8 +4585,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4887,8 +4601,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4904,8 +4617,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4921,8 +4633,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4938,8 +4649,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4955,8 +4665,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4972,8 +4681,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -4989,8 +4697,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5006,8 +4713,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5023,8 +4729,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5040,8 +4745,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5057,8 +4761,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5074,8 +4777,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5091,8 +4793,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5108,8 +4809,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5125,8 +4825,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5142,8 +4841,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5159,8 +4857,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5176,8 +4873,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5193,8 +4889,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5210,8 +4905,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5227,8 +4921,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5244,8 +4937,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5261,8 +4953,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5278,8 +4969,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5295,8 +4985,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5312,8 +5001,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5329,8 +5017,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5346,8 +5033,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5363,8 +5049,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5380,8 +5065,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5397,8 +5081,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5414,8 +5097,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5431,8 +5113,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5448,8 +5129,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5465,8 +5145,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5482,8 +5161,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5499,8 +5177,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5516,8 +5193,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5533,8 +5209,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5550,8 +5225,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5567,8 +5241,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5584,8 +5257,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5601,8 +5273,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5618,8 +5289,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5635,8 +5305,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5652,8 +5321,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5669,8 +5337,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5686,8 +5353,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5703,8 +5369,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5720,8 +5385,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5737,8 +5401,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5754,8 +5417,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5771,8 +5433,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5788,8 +5449,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5805,8 +5465,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5822,8 +5481,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5839,8 +5497,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5856,8 +5513,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5873,8 +5529,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5890,8 +5545,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5907,8 +5561,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5924,8 +5577,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5941,8 +5593,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5958,8 +5609,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5975,8 +5625,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -5994,8 +5643,7 @@
           "CVE-2024-24787"
         ],
         "FixedVersion": "1.21.10-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6011,8 +5659,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6028,8 +5675,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6045,8 +5691,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6062,8 +5707,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6079,8 +5723,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6096,8 +5739,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6113,8 +5755,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6130,8 +5771,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6147,8 +5787,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6164,8 +5803,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6181,8 +5819,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6198,8 +5835,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6215,8 +5851,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6232,8 +5867,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6249,8 +5883,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6266,8 +5899,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6283,8 +5915,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6300,8 +5931,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6317,8 +5947,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6334,8 +5963,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6351,8 +5979,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6370,8 +5997,7 @@
           "CVE-2024-24789"
         ],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6387,8 +6013,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6404,8 +6029,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6421,8 +6045,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6438,8 +6061,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6455,8 +6077,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6472,8 +6093,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6489,8 +6109,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6506,8 +6125,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6523,8 +6141,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6540,8 +6157,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6557,8 +6173,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6574,8 +6189,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6591,8 +6205,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6608,8 +6221,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6625,8 +6237,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6642,8 +6253,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6659,8 +6269,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6676,8 +6285,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6693,8 +6301,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6710,8 +6317,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6727,8 +6333,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6746,8 +6351,7 @@
           "CVE-2024-24790"
         ],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6763,8 +6367,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6780,8 +6383,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6797,8 +6399,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6814,8 +6415,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6831,8 +6431,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6848,8 +6447,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6865,8 +6463,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6882,8 +6479,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6899,8 +6495,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6916,8 +6511,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6933,8 +6527,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6950,8 +6543,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6967,8 +6559,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -6984,8 +6575,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7001,8 +6591,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7018,8 +6607,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7035,8 +6623,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7052,8 +6639,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7069,8 +6655,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7086,8 +6671,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7103,8 +6687,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7120,8 +6703,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7137,8 +6719,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.3-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7154,8 +6735,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.11-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7171,8 +6751,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.9-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7188,8 +6767,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.10-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -7205,8 +6783,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.21.5-r0"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -325,8 +307,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -342,8 +323,7 @@
         "Severity": "Low",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/openssl-3.3.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/openssl-3.3.0-r0.apk.wolfictl-scan.json
@@ -21,8 +21,7 @@
           "CVE-2023-6237"
         ],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -40,8 +39,7 @@
           "CVE-2024-2511"
         ],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -59,8 +57,7 @@
           "CVE-2024-4603"
         ],
         "FixedVersion": "3.3.0-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -76,8 +73,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -93,8 +89,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.3.0-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -110,8 +105,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.3.0-r5"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -21,8 +21,7 @@
           "CVE-2023-27043"
         ],
         "FixedVersion": "3.11.8-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -38,8 +37,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -55,8 +53,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -74,8 +71,7 @@
           "CVE-2023-6597"
         ],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -93,8 +89,7 @@
           "CVE-2024-0450"
         ],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -110,8 +105,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.11.8-r1"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -127,8 +121,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -144,8 +137,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "3.11.8-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -163,8 +155,7 @@
           "CVE-2023-5752"
         ],
         "FixedVersion": "23.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -182,8 +173,7 @@
           "CVE-2022-40897"
         ],
         "FixedVersion": "65.5.1"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -172,8 +163,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -189,8 +179,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -206,8 +195,7 @@
         "Severity": "Critical",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -223,8 +211,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -240,8 +227,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -257,8 +243,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -274,8 +259,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -291,8 +275,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -308,8 +291,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -327,8 +309,7 @@
           "CVE-2023-39325"
         ],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -344,8 +325,7 @@
         "Severity": "Medium",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -363,8 +343,7 @@
           "CVE-2023-3978"
         ],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -380,8 +359,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -399,8 +377,7 @@
           "CVE-2023-44487"
         ],
         "FixedVersion": "1.5.7-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -416,8 +393,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -433,8 +409,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -452,8 +427,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "1.5.7-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -469,8 +443,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -488,8 +461,7 @@
           "CVE-2023-45289"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -505,8 +477,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -524,8 +495,7 @@
           "CVE-2023-45290"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -543,8 +513,7 @@
           "CVE-2023-48795"
         ],
         "FixedVersion": "1.5.7-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -560,8 +529,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -579,8 +547,7 @@
           "CVE-2024-24783"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -596,8 +563,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -615,8 +581,7 @@
           "CVE-2024-24784"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -632,8 +597,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -651,8 +615,7 @@
           "CVE-2024-24785"
         ],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -670,8 +633,7 @@
           "CVE-2024-24786"
         ],
         "FixedVersion": "1.5.7-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -687,8 +649,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -704,8 +665,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -723,8 +683,7 @@
           "CVE-2024-24789"
         ],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -740,8 +699,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -759,8 +717,7 @@
           "CVE-2024-24790"
         ],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -778,8 +735,7 @@
           "CVE-2024-3817"
         ],
         "FixedVersion": "1.5.7-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -795,8 +751,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -814,8 +769,7 @@
           "CVE-2023-3978"
         ],
         "FixedVersion": "0.13.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -831,8 +785,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -848,8 +801,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -865,8 +817,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -884,8 +835,7 @@
           "CVE-2023-39325"
         ],
         "FixedVersion": "0.17.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -901,8 +851,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.5-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -920,8 +869,7 @@
           "CVE-2023-48795"
         ],
         "FixedVersion": "0.17.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -937,8 +885,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -954,8 +901,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r12"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -973,8 +919,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "0.23.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -990,8 +935,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r6"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1009,8 +953,7 @@
           "CVE-2024-24786"
         ],
         "FixedVersion": "1.33.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1026,8 +969,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r5"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1043,8 +985,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1060,8 +1001,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1079,8 +1019,7 @@
           "CVE-2023-0475"
         ],
         "FixedVersion": "1.7.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1096,8 +1035,7 @@
         "Severity": "High",
         "Aliases": [],
         "FixedVersion": "1.56.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1113,8 +1051,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1132,8 +1069,7 @@
           "CVE-2024-3817"
         ],
         "FixedVersion": "1.7.4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1149,8 +1085,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r8"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1168,8 +1103,7 @@
           "CVE-2023-44487"
         ],
         "FixedVersion": "0.17.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1187,8 +1121,7 @@
           "CVE-2023-44487"
         ],
         "FixedVersion": "1.56.3"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1204,8 +1137,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1221,8 +1153,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": "1.5.7-r4"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -1240,8 +1171,7 @@
           "CVE-2022-41723"
         ],
         "FixedVersion": "0.7.0"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -19,8 +19,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -36,8 +35,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -53,8 +51,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -70,8 +67,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -87,8 +83,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -104,8 +99,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -121,8 +115,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -138,8 +131,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -155,8 +147,7 @@
         "Severity": "Unknown",
         "Aliases": [],
         "FixedVersion": ""
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -174,8 +165,7 @@
           "CVE-2023-45288"
         ],
         "FixedVersion": "0.23.0"
-      },
-      "TriageAssessments": null
+      }
     },
     {
       "Package": {
@@ -193,8 +183,7 @@
           "CVE-2024-24786"
         ],
         "FixedVersion": "1.33.0"
-      },
-      "TriageAssessments": null
+      }
     }
   ],
   "GrypeDBStatus": {


### PR DESCRIPTION
For each vulnerability match, if user has provided advisory data (using `-a` / `--advisories-repo-dir`), show the latest status from the applicable advisory.

### Examples

#### neo4j

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/a1044a80-cc88-4b7e-9429-916c2b18bbc4">

#### mattermost-10.1

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/edf23abe-c189-4226-9070-9022b095b414">

This PR also deprecates the logic used for experimental triaging using govulncheck.

cc: @philroche 
