### PR TITLE
go.mod: set toolchain to go1.24.0 & update github actions

### DIFF
--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -8,10 +8,12 @@ runs:
         repository: wolfi-dev/wolfictl
         path: wolfictl-setup-gha
 
+    # Until https://github.com/actions/setup-go/issues/457 is fixed
+    - id: gotoolchain
+      run: echo "version=$(sed -ne 's|^toolchain go||p' wolfictl-setup-gha/go.mod)" >> "$GITHUB_OUTPUT"
     - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: '1.21'
-        check-latest: true
+        go-version: '${{ steps.gotoolchain.outputs.version}}'
 
     - id: build
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,11 +24,13 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # Until https://github.com/actions/setup-go/issues/457 is fixed
+      - id: gotoolchain
+        run: echo "version=$(sed -ne 's|^toolchain go||p' go.mod)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: 'go.mod'
-          check-latest: true
+          go-version: '${{ steps.gotoolchain.outputs.version}}'
 
       - uses: chainguard-dev/actions/goimports@2cadca168a422313df94f6169691a86498ae51b1 # main
       - run: make wolfictl
@@ -48,10 +50,13 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Until https://github.com/actions/setup-go/issues/457 is fixed
+      - id: gotoolchain
+        run: echo "version=$(sed -ne 's|^toolchain go||p' go.mod)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: 'go.mod'
-          check-latest: true
+          go-version: '${{ steps.gotoolchain.outputs.version}}'
 
       - run: make wolfictl
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -93,10 +98,13 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Until https://github.com/actions/setup-go/issues/457 is fixed
+      - id: gotoolchain
+        run: echo "version=$(sed -ne 's|^toolchain go||p' go.mod)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: 'go.mod'
-          check-latest: true
+          go-version: '${{ steps.gotoolchain.outputs.version}}'
 
       - run: rm -rf docs/**/*.md docs/**/*.1
       - run: make docs

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,13 +21,15 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      # Until https://github.com/actions/setup-go/issues/457 is fixed
+      - id: gotoolchain
+        run: echo "version=$(sed -ne 's|^toolchain go||p' go.mod)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: 'go.mod'
-          check-latest: true
-          cache: false
+          go-version: '${{ steps.gotoolchain.outputs.version}}'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          version: v1.63 # Please keep this in sync with the Makefile!
+          install-mode: goinstall # To get matching toolchain build
+          version: v1.64.5 # Please keep this in sync with the Makefile!

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ golangci-lint:
 	set -e ;\
 
 	# Please keep the installed version in sync with .github/workflows/golangci-lint.yaml
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4 ;\
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 ;\
 
 .PHONY: fmt
 fmt: ## Format all go files

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/wolfi-dev/wolfictl
 
 go 1.23.4
 
+toolchain go1.24.0
+
 // https://github.com/anchore/grype/blob/v0.80.1/go.mod#L266-L269
 // Pull in a fix for an unpatched CVE. mholt/archiver appears inactive/unmaintained.
 replace github.com/mholt/archiver/v3 => github.com/anchore/archiver/v3 v3.5.2


### PR DESCRIPTION
Locally and in ci this will preffer, but not require, 1.24. As
currently we preffer to pick up 1.24 features (i.e. PQC TLS), but do
not explicitely require it.

Regularly bump the toolchain stanza to new upstream releases.

Whenever a toolchain feature becomes required do bump go stanza.

Confirmation that new workflow works correctly can be seen at:
- https://github.com/xnox/wolfictl/actions/runs/13380270071/job/37367480931

This is alternative to:
- https://github.com/wolfi-dev/wolfictl/pull/1447

Related:
- https://github.com/actions/setup-go/issues/457