### PR TITLE
fix: logging started getting pretty noisy

### DIFF
--- a/docs/cmd/wolfictl.md
+++ b/docs/cmd/wolfictl.md
@@ -10,7 +10,7 @@ A CLI helper for developing Wolfi
 
 ```
   -h, --help               help for wolfictl
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory.md
+++ b/docs/cmd/wolfictl_advisory.md
@@ -17,7 +17,7 @@ Commands for consuming and maintaining security advisory data
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_alias.md
+++ b/docs/cmd/wolfictl_advisory_alias.md
@@ -15,7 +15,7 @@ Commands for discovering vulnerability aliases
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_alias_discover.md
+++ b/docs/cmd/wolfictl_advisory_alias_discover.md
@@ -51,7 +51,7 @@ than attempting any kind of merge of the separate advisories.
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_alias_find.md
+++ b/docs/cmd/wolfictl_advisory_alias_find.md
@@ -47,7 +47,7 @@ hyperlinked to the relevant webpage from the upstream data source.
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_copy.md
+++ b/docs/cmd/wolfictl_advisory_copy.md
@@ -31,7 +31,7 @@ of the event to now. The command will not copy events of type "detection", "fixe
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_create.md
+++ b/docs/cmd/wolfictl_advisory_create.md
@@ -53,7 +53,7 @@ newly created advisory and any other advisories for the same package.
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_diff.md
+++ b/docs/cmd/wolfictl_advisory_diff.md
@@ -21,7 +21,7 @@ See the advisory data differences introduced by your local changes
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_discover.md
+++ b/docs/cmd/wolfictl_advisory_discover.md
@@ -27,7 +27,7 @@ Automatically create advisories by matching distro packages to vulnerabilities i
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_guide.md
+++ b/docs/cmd/wolfictl_advisory_guide.md
@@ -22,7 +22,7 @@ Launch an interactive guide to help you enter advisory data for a package
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_guide_graph.md
+++ b/docs/cmd/wolfictl_advisory_guide_graph.md
@@ -21,7 +21,7 @@ Generate a DOT graph of the advisory guide interview questions
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_id.md
+++ b/docs/cmd/wolfictl_advisory_id.md
@@ -21,7 +21,7 @@ Generate a new advisory ID
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_list.md
+++ b/docs/cmd/wolfictl_advisory_list.md
@@ -93,7 +93,7 @@ flag. This will report just the count, not the full list of advisories.
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_osv.md
+++ b/docs/cmd/wolfictl_advisory_osv.md
@@ -42,7 +42,7 @@ directory must already exist before running the command.
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_secdb.md
+++ b/docs/cmd/wolfictl_advisory_secdb.md
@@ -29,7 +29,7 @@ Build an Alpine-style security database from advisory data
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_update.md
+++ b/docs/cmd/wolfictl_advisory_update.md
@@ -50,7 +50,7 @@ required fields are missing.
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_validate.md
+++ b/docs/cmd/wolfictl_advisory_validate.md
@@ -65,7 +65,7 @@ print an error message that specifies where and how the data is invalid.
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_advisory_validate_fixes.md
+++ b/docs/cmd/wolfictl_advisory_validate_fixes.md
@@ -24,7 +24,7 @@ Validate fixes recorded in advisories
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_apk.md
+++ b/docs/cmd/wolfictl_apk.md
@@ -15,7 +15,7 @@
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_apk_cp.md
+++ b/docs/cmd/wolfictl_apk_cp.md
@@ -27,7 +27,7 @@ wolfictl apk cp [flags]
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_apk_ls.md
+++ b/docs/cmd/wolfictl_apk_ls.md
@@ -30,7 +30,7 @@ wolfictl apk ls https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_bump.md
+++ b/docs/cmd/wolfictl_bump.md
@@ -46,7 +46,7 @@ wolfictl bump openssh.yaml perl lib*.yaml
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_check.md
+++ b/docs/cmd/wolfictl_check.md
@@ -17,7 +17,7 @@ Subcommands used for CI checks in Wolfi
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_check_diff.md
+++ b/docs/cmd/wolfictl_check_diff.md
@@ -25,7 +25,7 @@ Create a diff comparing proposed apk changes following a melange build, to the l
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_check_so-name.md
+++ b/docs/cmd/wolfictl_check_so-name.md
@@ -25,7 +25,7 @@ Check so name files have not changed in upgrade
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_dot.md
+++ b/docs/cmd/wolfictl_dot.md
@@ -45,7 +45,7 @@ Open browser to explore crane's deps recursively, only showing a minimum subgrap
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_gh.md
+++ b/docs/cmd/wolfictl_gh.md
@@ -15,7 +15,7 @@ Commands used to interact with GitHub
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_gh_gc.md
+++ b/docs/cmd/wolfictl_gh_gc.md
@@ -15,7 +15,7 @@ Garbage collection commands used with GitHub
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_gh_gc_branch.md
+++ b/docs/cmd/wolfictl_gh_gc_branch.md
@@ -28,7 +28,7 @@ wolfictl gh gc branch https://github.com/wolfi-dev/os --match "wolfictl-"
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_gh_gc_issues.md
+++ b/docs/cmd/wolfictl_gh_gc_issues.md
@@ -28,7 +28,7 @@ wolfictl gc issues https://github.com/wolfi-dev/versions --match "version-stream
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_gh_release.md
+++ b/docs/cmd/wolfictl_gh_release.md
@@ -34,7 +34,7 @@ wolfictl gh release --bump-prerelease-with-prefix rc
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_image.md
+++ b/docs/cmd/wolfictl_image.md
@@ -15,7 +15,7 @@
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_image_apk.md
+++ b/docs/cmd/wolfictl_image_apk.md
@@ -37,7 +37,7 @@ Show APK(s) in a container image
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_lint.md
+++ b/docs/cmd/wolfictl_lint.md
@@ -24,7 +24,7 @@ Lint the code
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_lint_yam.md
+++ b/docs/cmd/wolfictl_lint_yam.md
@@ -21,7 +21,7 @@ wolfictl lint yam [file]... [flags]
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_ruby.md
+++ b/docs/cmd/wolfictl_ruby.md
@@ -43,7 +43,7 @@ wolfictl ruby check-upgrade . --ruby-version 3.2 --ruby-upgrade-version 3.3
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_ruby_check-upgrade.md
+++ b/docs/cmd/wolfictl_ruby_check-upgrade.md
@@ -36,7 +36,7 @@ wolfictl ruby check-upgrade . --ruby-version 3.2 --ruby-upgrade-version 3.3
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_ruby_code-search.md
+++ b/docs/cmd/wolfictl_ruby_code-search.md
@@ -44,7 +44,7 @@ wolfictl ruby code-search . --ruby-version 3.2 --search-terms 'language:ruby rac
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_scan.md
+++ b/docs/cmd/wolfictl_scan.md
@@ -111,7 +111,7 @@ wolfictl scan package1 package2 --remote
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_version.md
+++ b/docs/cmd/wolfictl_version.md
@@ -22,7 +22,7 @@ Prints the version
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/wolfictl_withdraw.md
+++ b/docs/cmd/wolfictl_withdraw.md
@@ -26,7 +26,7 @@ withdraw --signing-key ./foo.rsa example-pkg-1.2.3-r4 also-bad-2.3.4-r1 <old/APK
 ### Options inherited from parent commands
 
 ```
