### PR TITLE
fix(osv): stop adding ID of record to "related" too

### DIFF
--- a/pkg/advisory/osv.go
+++ b/pkg/advisory/osv.go
@@ -156,9 +156,9 @@ func BuildOSVDataset(ctx context.Context, opts OSVOptions) error {
 					continue
 				}
 
-				// Note: The OSV data should include our advisory ID itself among the listed
-				// related vulnerability IDs.
-				related := append([]string{adv.ID}, adv.Aliases...)
+				// TODO: Use the 'upstream' field instead of 'related'. See https://github.com/ossf/osv-schema/pull/312.
+				//  Make sure to communicate to data consumers ahead of this change, though!
+				related := adv.Aliases
 
 				affecteds := make([]models.Affected, 0, len(affectedPackages))
 				for _, pkg := range affectedPackages {

--- a/pkg/advisory/testdata/osv/expected/CGA-37qj-pjrf-fmrw.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-37qj-pjrf-fmrw.json
@@ -2,7 +2,6 @@
   "modified": "2022-09-15T02:40:18Z",
   "id": "CGA-37qj-pjrf-fmrw",
   "related": [
-    "CGA-37qj-pjrf-fmrw",
     "CVE-2020-8927"
   ],
   "affected": [

--- a/pkg/advisory/testdata/osv/expected/CGA-5f5c-53mg-6p2v.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-5f5c-53mg-6p2v.json
@@ -2,7 +2,6 @@
   "modified": "2023-05-04T14:34:34Z",
   "id": "CGA-5f5c-53mg-6p2v",
   "related": [
-    "CGA-5f5c-53mg-6p2v",
     "GHSA-33pg-m6jh-5237"
   ],
   "affected": [

--- a/pkg/advisory/testdata/osv/expected/CGA-6mjr-v678-c6gm.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-6mjr-v678-c6gm.json
@@ -2,7 +2,6 @@
   "modified": "2023-02-07T16:50:17Z",
   "id": "CGA-6mjr-v678-c6gm",
   "related": [
-    "CGA-6mjr-v678-c6gm",
     "CVE-2022-4450"
   ],
   "affected": [

--- a/pkg/advisory/testdata/osv/expected/CGA-gg4h-ppqq-vf35.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-gg4h-ppqq-vf35.json
@@ -2,7 +2,6 @@
   "modified": "2023-05-04T14:34:34Z",
   "id": "CGA-gg4h-ppqq-vf35",
   "related": [
-    "CGA-gg4h-ppqq-vf35",
     "GHSA-6wrf-mxfj-pf5p"
   ],
   "affected": [

--- a/pkg/advisory/testdata/osv/expected/CGA-mm7m-x6cw-5fg4.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-mm7m-x6cw-5fg4.json
@@ -2,7 +2,6 @@
   "modified": "2023-04-08T16:32:54Z",
   "id": "CGA-mm7m-x6cw-5fg4",
   "related": [
-    "CGA-mm7m-x6cw-5fg4",
     "CVE-2023-0466"
   ],
   "affected": [

--- a/pkg/advisory/testdata/osv/expected/CGA-vj68-6p3f-8xmr.json
+++ b/pkg/advisory/testdata/osv/expected/CGA-vj68-6p3f-8xmr.json
@@ -2,7 +2,6 @@
   "modified": "2023-03-28T14:54:27Z",
   "id": "CGA-vj68-6p3f-8xmr",
   "related": [
-    "CGA-vj68-6p3f-8xmr",
     "CVE-2023-0465"
   ],
   "affected": [


### PR DESCRIPTION
The inclusion of the OSV record's ID as a related record was never necessary, and caused confusion downstream, such as on osv.dev.
