### PR TITLE
fix(adv): extend event max age from 3 to 30 days

### DIFF
--- a/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/a/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/a/ko.advisories.yaml
@@ -4,7 +4,7 @@ package:
   name: ko
 
 advisories:
-  - id: CVE-2023-11111
+  - id: CGA-2222-2222-2222
     events:
       - timestamp: 1970-01-01T00:00:00Z
         type: true-positive-determination

--- a/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/b/ko.advisories.yaml
+++ b/pkg/advisory/testdata/diff/added-event-with-non-recent-timestamp/b/ko.advisories.yaml
@@ -4,9 +4,9 @@ package:
   name: ko
 
 advisories:
-  - id: CVE-2023-11111
+  - id: CGA-2222-2222-2222
     events:
       - timestamp: 1970-01-01T00:00:00Z
         type: true-positive-determination
-      - timestamp: 2023-11-02T00:00:00Z # Not recent enough!
+      - timestamp: 2023-10-10T00:00:00Z # Not recent enough!
         type: true-positive-determination

--- a/pkg/advisory/validate.go
+++ b/pkg/advisory/validate.go
@@ -17,6 +17,8 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/internal/errorhelpers"
 )
 
+const eventMaxValidAgeInDays = 30
+
 type ValidateOptions struct {
 	// AdvisoryDocs is the Index of advisories on which to operate.
 	AdvisoryDocs *configs.Index[v2.Document]
@@ -448,8 +450,6 @@ func (opts ValidateOptions) validateIndexDiffForAddedEvents(events []v2.Event, p
 	}
 	return errors.Join(errs...)
 }
-
-const eventMaxValidAgeInDays = 3
 
 func (opts ValidateOptions) isRecent(t time.Time) bool {
 	const maxAge = eventMaxValidAgeInDays * 24 * time.Hour // 3 days


### PR DESCRIPTION
Per discussion with @powersj and @hbh7, this should be more accommodating of legitimate cases where advisory PRs are open for longer, without allowing knowably bad data to get added.