### PR TITLE
remove --verbosity flag in favor of --log-level

### DIFF
--- a/docs/cmd/wolfictl_advisory_osv.md
+++ b/docs/cmd/wolfictl_advisory_osv.md
@@ -37,7 +37,6 @@ directory must already exist before running the command.
   -h, --help                          help for osv
   -o, --output string                 path to a local directory in which the OSV dataset will be written
   -p, --packages-repo-dir strings     path to the directory(ies) containing Chainguard package data
-  -v, --verbose count                 logging verbosity (v = info, vv = debug, default is none)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/wolfictl_advisory_validate.md
+++ b/docs/cmd/wolfictl_advisory_validate.md
@@ -60,7 +60,6 @@ print an error message that specifies where and how the data is invalid.
       --skip-alias                         skip alias completeness validation (default true)
       --skip-diff                          skip diff-based validations
       --skip-existence                     skip package configuration existence validation
-  -v, --verbose count                      logging verbosity (v = info, vv = debug, default is none)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/wolfictl_advisory_validate_fixes.md
+++ b/docs/cmd/wolfictl_advisory_validate_fixes.md
@@ -19,7 +19,6 @@ Validate fixes recorded in advisories
   -b, --built-packages-dir string    directory containing built packages
       --distro string                distro to use during vulnerability matching (default "wolfi")
   -h, --help                         help for fixes
-  -v, --verbose count                logging verbosity (v = info, vv = debug, default is none)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/wolfictl_scan.md
+++ b/docs/cmd/wolfictl_scan.md
@@ -106,7 +106,6 @@ wolfictl scan package1 package2 --remote
       --require-zero                 exit 1 if any vulnerabilities are found
   -s, --sbom                         treat input(s) as SBOM(s) of APK(s) instead of as actual APK(s)
       --use-cpes                     turn on all CPE matching in Grype
-  -v, --verbose count                logging verbosity (v = info, vv = debug, default is none)
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/wolfictl-advisory-osv.1
+++ b/docs/man/man1/wolfictl-advisory-osv.1
@@ -57,10 +57,6 @@ directory must already exist before running the command.
 \fB\-p\fP, \fB\-\-packages\-repo\-dir\fP=[]
     path to the directory(ies) containing Chainguard package data
 
-.PP
-\fB\-v\fP, \fB\-\-verbose\fP[=0]
-    logging verbosity (v = info, vv = debug, default is none)
-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/wolfictl-advisory-validate-fixes.1
+++ b/docs/man/man1/wolfictl-advisory-validate-fixes.1
@@ -35,10 +35,6 @@ Validate fixes recorded in advisories
 \fB\-h\fP, \fB\-\-help\fP[=false]
     help for fixes
 
-.PP
-\fB\-v\fP, \fB\-\-verbose\fP[=0]
-    logging verbosity (v = info, vv = debug, default is none)
-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/wolfictl-advisory-validate.1
+++ b/docs/man/man1/wolfictl-advisory-validate.1
@@ -119,10 +119,6 @@ print an error message that specifies where and how the data is invalid.
 \fB\-\-skip\-existence\fP[=false]
     skip package configuration existence validation
 
-.PP
-\fB\-v\fP, \fB\-\-verbose\fP[=0]
-    logging verbosity (v = info, vv = debug, default is none)
-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/wolfictl-scan.1
+++ b/docs/man/man1/wolfictl-scan.1
@@ -154,10 +154,6 @@ found and the \-\-require\-zero flag is specified.
 \fB\-\-use\-cpes\fP[=false]
     turn on all CPE matching in Grype
 
-.PP
-\fB\-v\fP, \fB\-\-verbose\fP[=0]
-    logging verbosity (v = info, vv = debug, default is none)
-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"sort"
 	"strings"
@@ -10,7 +9,6 @@ import (
 
 	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/melange/pkg/config"
-	charmlog "github.com/charmbracelet/log"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
@@ -18,7 +16,6 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
-	"github.com/wolfi-dev/wolfictl/pkg/internal"
 	"github.com/wolfi-dev/wolfictl/pkg/versions"
 	"github.com/wolfi-dev/wolfictl/pkg/vuln"
 )
