### PR TITLE
sbom: remove elf-package cataloger during .apk scan

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -102,6 +102,8 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 			pkgcataloging.ImageTag,
 		).WithRemovals(
 			"sbom",
+			// TODO consider how to turn it on https://github.com/chainguard-dev/internal-dev/issues/8731
+			"elf-package",
 		),
 	).WithCatalogers(
 		catalogers.AngularJSReference,


### PR DESCRIPTION
With this change .apk which contain ELF package notes scan the same
way as they did before. This unblocks enabling ELF package notes,
whilst design on how to incorporate them into `wolfictl scan` can then
iterate on that at a later point.

```
$ ./wolfictl --log-level=debug  scan scanelf-1.3.8-r2.apk
2025/01/25 22:10:38 DEBU checking cache for SBOM expectedPath=/home/xnox/.cache/wolfictl/sbom/apk/scanelf-1.3.8-r2-sha256-8f340707e80c5a4159c41ef40ed6d3e2dc052f806b5cfbf906b1ade9b575ab14.syft.json
2025/01/25 22:10:38 DEBU SBOM cache miss cachedPath=/home/xnox/.cache/wolfictl/sbom/apk/scanelf-1.3.8-r2-sha256-8f340707e80c5a4159c41ef40ed6d3e2dc052f806b5cfbf906b1ade9b575ab14.syft.json
2025/01/25 22:10:38 INFO generating SBOM for APK file path=scanelf-1.3.8-r2.apk distroID=wolfi
2025/01/25 22:10:38 DEBU created temp directory to unpack APK path=/tmp/wolfictl-sbom-2146823426
2025/01/25 22:10:38 DEBU unpacked APK file to temp directory apkFilePath=scanelf-1.3.8-r2.apk
2025/01/25 22:10:38 DEBU apk temp directory item path=.
2025/01/25 22:10:38 DEBU apk temp directory item path=.PKGINFO
2025/01/25 22:10:38 DEBU apk temp directory item path=.melange.yaml
2025/01/25 22:10:38 DEBU apk temp directory item path=usr
2025/01/25 22:10:38 DEBU apk temp directory item path=usr/bin
2025/01/25 22:10:38 DEBU apk temp directory item path=usr/bin/scanelf
2025/01/25 22:10:38 DEBU apk temp directory item path=var
2025/01/25 22:10:38 DEBU apk temp directory item path=var/lib
2025/01/25 22:10:38 DEBU apk temp directory item path=var/lib/db
2025/01/25 22:10:38 DEBU apk temp directory item path=var/lib/db/sbom
2025/01/25 22:10:38 DEBU apk temp directory item path=var/lib/db/sbom/scanelf-1.3.8-r2.spdx.json
2025/01/25 22:10:38 DEBU synthesized APK package for SBOM name=scanelf version=1.3.8-r2 id=0b4aac8b80c2df13
2025/01/25 22:10:38 DEBU created Syft source from directory description="{fae5e479007d6102592372c66694727566238f1264d6deafd13639209ca07b7e /tmp/wolfictl-sbom-2146823426  {/tmp/wolfictl-sbom-2146823426 }}"
2025/01/25 22:10:39 INFO finished Syft SBOM generation packageCount=1
2025/01/25 22:10:39 DEBU cleaning up temp directory path=/tmp/wolfictl-sbom-2146823426
🔎 Scanning "scanelf-1.3.8-r2.apk"
2025/01/25 22:10:40 DEBU scanning APK SBOM for vulnerabilities packageCount=1
2025/01/25 22:10:40 INFO converted packages to grype packages packageCount=1
2025/01/25 22:10:40 DEBU grype matching finished matchCount=0
✅ No vulnerabilities found
```

Fixes: https://github.com/wolfi-dev/wolfictl/issues/1409
