### PR TITLE
feat(sbom,scan): leverage CPE data in melange configuration when available

### DIFF
--- a/pkg/sbom/pkginfo.go
+++ b/pkg/sbom/pkginfo.go
@@ -10,7 +10,10 @@ import (
 	"time"
 )
 
-const pkginfoPath = ".PKGINFO"
+const (
+	pkginfoPath              = ".PKGINFO"
+	melangeConfigurationPath = ".melange.yaml"
+)
 
 type pkgInfo struct {
 	PkgName   string


### PR DESCRIPTION
Based on the work in melange: https://github.com/chainguard-dev/melange/pull/1768

### Scanning an APK with embedded CPE data from melange configuration

```console
$ wolfictl sbom -D ../wolfi-os/packages/aarch64/cosign-2.4.3-r1.apk -o syft-json | jq '.artifacts | map(select(.type == "apk"))'          
[
  {
    "id": "faf1d6bb7e0fc4cc",
    "name": "cosign",
    "version": "2.4.3-r1",
    "type": "apk",
    "foundBy": "wolfictl",
    // ...
    "cpes": [
      {
        "cpe": "cpe:2.3:a:sigstore:cosign:2.4.3-r1:*:*:*:*:*:*:*",
        "source": "melange-configuration"
      }
    ],
```

The above was a cosign APK built with a Melange YAML of:

```yaml
package:
  name: cosign
  version: "2.4.3"
  epoch: 1
  description: Container Signing
  copyright:
    - license: Apache-2.0
  cpe:
    vendor: sigstore
    product: cosign
# ...
```

### Without CPE data

The default behavior without adding CPE data to the Melange YAML, which is totally okay.

```console
$ wolfictl sbom -D ./packages/aarch64/crane-0.20.3-r2.apk -o syft-json | jq '.artifacts | map(select(.type == "apk"))'
2025/02/27 20:25:07 WARN adding 'file' tag to the default cataloger selection, to override add '-file' to the cataloger selection request
[
  {
    "id": "470e4c28f8190085",
    "name": "crane",
    "version": "0.20.3-r2",
    "type": "apk",
    "foundBy": "wolfictl",
    // ...
    "cpes": [
      {
        "cpe": "cpe:2.3:a:crane:crane:0.20.3-r2:*:*:*:*:*:*:*",
        "source": "syft-generated"
      }
    ],
```