@@ -218,29 +215,6 @@ func addNoDistroDetectionFlag(val *bool, cmd *cobra.Command) {
 
 func addPackageRepoURLFlag(val *string, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(val, flagNamePackageRepoURL, "r", "", "URL of the APK package repository")
-}
-
-func addVerboseFlag(val *int, cmd *cobra.Command) {
-	cmd.Flags().CountVarP(val, "verbose", "v", "logging verbosity (v = info, vv = debug, default is none)")
-}
-
-func newLogger(verbosity int) *slog.Logger {
-	var level charmlog.Level
-	switch {
-	case verbosity == 1:
-		level = charmlog.InfoLevel
-	case verbosity >= 2:
-		level = charmlog.DebugLevel
-	default:
-		return internal.NopLogger()
-	}
-
-	cl := charmlog.NewWithOptions(os.Stderr, charmlog.Options{
-		Level:           level,
-		ReportTimestamp: true,
-	})
-
-	return slog.New(cl)
 }
 
 func newAllowedFixedVersionsFunc(apkindexes []*apk.APKIndex, buildCfgs *configs.Index[config.Configuration]) func(packageName string) []string {

--- a/pkg/cli/advisory_osv.go
+++ b/pkg/cli/advisory_osv.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"chainguard.dev/melange/pkg/config"
-	"github.com/chainguard-dev/clog"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 	"github.com/wolfi-dev/wolfictl/pkg/configs"
@@ -40,8 +39,7 @@ directory must already exist before running the command.
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			logger := clog.NewLogger(newLogger(p.verbosity))
-			ctx := clog.WithLogger(cmd.Context(), logger)
+			ctx := cmd.Context()
 
 			if len(p.advisoriesRepoDirs) == 0 {
 				return fmt.Errorf("at least one advisory repository directory must be specified")
@@ -110,12 +108,10 @@ type osvParams struct {
 	advisoriesRepoDirs []string
 	packagesRepoDirs   []string
 	outputDirectory    string
-	verbosity          int
 }
 
 func (p *osvParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&p.advisoriesRepoDirs, "advisories-repo-dir", "a", nil, "path to the directory(ies) containing Chainguard advisory data")
 	cmd.Flags().StringSliceVarP(&p.packagesRepoDirs, "packages-repo-dir", "p", nil, "path to the directory(ies) containing Chainguard package data")
 	cmd.Flags().StringVarP(&p.outputDirectory, "output", "o", "", "path to a local directory in which the OSV dataset will be written")
-	addVerboseFlag(&p.verbosity, cmd)
 }

--- a/pkg/cli/advisory_validate.go
+++ b/pkg/cli/advisory_validate.go
@@ -64,14 +64,14 @@ print an error message that specifies where and how the data is invalid.`,
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			logger := clog.FromContext(cmd.Context())
 			var advisoriesRepoDir string
 			var advisoriesRepoUpstreamHTTPSURL string
 			var advisoriesRepoForkPoint string
 			var packagesRepoDir string
 			var apkRepositoryURL string
 
-			logger := clog.NewLogger(newLogger(p.verbosity))
-			ctx := clog.WithLogger(cmd.Context(), logger)
+			ctx := cmd.Context()
 
 			if p.doNotDetectDistro {
 				logger.Debug("distro auto-detection disabled")
@@ -232,7 +232,6 @@ type validateParams struct {
 	skipAliasCompletenessValidation bool
 	skipPackageExistenceValidation  bool
 	packageRepositoryURL            string
-	verbosity                       int
 }
 
 const (
@@ -246,7 +245,6 @@ const (
 func (p *validateParams) addFlagsTo(cmd *cobra.Command) {
 	addNoDistroDetectionFlag(&p.doNotDetectDistro, cmd)
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
-	addVerboseFlag(&p.verbosity, cmd)
 	cmd.Flags().StringVar(&p.advisoriesRepoUpstreamHTTPSURL, flagNameAdvisoriesRepoURL, "", "HTTPS URL of the upstream Git remote for the advisories repo")
 	cmd.Flags().StringVar(&p.advisoriesRepoBaseHash, flagNameAdvisoriesRepoBaseHash, "", "commit hash of the upstream repo to which the current state will be compared in the diff")
 	addDistroDirFlag(&p.packagesRepoDir, cmd)

--- a/pkg/cli/advisory_validate_fixes.go
+++ b/pkg/cli/advisory_validate_fixes.go
@@ -27,8 +27,8 @@ func cmdAdvisoryValidateFixes() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			logger := clog.NewLogger(newLogger(p.verbosity))
-			ctx := clog.WithLogger(cmd.Context(), logger)
+			ctx := cmd.Context()
+			logger := clog.FromContext(ctx)
 
 			if p.advisoriesRepoDir == "" {
 				return fmt.Errorf("need --%s", flagNameAdvisoriesRepoDir)
@@ -107,13 +107,11 @@ func cmdAdvisoryValidateFixes() *cobra.Command {
 type validateFixesParams struct {
 	advisoriesRepoDir string
 	builtPackagesDir  string
-	verbosity         int
 	distro            string
 }
 
 func (p *validateFixesParams) addFlagsToCommand(cmd *cobra.Command) {
 	addAdvisoriesDirFlag(&p.advisoriesRepoDir, cmd)
-	addVerboseFlag(&p.verbosity, cmd)
 
 	cmd.Flags().StringVarP(&p.builtPackagesDir, flagNameBuiltPackagesDir, "b", "", "directory containing built packages")
 	cmd.Flags().StringVar(&p.distro, "distro", "wolfi", "distro to use during vulnerability matching")

--- a/pkg/cli/sbom.go
+++ b/pkg/cli/sbom.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	sbomSyft "github.com/anchore/syft/syft/sbom"
-	"github.com/chainguard-dev/clog"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/cli/components/sbompackages"
 	"github.com/wolfi-dev/wolfictl/pkg/sbom"
@@ -28,8 +27,7 @@ func cmdSBOM() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := clog.NewLogger(newLogger(p.verbosity))
-			ctx := clog.WithLogger(cmd.Context(), logger)
+			ctx := cmd.Context()
 
 			if !slices.Contains([]string{sbomFormatOutline, sbomFormatSyftJSON}, p.outputFormat) {
 				return fmt.Errorf("invalid output format %q, must be one of [%s]", p.outputFormat, strings.Join([]string{sbomFormatOutline, sbomFormatSyftJSON}, ", "))
@@ -89,12 +87,10 @@ type sbomParams struct {
 	outputFormat     string
 	distro           string
 	disableSBOMCache bool
-	verbosity        int
 }
 
 func (p *sbomParams) addFlagsTo(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&p.outputFormat, "output", "o", sbomFormatOutline, "output format (outline, syft-json)")
 	cmd.Flags().StringVar(&p.distro, "distro", "wolfi", "distro to report in SBOM")
 	cmd.Flags().BoolVarP(&p.disableSBOMCache, "disable-sbom-cache", "D", false, "don't use the SBOM cache")
-	addVerboseFlag(&p.verbosity, cmd)
 }

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -127,8 +127,8 @@ wolfictl scan package1 package2 --remote
 		Args:          cobra.MinimumNArgs(1),
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := clog.NewLogger(newLogger(p.verbosity))
-			ctx := clog.WithLogger(cmd.Context(), logger)
+			ctx := cmd.Context()
+			logger := clog.FromContext(ctx)
 
 			if p.outputFormat == "" {
 				p.outputFormat = outputFormatOutline
@@ -350,7 +350,6 @@ type scanParams struct {
 	triageWithGoVulnCheck bool
 	remoteScanning        bool
 	useCPEMatching        bool
-	verbosity             int
 }
 
 func (p *scanParams) addFlagsTo(cmd *cobra.Command) {
@@ -367,7 +366,6 @@ func (p *scanParams) addFlagsTo(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkHidden("govulncheck") //nolint:errcheck
 	cmd.Flags().BoolVarP(&p.remoteScanning, "remote", "r", false, "treat input(s) as the name(s) of package(s) in the Wolfi package repository to download and scan the latest versions of")
 	cmd.Flags().BoolVar(&p.useCPEMatching, "use-cpes", false, "turn on all CPE matching in Grype")
-	addVerboseFlag(&p.verbosity, cmd)
 }
 
 func (p *scanParams) resolveInputsToScan(ctx context.Context, args []string) (inputs []string, cleanup func() error, err error) {


### PR DESCRIPTION
This aligns wolfictl's debug-logging flag across all its commands to use `--log-level` and the top-level charmbracelet logger, instead of having different ones for certain commands.