### PR TITLE
feat(sbom,scan): wire up Anchore logging into our slog instance

### DIFF
--- a/pkg/anchorelog/slog_adapter.go
+++ b/pkg/anchorelog/slog_adapter.go
@@ -1,0 +1,102 @@
+package anchorelogger
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/anchore/go-logger"
+)
+
+// Assertion that our adapter satisfies their interface.
+var _ logger.Logger = (*SlogAdapter)(nil)
+
+// SlogAdapter wraps a standard Go `*slog.Logger` to implement Anchore's
+// proprietary logging interface, which is consumed by Syft and Grype.
+type SlogAdapter struct {
+	logger *slog.Logger
+}
+
+func NewSlogAdapter(logger *slog.Logger) *SlogAdapter {
+	return &SlogAdapter{logger: logger}
+}
+
+func (s *SlogAdapter) log(level func(msg string, args ...any), args ...interface{}) {
+	if len(args) == 0 {
+		return
+	}
+	msg := fmt.Sprint(args...)
+	level(msg)
+}
+
+func (s *SlogAdapter) Errorf(format string, args ...interface{}) {
+	s.logger.Error(fmt.Sprintf(format, args...))
+}
+
+func (s *SlogAdapter) Error(args ...interface{}) {
+	s.log(s.logger.Error, args...)
+}
+
+func (s *SlogAdapter) Warnf(format string, args ...interface{}) {
+	s.logger.Warn(fmt.Sprintf(format, args...))
+}
+
+func (s *SlogAdapter) Warn(args ...interface{}) {
+	s.log(s.logger.Warn, args...)
+}
+
+func (s *SlogAdapter) Infof(format string, args ...interface{}) {
+	s.logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (s *SlogAdapter) Info(args ...interface{}) {
+	s.log(s.logger.Info, args...)
+}
+
+func (s *SlogAdapter) Debugf(format string, args ...interface{}) {
+	s.logger.Debug(fmt.Sprintf(format, args...))
+}
+
+func (s *SlogAdapter) Debug(args ...interface{}) {
+	s.log(s.logger.Debug, args...)
+}
+
+func (s *SlogAdapter) Tracef(format string, args ...interface{}) {
+	s.logger.Debug(fmt.Sprintf(format, args...))
+}
+
+func (s *SlogAdapter) Trace(args ...interface{}) {
+	s.log(s.logger.Debug, args...)
+}
+
+func (s *SlogAdapter) WithFields(fields ...interface{}) logger.MessageLogger {
+	attrs := make([]slog.Attr, 0, len(fields)/2)
+	for i := 0; i < len(fields)-1; i += 2 {
+		key, ok := fields[i].(string)
+		if !ok {
+			continue // Skip malformed pairs
+		}
+		attrs = append(attrs, slog.Any(key, fields[i+1]))
+	}
+	args := make([]any, len(attrs))
+	for i, attr := range attrs {
+		args[i] = attr
+	}
+	return &SlogAdapter{logger: s.logger.With(args...)}
+}
+
+func (s *SlogAdapter) Nested(fields ...interface{}) logger.Logger {
+	l, ok := s.WithFields(fields...).(logger.Logger)
+	if !ok {
+		panic("the Anchore slog adapter has been mis-implemented, and WithFields is returning a type that doesn't conform to logger.Logger")
+	}
+	return l
+}
+
+func (s *SlogAdapter) SetOutput(_ io.Writer) {
+	// No-op; slog.Logger doesn't support changing output dynamically.
+}
+
+func (s *SlogAdapter) GetOutput() io.Writer {
+	return nil // Not applicable
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -24,6 +24,7 @@ import (
 	"github.com/anchore/syft/syft/source/directorysource"
 	"github.com/chainguard-dev/clog"
 	"github.com/package-url/packageurl-go"
+	anchorelogger "github.com/wolfi-dev/wolfictl/pkg/anchorelog"
 	"github.com/wolfi-dev/wolfictl/pkg/sbom/catalogers"
 	"github.com/wolfi-dev/wolfictl/pkg/tar"
 )
@@ -96,6 +97,8 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 		return nil, fmt.Errorf("failed to create source from directory: %w", err)
 	}
 	logger.Debug("created Syft source from directory", "description", src.Describe())
+
+	syft.SetLogger(anchorelogger.NewSlogAdapter(logger.Base()))
 
 	cfg := syft.DefaultCreateSBOMConfig().WithCatalogerSelection(
 		pkgcataloging.NewSelectionRequest().WithDefaults(

--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -25,6 +25,7 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 	sbomSyft "github.com/anchore/syft/syft/sbom"
 	"github.com/chainguard-dev/clog"
+	anchorelogger "github.com/wolfi-dev/wolfictl/pkg/anchorelog"
 	"github.com/wolfi-dev/wolfictl/pkg/sbom"
 )
 
@@ -205,6 +206,8 @@ func (s *Scanner) APKSBOM(ctx context.Context, ssbom *sbomSyft.SBOM) (*Result, e
 	if err != nil {
 		return nil, err
 	}
+
+	grype.SetLogger(anchorelogger.NewSlogAdapter(logger.Base()))
 
 	syftPkgs := ssbom.Artifacts.Packages.Sorted()
 	grypePkgs := grypePkg.FromPackages(syftPkgs, grypePkg.SynthesisConfig{GenerateMissingCPEs: false})


### PR DESCRIPTION
This creates an adapter from the `slog.Logger` we get from `clog` to the Anchore proprietary [go-logger interface](https://github.com/anchore/go-logger/blob/main/logger.go), so we can start picking up log activity from the underlying tasks of generating an SBOM and vulnerability matching (from syft and grype, respectively).

Here's a sample of the new kinds of logging available to us:

### SBOM generation

```
2025/02/11 08:26:57 DEBU used CPE dictionary to find CPEs for rust-crate package "tungstenite": [{cpe:2.3:a:snapview:tungstenite:0.24.0:*:*:*:*:rust:*:* nvd-cpe-dictionary}]
2025/02/11 08:26:57 DEBU used CPE dictionary to find CPEs for rust-crate package "wasmtime": [{cpe:2.3:a:bytecodealliance:wasmtime:24.0.2:*:*:*:*:rust:*:* nvd-cpe-dictionary}]
2025/02/11 08:26:57 DEBU used CPE dictionary to find CPEs for rust-crate package "zeroize_derive": [{cpe:2.3:a:zeroize_derive_project:zeroize_derive:1.4.2:*:*:*:*:rust:*:* nvd-cpe-dictionary}]
2025/02/11 08:26:57 DEBU package cataloger completed name=cargo-auditable-binary-cataloger
2025/02/11 08:26:57 INFO task completed task=cargo-auditable-binary-cataloger elapsed=195.560667ms
2025/02/11 08:26:57 DEBU starting package cataloger name=php-pecl-serialized-cataloger
2025/02/11 08:26:57 DEBU searching for paths matching glob glob=**/php/.registry/.channel.*/*.reg
2025/02/11 08:26:57 DEBU discovered 0 packages cataloger=php-pecl-serialized-cataloger
2025/02/11 08:26:57 DEBU package cataloger completed name=php-pecl-serialized-cataloger
```

### Vuln matching

```
2025/02/11 08:31:28 DEBU searching for vulnerability matches package=pkg:cargo/zbus_names@4.1.0
2025/02/11 08:31:28 DEBU searching for vulnerability matches package=pkg:cargo/zbus_names@4.1.0
2025/02/11 08:31:28 DEBU searching for vulnerability matches package=pkg:cargo/zed@0.168.2
2025/02/11 08:31:28 DEBU searching for vulnerability matches package="pkg:apk/wolfi/zed@0.168.2-r0?arch=aarch64&origin=zed"
2025/02/11 08:31:28 DEBU found 2 vulnerabilities package="pkg:apk/wolfi/zed@0.168.2-r0?arch=aarch64&origin=zed"
2025/02/11 08:31:28 DEBU   ├── vuln=CVE-2025-24898 namespace=wolfi:distro:wolfi:rolling
2025/02/11 08:31:28 DEBU   └── vuln=GHSA-rpmj-rpgj-qmpm namespace=wolfi:distro:wolfi:rolling
2025/02/11 08:31:28 DEBU searching for vulnerability matches package=pkg:cargo/zed_actions@0.1.0
```