### PR TITLE
print full package version with image apk subcommand

### DIFF
--- a/pkg/cli/image_apk.go
+++ b/pkg/cli/image_apk.go
@@ -78,7 +78,7 @@ func cmdImageAPK() *cobra.Command {
 			if len(p.distroDirPaths) == 0 {
 				for i := range apks {
 					apk := apks[i]
-					fmt.Println(apk.Name)
+					fmt.Printf("%s (%s)\n", apk.Name, apk.Version)
 				}
 
 				return nil


### PR DESCRIPTION
```bash
$ ./wolfictl image apk cgr.dev/chainguard/wolfi-base:latest
apk-tools (2.14.4-r1)
busybox (1.37.0-r0)
ca-certificates-bundle (20241010-r2)
glibc (2.40-r3)
glibc-locale-posix (2.40-r3)
ld-linux (2.40-r3)
libcrypt1 (2.40-r3)
libcrypto3 (3.4.0-r2)
libgcc (14.2.0-r6)
libssl3 (3.4.0-r2)
libxcrypt (4.4.36-r8)
wolfi-base (1-r6)
wolfi-baselayout (20230201-r15)
wolfi-keys (1-r8)
zlib (1.3.1-r4)
```