### PR TITLE
pkg/apk: don't log requests

### DIFF
--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -22,7 +22,7 @@ type Context struct {
 
 func New(client *http.Client, indexURL string) Context {
 	rc := retryablehttp.NewClient()
-	//	rc.Logger = log.New(io.Discard, "", 0) // Don't log requests at all.
+	rc.Logger = log.New(io.Discard, "", 0) // Don't log requests at all.
 	rc.HTTPClient = client
 	return Context{
 		client:   rc.StandardClient(),

--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -22,6 +22,7 @@ type Context struct {
 
 func New(client *http.Client, indexURL string) Context {
 	rc := retryablehttp.NewClient()
+	//	rc.Logger = log.New(io.Discard, "", 0) // Don't log requests at all.
 	rc.HTTPClient = client
 	return Context{
 		client:   rc.StandardClient(),


### PR DESCRIPTION
hashi's retryablehttp debug-logs every request, which is noisy and incompatible with `log/slog` (https://github.com/hashicorp/go-retryablehttp/issues/211), so let's just make it totally quiet until we can make it debug-quiet.

Before

```
go test ./pkg/apk -v -run=Test_getApkPackages
=== RUN   Test_getApkPackages
2025/01/08 09:20:59 [DEBUG] GET http://127.0.0.1:58527/APKINDEX.tar.gz
2025/01/08 09:20:59 found 2 latest apk index package versions
--- PASS: Test_getApkPackages (0.00s)
PASS
ok      github.com/wolfi-dev/wolfictl/pkg/apk   0.306s
```

After

```
go test ./pkg/apk -v -run=Test_getApkPackages
=== RUN   Test_getApkPackages
2025/01/08 09:20:52 found 2 latest apk index package versions
--- PASS: Test_getApkPackages (0.00s)
PASS
ok      github.com/wolfi-dev/wolfictl/pkg/apk   0.327s
```