-      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+      --log-level string   log level (e.g. debug, info, warn, error) (default "WARN")
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/wolfictl-advisory-alias-discover.1
+++ b/docs/man/man1/wolfictl-advisory-alias-discover.1
@@ -69,7 +69,7 @@ than attempting any kind of merge of the separate advisories.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-alias-find.1
+++ b/docs/man/man1/wolfictl-advisory-alias-find.1
@@ -38,7 +38,7 @@ hyperlinked to the relevant webpage from the upstream data source.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-alias.1
+++ b/docs/man/man1/wolfictl-advisory-alias.1
@@ -26,7 +26,7 @@ Commands for discovering vulnerability aliases
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-copy.1
+++ b/docs/man/man1/wolfictl-advisory-copy.1
@@ -38,7 +38,7 @@ of the event to now. The command will not copy events of type "detection", "fixe
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-create.1
+++ b/docs/man/man1/wolfictl-advisory-create.1
@@ -102,7 +102,7 @@ newly created advisory and any other advisories for the same package.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-diff.1
+++ b/docs/man/man1/wolfictl-advisory-diff.1
@@ -26,7 +26,7 @@ See the advisory data differences introduced by your local changes
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-discover.1
+++ b/docs/man/man1/wolfictl-advisory-discover.1
@@ -51,7 +51,7 @@ Automatically create advisories by matching distro packages to vulnerabilities i
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-guide-graph.1
+++ b/docs/man/man1/wolfictl-advisory-guide-graph.1
@@ -26,7 +26,7 @@ Generate a DOT graph of the advisory guide interview questions
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-guide.1
+++ b/docs/man/man1/wolfictl-advisory-guide.1
@@ -30,7 +30,7 @@ Launch an interactive guide to help you enter advisory data for a package
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-id.1
+++ b/docs/man/man1/wolfictl-advisory-id.1
@@ -26,7 +26,7 @@ Generate a new advisory ID
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-list.1
+++ b/docs/man/man1/wolfictl-advisory-list.1
@@ -200,7 +200,7 @@ wolfictl adv ls <various filter flags> \-\-count
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-osv.1
+++ b/docs/man/man1/wolfictl-advisory-osv.1
@@ -60,7 +60,7 @@ directory must already exist before running the command.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-secdb.1
+++ b/docs/man/man1/wolfictl-advisory-secdb.1
@@ -51,7 +51,7 @@ Build an Alpine\-style security database from advisory data
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-update.1
+++ b/docs/man/man1/wolfictl-advisory-update.1
@@ -98,7 +98,7 @@ required fields are missing.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-validate-fixes.1
+++ b/docs/man/man1/wolfictl-advisory-validate-fixes.1
@@ -38,7 +38,7 @@ Validate fixes recorded in advisories
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory-validate.1
+++ b/docs/man/man1/wolfictl-advisory-validate.1
@@ -122,7 +122,7 @@ print an error message that specifies where and how the data is invalid.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-advisory.1
+++ b/docs/man/man1/wolfictl-advisory.1
@@ -26,7 +26,7 @@ Commands for consuming and maintaining security advisory data
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-apk-cp.1
+++ b/docs/man/man1/wolfictl-apk-cp.1
@@ -40,7 +40,7 @@ wolfictl\-apk\-cp \-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-apk-ls.1
+++ b/docs/man/man1/wolfictl-apk-ls.1
@@ -43,7 +43,7 @@ wolfictl\-apk\-ls \-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-apk.1
+++ b/docs/man/man1/wolfictl-apk.1
@@ -23,7 +23,7 @@ wolfictl\-apk \-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-bump.1
+++ b/docs/man/man1/wolfictl-bump.1
@@ -64,7 +64,7 @@ modifying anything in the filesystem.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-check-diff.1
+++ b/docs/man/man1/wolfictl-check-diff.1
@@ -43,7 +43,7 @@ Create a diff comparing proposed apk changes following a melange build, to the l
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-check-so-name.1
+++ b/docs/man/man1/wolfictl-check-so-name.1
@@ -43,7 +43,7 @@ Check so name files have not changed in upgrade
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-check.1
+++ b/docs/man/man1/wolfictl-check.1
@@ -26,7 +26,7 @@ Subcommands used for CI checks in Wolfi
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-dot.1
+++ b/docs/man/man1/wolfictl-dot.1
@@ -81,7 +81,7 @@ wolfictl dot \-\-web \-R \-S crane
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-gh-gc-branch.1
+++ b/docs/man/man1/wolfictl-gh-gc-branch.1
@@ -41,7 +41,7 @@ wolfictl gh gc branch
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-gh-gc-issues.1
+++ b/docs/man/man1/wolfictl-gh-gc-issues.1
@@ -41,7 +41,7 @@ wolfictl gc issues
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-gh-gc.1
+++ b/docs/man/man1/wolfictl-gh-gc.1
@@ -26,7 +26,7 @@ Garbage collection commands used with GitHub
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-gh-release.1
+++ b/docs/man/man1/wolfictl-gh-release.1
@@ -55,7 +55,7 @@ wolfictl gh release \-\-bump\-prerelease\-with\-prefix rc
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-gh.1
+++ b/docs/man/man1/wolfictl-gh.1
@@ -26,7 +26,7 @@ Commands used to interact with GitHub
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-image-apk.1
+++ b/docs/man/man1/wolfictl-image-apk.1
@@ -34,7 +34,7 @@ Show APK(s) in a container image
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-image.1
+++ b/docs/man/man1/wolfictl-image.1
@@ -26,7 +26,7 @@ wolfictl\-image \- (Experimental) Commands for working with container images tha
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-lint-yam.1
+++ b/docs/man/man1/wolfictl-lint-yam.1
@@ -23,7 +23,7 @@ wolfictl\-lint\-yam \-
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-lint.1
+++ b/docs/man/man1/wolfictl-lint.1
@@ -38,7 +38,7 @@ Lint the code
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-ruby-check-upgrade.1
+++ b/docs/man/man1/wolfictl-ruby-check-upgrade.1
@@ -39,7 +39,7 @@ NOTE: This is currently restricted to ruby code housed on Github as that is the
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-ruby-code-search.1
+++ b/docs/man/man1/wolfictl-ruby-code-search.1
@@ -55,7 +55,7 @@ NOTE: This is currently restricted to ruby code housed on Github as that is the
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-ruby.1
+++ b/docs/man/man1/wolfictl-ruby.1
@@ -40,7 +40,7 @@ NOTE: This is currently restricted to ruby code housed on Github as that is the
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-scan.1
+++ b/docs/man/man1/wolfictl-scan.1
@@ -157,7 +157,7 @@ found and the \-\-require\-zero flag is specified.
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-version.1
+++ b/docs/man/man1/wolfictl-version.1
@@ -30,7 +30,7 @@ Prints the version
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl-withdraw.1
+++ b/docs/man/man1/wolfictl-withdraw.1
@@ -30,7 +30,7 @@ Withdraw packages from an APKINDEX.tar.gz
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/docs/man/man1/wolfictl.1
+++ b/docs/man/man1/wolfictl.1
@@ -24,7 +24,7 @@ A CLI helper for developing Wolfi
     help for wolfictl
 
 .PP
