### PR TITLE
fix(text): add context to dag construction error messages

### DIFF
--- a/pkg/cli/text.go
+++ b/pkg/cli/text.go
@@ -29,14 +29,14 @@ func cmdText() *cobra.Command {
 
 			pkgs, err := dag.NewPackages(ctx, os.DirFS(dir), dir, pipelineDir)
 			if err != nil {
-				return err
+				return fmt.Errorf("constructing new package set from directory %q: %w", dir, err)
 			}
 			g, err := dag.NewGraph(ctx, pkgs,
 				dag.WithKeys(extraKeys...),
 				dag.WithRepos(extraRepos...),
 				dag.WithArch(arch))
 			if err != nil {
-				return err
+				return fmt.Errorf("creating graph: %w", err)
 			}
 
 			return text(g, pkgs, arch, textType(t), os.Stdout)

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -257,7 +257,7 @@ func NewPackages(ctx context.Context, fsys fs.FS, dirPath, pipelineDir string) (
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("walking filesystem: %w", err)
 	}
 
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
I was trying to locally replicate an error in CI, but I hadn't set up my local environment quite right.

Here's the error that `wolfictl` gave me:

```text
Error: stat .: no such file or directory
```

That was it. 😱 

Now, it turns out that the real issue was that in CI, we clone the Wolfi `os` directory to a local directory called `wolfi-os`, and I hadn't done that on my machine. But this was impossible to know from the error.

With this PR, the error now looks like:

```text
Error: constructing new packages set from directory "wolfi-os": walking filesystem: stat .: no such file or directory
```
