### PR TITLE
feat(sbom,scan): use openjdk CPE for corretto

### DIFF
--- a/pkg/sbom/cpe.go
+++ b/pkg/sbom/cpe.go
@@ -40,6 +40,13 @@ func generateWfnAttributesForAPK(p pkgInfo) *wfn.Attributes {
 		return &attr
 	}
 
+	if strings.HasPrefix(name, "corretto-") {
+		attr.Vendor = "oracle"
+		attr.Product = "jdk"
+
+		return &attr
+	}
+
 	if strings.HasPrefix(name, "dotnet-") {
 		attr.Vendor = "microsoft"
 		attr.Product = ".net"


### PR DESCRIPTION
This will help find CVEs for OpenJDK that apply too to corretto.