-\fB\-\-log\-level\fP="INFO"
+\fB\-\-log\-level\fP="WARN"
     log level (e.g. debug, info, warn, error)
 
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace modernc.org/sqlite v1.33.0 => modernc.org/sqlite v1.32.0
 replace golang.org/x/vuln => github.com/chainguard-dev/golang-vuln v1.1.3
 
 require (
-	chainguard.dev/apko v0.23.0
+	chainguard.dev/apko v0.23.1-0.20250125200830-0b6b8a0543aa
 	chainguard.dev/melange v0.19.2
 	cloud.google.com/go/storage v1.50.0
 	github.com/adrg/xdg v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cel.dev/expr v0.16.2 h1:RwRhoH17VhAu9U5CMvMhH1PDVgf0tuz9FT+24AfMLfU=
 cel.dev/expr v0.16.2/go.mod h1:gXngZQMkWJoSbE8mOzehJlXQyubn/Vg0vR9/F3W7iw8=
-chainguard.dev/apko v0.23.0 h1:lUZwsPeSLfPLzLS373iKlH5hccxFScCN+lK48gzlDd8=
-chainguard.dev/apko v0.23.0/go.mod h1:5/mNllmhqvYcETNQKAaSZm5ZrdXnxsP8f+WqNAGZzzE=
+chainguard.dev/apko v0.23.1-0.20250125200830-0b6b8a0543aa h1:qGiXR6m1StxXiJr3GiUSsoHixOlvcprpKphP2CaFg/k=
+chainguard.dev/apko v0.23.1-0.20250125200830-0b6b8a0543aa/go.mod h1:5/mNllmhqvYcETNQKAaSZm5ZrdXnxsP8f+WqNAGZzzE=
 chainguard.dev/go-grpc-kit v0.17.7 h1:TqHua7er5k8m6WM96y0Tm7IoLLkuZ5vh3+5SR1gruKg=
 chainguard.dev/go-grpc-kit v0.17.7/go.mod h1:JroMzTY9mdhKe/bvtyChgfECaNh80+bMZH3HS+TGXHw=
 chainguard.dev/melange v0.19.2 h1:rPDFaC4scIkfLa+dOzwYquQ9wWMgBV9IfR2K0PWROYo=

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -11,7 +11,8 @@ import (
 )
 
 func New() *cobra.Command {
-	var level slag.Level
+	var level = slag.Level(slog.LevelWarn)
+
 	cmd := &cobra.Command{
 		Use:               "wolfictl",
 		DisableAutoGenTag: true,


### PR DESCRIPTION
For multiple reasons, the log output shown to users by default started creeping up over time. This PR gets the default logging back to a healthy minimum (while still configurable to any crazy amount, of course!).

- Logging for at least some commands used to default to WARN level. We recently cleaned up logging, but according to git bisect, commit https://github.com/wolfi-dev/wolfictl/commit/d2196cdc063ac4a5dc0c117ba115f0919dbe355d changed commands like "scan" to log at INFO by default, which is noisier than intended for the commands. This change sets the default logging level to WARN while preserving the ability to set it to INFO or higher if desired.
- Updated apko to latest on main (v0.23.1-0.20250125200830-0b6b8a0543aa) to pick up logging noise improvements from https://github.com/chainguard-dev/apko/pull/1497.

### Before

```console
$ go run . scan -r crane
📡 Finding remote packages
2025/01/25 15:21:31 [DEBUG] GET https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
2025/01/25 15:21:31 [DEBUG] GET https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
2025/01/25 15:21:31 [DEBUG] GET https://apk.cgr.dev/chainguard-private/x86_64/APKINDEX.tar.gz
2025/01/25 15:21:31 [DEBUG] GET https://apk.cgr.dev/chainguard-private/aarch64/APKINDEX.tar.gz
2025/01/25 15:21:31 [DEBUG] GET https://apk.cgr.dev/extra-packages/aarch64/APKINDEX.tar.gz
2025/01/25 15:21:31 [DEBUG] GET https://apk.cgr.dev/extra-packages/x86_64/APKINDEX.tar.gz
2025/01/25 15:21:34 INFO downloaded APK path=/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-aarch64-crane-0.20.3-r1.apk1815856246
2025/01/25 15:21:34 INFO downloaded APK path=/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-x86_64-crane-0.20.3-r1.apk771089764
2025/01/25 15:21:34 INFO generating SBOM for APK file path=/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-x86_64-crane-0.20.3-r1.apk771089764 distroID=wolfi
2025/01/25 15:21:34 INFO generating SBOM for APK file path=/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-aarch64-crane-0.20.3-r1.apk1815856246 distroID=wolfi
2025/01/25 15:21:35 INFO finished Syft SBOM generation packageCount=19
2025/01/25 15:21:35 INFO finished Syft SBOM generation packageCount=19
🔎 Scanning "/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-aarch64-crane-0.20.3-r1.apk1815856246"
2025/01/25 15:21:35 INFO converted packages to grype packages packageCount=19
✅ No vulnerabilities found
🔎 Scanning "/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-x86_64-crane-0.20.3-r1.apk771089764"
2025/01/25 15:21:35 INFO converted packages to grype packages packageCount=19
✅ No vulnerabilities found
```

### Now

```console
$ go run . scan -r crane            
📡 Finding remote packages
🔎 Scanning "/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-x86_64-crane-0.20.3-r1.apk300702529"
✅ No vulnerabilities found
🔎 Scanning "/var/folders/pz/h07rtjmd4mv4wpnr5st5q1480000gn/T/packages.wolfi.dev-os-aarch64-crane-0.20.3-r1.apk2082852862"
✅ No vulnerabilities found
```
