### PR TITLE
Re-use central tree component for SBOM package rendering

### DIFF
--- a/pkg/cli/components/sbompackages/sbompackages.go
+++ b/pkg/cli/components/sbompackages/sbompackages.go
@@ -1,0 +1,57 @@
+package sbompackages
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/samber/lo"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/components/tree"
+	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
+)
+
+func Render(packages []pkg.Package) (string, error) {
+	if len(packages) == 0 {
+		return "", nil
+	}
+
+	sort.SliceStable(packages, func(i, j int) bool {
+		iLoc := renderLocation(packages[i])
+		jLoc := renderLocation(packages[j])
+		if iLoc != jLoc {
+			return iLoc < jLoc
+		}
+
+		return packages[i].Name < packages[j].Name
+	})
+
+	t, err := tree.New(packages, func(p pkg.Package) []string {
+		pathParts := []string{
+			"",
+			fmt.Sprintf("📄 %s", renderLocation(p)),
+			fmt.Sprintf(
+				"📦 %s %s %s",
+				p.Name,
+				p.Version,
+				styles.Faint().Render("("+string(p.Type)+")"),
+			),
+		}
+
+		return pathParts
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return t.Render(), nil
+}
+
+func renderLocation(p pkg.Package) string {
+	locs := lo.Map(p.Locations.ToSlice(), func(l file.Location, _ int) string {
+		return "/" + l.RealPath
+	})
+
+	return strings.Join(locs, ", ")
+}

--- a/pkg/cli/components/scanfindings/scanfindings.go
+++ b/pkg/cli/components/scanfindings/scanfindings.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/tree"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/vulnid"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/styles"
@@ -15,10 +14,6 @@ import (
 )
 
 const noVulnerabilitiesFound = "✅ No vulnerabilities found"
-
-var (
-	styleSubtle = lipgloss.NewStyle().Foreground(lipgloss.Color("#999999"))
-)
 
 func renderSeverity(severity string) string {
 	switch severity {
@@ -55,7 +50,7 @@ func renderVulnerabilityID(vuln scan.Vulnerability) string {
 		"%s %s",
 		vulnid.Hyperlink(cveID),
 
-		styleSubtle.Render(vulnid.Hyperlink(vuln.ID)),
+		styles.Faint().Render(vulnid.Hyperlink(vuln.ID)),
 	)
 }
 
@@ -83,7 +78,7 @@ func renderAdvisoryPathParts(adv *v2.Advisory) []string {
 			vulnid.Hyperlink(adv.ID),
 			styles.Bold().Render(latest.Type),
 			da,
-			styleSubtle.Render("@ "+ts),
+			styles.Faint().Render("@ "+ts),
 		),
 	}
 
@@ -116,7 +111,7 @@ func Render(findings []scan.Finding) (string, error) {
 				"📦 %s %s %s",
 				f.Package.Name,
 				f.Package.Version,
-				styleSubtle.Render("("+f.Package.Type+")"),
+				styles.Faint().Render("("+f.Package.Type+")"),
 			),
 			fmt.Sprintf(
 				"%s %s%s",


### PR DESCRIPTION
Also clean up styles used in `scanfindings` component.