### PR TITLE
chore: silence file tag warning by adding it explicitly

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -14,6 +14,7 @@ import (
 
 	"chainguard.dev/melange/pkg/config"
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging/filecataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
@@ -129,6 +130,7 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 	cfg := syft.DefaultCreateSBOMConfig().WithCatalogerSelection(
 		pkgcataloging.NewSelectionRequest().WithDefaults(
 			pkgcataloging.ImageTag,
+			filecataloging.FileTag, // see https://github.com/anchore/syft/pull/3505 for context
 		).WithRemovals(
 			"sbom",
 			// TODO consider how to turn it on https://github.com/chainguard-dev/internal-dev/issues/8731


### PR DESCRIPTION
This handles a warning that started showing up in Syft's logging recently, which was [put in place](https://github.com/anchore/syft/pull/3505) to make users aware that they were running with file catalogers turned on. This PR accepts the new cataloger explicitly, which removes the warning.

```console
$ wolfictl scan ~/apks/apko-0.25.1-r2.apk
2025/03/03 10:11:17 WARN adding 'file' tag to the default cataloger selection, to override add '-file' to the cataloger selection request
...
```