### PR TITLE
feat(adv): add `-o json` option to `adv ls` command

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -36,10 +36,11 @@ import (
 
 const (
 	outputFormatOutline = "outline"
+	outputFormatTable   = "table"
 	outputFormatJSON    = "json"
 )
 
-var validOutputFormats = []string{outputFormatOutline, outputFormatJSON}
+var validScanOutputFormats = []string{outputFormatOutline, outputFormatJSON}
 
 func cmdScan() *cobra.Command {
 	p := &scanParams{}
@@ -135,11 +136,11 @@ wolfictl scan package1 package2 --remote
 
 			// Validate inputs
 
-			if !slices.Contains(validOutputFormats, p.outputFormat) {
+			if !slices.Contains(validScanOutputFormats, p.outputFormat) {
 				return fmt.Errorf(
 					"invalid output format %q, must be one of [%s]",
 					p.outputFormat,
-					strings.Join(validOutputFormats, ", "),
+					strings.Join(validScanOutputFormats, ", "),
 				)
 			}
 
@@ -355,7 +356,7 @@ type scanParams struct {
 func (p *scanParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&p.requireZeroFindings, "require-zero", false, "exit 1 if any vulnerabilities are found")
 	cmd.Flags().StringVar(&p.localDBFilePath, "local-file-grype-db", "", "import a local grype db file")
-	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", "", fmt.Sprintf("output format (%s), defaults to %s", strings.Join(validOutputFormats, "|"), outputFormatOutline))
+	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", "", fmt.Sprintf("output format (%s), defaults to %s", strings.Join(validScanOutputFormats, "|"), outputFormatOutline))
 	cmd.Flags().BoolVarP(&p.sbomInput, "sbom", "s", false, "treat input(s) as SBOM(s) of APK(s) instead of as actual APK(s)")
 	cmd.Flags().BoolVar(&p.packageBuildLogInput, "build-log", false, "treat input as a package build log file (or a directory that contains a packages.log file)")
 	cmd.Flags().StringVar(&p.distro, "distro", "wolfi", "distro to use during vulnerability matching")

--- a/pkg/configs/advisory/v2/advisory.go
+++ b/pkg/configs/advisory/v2/advisory.go
@@ -13,14 +13,14 @@ import (
 )
 
 type Advisory struct {
-	ID string `yaml:"id"`
+	ID string `yaml:"id" json:"id"`
 
 	// Aliases lists any known IDs of this vulnerability in databases.
-	Aliases []string `yaml:"aliases,omitempty"`
+	Aliases []string `yaml:"aliases,omitempty" json:"aliases"`
 
 	// Events is a list of timestamped events that occurred during the investigation
 	// and resolution of the vulnerability.
-	Events []Event `yaml:"events"`
+	Events []Event `yaml:"events" json:"events"`
 }
 
 // IsZero returns true if the advisory has no data.

--- a/pkg/configs/advisory/v2/analysis_not_planned.go
+++ b/pkg/configs/advisory/v2/analysis_not_planned.go
@@ -7,7 +7,7 @@ import "errors"
 // analyzed further by the distro maintainers.
 type AnalysisNotPlanned struct {
 	// Note should explain why there is no plan to analyze the vulnerability match.
-	Note string `yaml:"note"`
+	Note string `yaml:"note" json:"note"`
 }
 
 // Validate returns an error if the AnalysisNotPlanned data is invalid.

--- a/pkg/configs/advisory/v2/detection.go
+++ b/pkg/configs/advisory/v2/detection.go
@@ -30,10 +30,10 @@ var (
 // detected for a distro package.
 type Detection struct {
 	// Type is the type of detection used to identify the vulnerability match.
-	Type string `yaml:"type"`
+	Type string `yaml:"type" json:"type"`
 
 	// Data is the data associated with the detection type.
-	Data interface{} `yaml:"data,omitempty"`
+	Data interface{} `yaml:"data,omitempty" json:"data,omitempty"`
 }
 
 // Validate returns an error if the Detection data is invalid.

--- a/pkg/configs/advisory/v2/document.go
+++ b/pkg/configs/advisory/v2/document.go
@@ -18,9 +18,9 @@ import (
 const SchemaVersion = "2.0.2"
 
 type Document struct {
-	SchemaVersion string     `yaml:"schema-version"`
-	Package       Package    `yaml:"package"`
-	Advisories    Advisories `yaml:"advisories,omitempty"`
+	SchemaVersion string     `yaml:"schema-version" json:"schemaVersion"`
+	Package       Package    `yaml:"package" json:"package"`
+	Advisories    Advisories `yaml:"advisories,omitempty" json:"advisories"`
 }
 
 func (doc Document) Name() string {
@@ -79,7 +79,7 @@ func decodeDocument(r io.Reader) (*Document, error) {
 }
 
 type Package struct {
-	Name string `yaml:"name"`
+	Name string `yaml:"name" json:"name"`
 }
 
 func (p Package) Validate() error {

--- a/pkg/configs/advisory/v2/event.go
+++ b/pkg/configs/advisory/v2/event.go
@@ -47,15 +47,15 @@ var (
 // and resolution of a potential vulnerability match.
 type Event struct {
 	// Timestamp is the time at which the event occurred.
-	Timestamp Timestamp `yaml:"timestamp"`
+	Timestamp Timestamp `yaml:"timestamp" json:"timestamp"`
 
 	// Type is a string that identifies the kind of event. This field is used to
 	// determine how to unmarshal the Data field.
-	Type string `yaml:"type"`
+	Type string `yaml:"type" json:"type"`
 
 	// Data is the event-specific data. The type of this field is determined by the
 	// Type field.
-	Data interface{} `yaml:"data,omitempty"`
+	Data interface{} `yaml:"data,omitempty" json:"data,omitempty"`
 }
 
 type partialEvent struct {

--- a/pkg/configs/advisory/v2/false_positive_determination.go
+++ b/pkg/configs/advisory/v2/false_positive_determination.go
@@ -81,8 +81,8 @@ var FPTypes = []string{
 // FalsePositiveDetermination is an event that indicates that a previously
 // detected vulnerability was determined to be a false positive.
 type FalsePositiveDetermination struct {
-	Type string `yaml:"type"`
-	Note string `yaml:"note,omitempty"`
+	Type string `yaml:"type" json:"type"`
+	Note string `yaml:"note,omitempty" json:"note"`
 }
 
 func (fp FalsePositiveDetermination) Validate() error {

--- a/pkg/configs/advisory/v2/fix_not_planned.go
+++ b/pkg/configs/advisory/v2/fix_not_planned.go
@@ -6,7 +6,7 @@ import "errors"
 // not to receive a fix for the vulnerability.
 type FixNotPlanned struct {
 	// Note should explain why there is no plan to fix the vulnerability.
-	Note string `yaml:"note"`
+	Note string `yaml:"note" json:"note"`
 }
 
 // Validate returns an error if the FixNotPlanned data is invalid.

--- a/pkg/configs/advisory/v2/fixed.go
+++ b/pkg/configs/advisory/v2/fixed.go
@@ -11,7 +11,7 @@ import (
 type Fixed struct {
 	// FixedVersion is the version of the distribution package that contains
 	// the fix to the vulnerability.
-	FixedVersion string `yaml:"fixed-version"`
+	FixedVersion string `yaml:"fixed-version" json:"fixedVersion"`
 }
 
 // Validate returns an error if the Fixed data is invalid.

--- a/pkg/configs/advisory/v2/pending_upstream_fix.go
+++ b/pkg/configs/advisory/v2/pending_upstream_fix.go
@@ -13,7 +13,7 @@ import "errors"
 // changes that should be managed by the upstream maintainers.
 type PendingUpstreamFix struct {
 	// Note should explain why an upstream fix is anticipated or necessary.
-	Note string `yaml:"note"`
+	Note string `yaml:"note" json:"note"`
 }
 
 // Validate returns an error if the PendingUpstreamFix data is invalid.

--- a/pkg/configs/advisory/v2/timestamp.go
+++ b/pkg/configs/advisory/v2/timestamp.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -16,6 +17,11 @@ func Now() Timestamp {
 }
 
 const yamlTagTimestamp = "!!timestamp" // see https://yaml.org/type/timestamp.html
+
+// MarshalJSON implements json.Marshaler.
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
 
 // MarshalYAML implements yaml.Marshaler.
 func (t Timestamp) MarshalYAML() (interface{}, error) {

--- a/pkg/configs/advisory/v2/true_positive_determination.go
+++ b/pkg/configs/advisory/v2/true_positive_determination.go
@@ -3,5 +3,5 @@ package v2
 // TruePositiveDetermination is an event that indicates that a previously
 // detected vulnerability was acknowledged to be a true positive.
 type TruePositiveDetermination struct {
-	Note string `yaml:"note,omitempty"`
+	Note string `yaml:"note,omitempty" json:"note"`
 }


### PR DESCRIPTION
The `adv ls` command is a nifty way to zoom into particular aspects of advisory data pretty quickly. The existing command rendered a terminal-friendly table, but the output is not really machine-readable.

This PR adds a new `--output`/`-o` flag, whose value defaults to `table` (the existing rendering mechanism), but where users can now pass `json` to produce machine-readable data from the `adv ls` query.

#### Example

```console
$ wolfictl adv ls --type fp --updated-since 2024-11-20 -o json | jq
[
  {
    "schemaVersion": "2.0.2",
    "package": {
      "name": "akhq"
    },
    "advisories": [
      {
        "id": "CGA-2hmx-pc95-g53j",
        "aliases": [
          "CVE-2024-47535",
          "GHSA-xq3w-v528-46rv"
        ],
        "events": [
          {
            "timestamp": "2024-11-20T20:00:27Z",
            "type": "false-positive-determination",
            "data": {
              "type": "vulnerable-code-cannot-be-controlled-by-adversary",
              "note": "Vulnerability affects only Windows systems."
# ...
```

Closes #1341