### PR TITLE
fix: panic caused by extra log entry

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -212,7 +212,6 @@ func newAPKPackage(
 		if err != nil {
 			return nil, fmt.Errorf("extracting CPE from melange configuration: %w", err)
 		}
-		log.Info("extracted CPE from melange configuration", "cpe", c.BindToFmtString())
 		attr = c
 	}
 


### PR DESCRIPTION
I was overzealous in adding more log entries in https://github.com/wolfi-dev/wolfictl/pull/1469. We weren't expecting a non-nil value of c here, so I shouldn't have logged it!