### PR TITLE
ci: remove wolfictl text check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,45 +34,6 @@ jobs:
       - run: make wolfictl
       - run: make test
 
-  wolfictl-text:
-    permissions:
-      contents: read
-
-    name: wolfictl text on wolfi-dev/os
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
-        with:
-          go-version-file: 'go.mod'
-          check-latest: true
-
-      - run: make wolfictl
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: 'wolfi-dev/os'
-          path: 'wolfi-os'
-      - name: Test Wolfi OS repo
-        run: |
-          ./wolfictl text -d wolfi-os \
-            --type=name \
-            --pipeline-dir=wolfi-os/pipelines/ \
-            --keyring-append=https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub \
-            --repository-append=https://packages.wolfi.dev/bootstrap/stage3
-
-      - name: Test nested repo structure
-        run: |
-          ./wolfictl text -d testdata/text/ | grep foo-0.0.2-r0
-          ./wolfictl text -d testdata/text/ | grep bar-0.0.1-r0
-          ./wolfictl text -d testdata/text/ | grep root-0.0.1-r0
-
-
   docs:
     permissions:
       contents: read


### PR DESCRIPTION
This check will routinely fail until build graph completeness is guaranteed in Wolfi itself.

Until then, this check is only causing noise and meaningless red Xs in wolfictl.

cc: @imjasonh @jonjohnsonjr 