### PR TITLE
Use Chainguard API to validate a generated CGA ID is unique

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace golang.org/x/vuln => github.com/chainguard-dev/golang-vuln v1.1.3
 require (
 	chainguard.dev/apko v0.25.2-0.20250225192758-581904a29f4a
 	chainguard.dev/melange v0.22.1
+	chainguard.dev/sdk v0.1.31
 	cloud.google.com/go/storage v1.50.0
 	github.com/adrg/xdg v0.5.3
 	github.com/anchore/grype v0.87.1-0.20250128180623-27bcc7a9e9e8 // tracking main/27bcc7a9e9e8 until https://github.com/anchore/grype/pull/2397 is released
@@ -74,7 +75,6 @@ require github.com/anchore/go-logger v0.0.0-20240217160628-ee28a485904f
 require (
 	cel.dev/expr v0.19.2 // indirect
 	chainguard.dev/go-grpc-kit v0.17.7 // indirect
-	chainguard.dev/sdk v0.1.31 // indirect
 	cloud.google.com/go v0.118.2 // indirect
 	cloud.google.com/go/auth v0.15.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
@@ -125,6 +125,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bitnami/go-version v0.0.0-20250131085805-b1f57a8634ef // indirect
+	github.com/bits-and-blooms/bitset v1.15.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bmatcuk/doublestar/v2 v2.0.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -769,6 +769,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitnami/go-version v0.0.0-20250131085805-b1f57a8634ef h1:TSFnfbbu2oAOuWbeDDTtwXWE6z+PmpgbSsMBeV7l0ww=
 github.com/bitnami/go-version v0.0.0-20250131085805-b1f57a8634ef/go.mod h1:9iglf1GG4oNRJ39bZ5AZrjgAFD2RwQbXw6Qf7Cs47wo=
+github.com/bits-and-blooms/bitset v1.15.0 h1:DiCRMscZsGyYePE9AR3sVhKqUXCt5IZvkX5AfAc5xLQ=
+github.com/bits-and-blooms/bitset v1.15.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar/v2 v2.0.4 h1:6I6oUiT/sU27eE2OFcWqBhL1SwjyvQuOssxT4a1yidI=

--- a/pkg/advisory/cga_id.go
+++ b/pkg/advisory/cga_id.go
@@ -9,8 +9,8 @@ import (
 	advisoryapi "chainguard.dev/sdk/proto/platform/advisory/v1"
 )
 
-// ChainguardAPIURL is the public Chainguard API.
-const ChainguardAPIURL = "https://console-api.enforce.dev"
+// chainguardAPIURL is the public Chainguard API.
+const chainguardAPIURL = "https://console-api.enforce.dev"
 
 var DefaultIDGenerator IDGenerator = &RandomIDGenerator{}
 
@@ -67,7 +67,7 @@ func (s StaticIDGenerator) GenerateCGAID() (string, error) {
 	return s.ID, nil
 }
 
-type StaticListIDGenerator struct {
+type staticListIDGenerator struct {
 	// The set of IDs to return sequentially.
 	IDs []string
 
@@ -75,7 +75,7 @@ type StaticListIDGenerator struct {
 	idx int
 }
 
-func (s *StaticListIDGenerator) GenerateCGAID() (string, error) {
+func (s *staticListIDGenerator) GenerateCGAID() (string, error) {
 	if len(s.IDs) == 0 {
 		return "", fmt.Errorf("IDs list is empty")
 	}
@@ -88,13 +88,13 @@ func realGetAdvisoryClients(ctx context.Context) (advisoryapi.Clients, error) {
 	// Create a GRPC client to communicate with the Chainguard API.
 	// Passing an empty string for the token creates an anonymous client,
 	// which is acceptable in this case since the ListDocuments endpoint is unauthenticated.
-	return advisoryapi.NewClients(ctx, ChainguardAPIURL, "")
+	return advisoryapi.NewClients(ctx, chainguardAPIURL, "")
 }
 
 var getAdvisoryClients = realGetAdvisoryClients
 
-// CGAIDExists checks if the given CGA ID has already been assigned to an advisory.
-func CGAIDExists(ctx context.Context, id string) (bool, error) {
+// cgaIDExists checks if the given CGA ID has already been assigned to an advisory.
+func cgaIDExists(ctx context.Context, id string) (bool, error) {
 	clients, err := getAdvisoryClients(ctx)
 	if err != nil {
 		return false, fmt.Errorf("constructing chainguard api client: %w", err)

--- a/pkg/advisory/create.go
+++ b/pkg/advisory/create.go
@@ -97,9 +97,9 @@ func createAdvisoryConfig(ctx context.Context, documents *configs.Index[v2.Docum
 			return fmt.Errorf("generating CGA ID: %w", err)
 		}
 
-		exists, err := CGAIDExists(ctx, id)
+		exists, err := cgaIDExists(ctx, id)
 		if err != nil {
-			return fmt.Errorf("checking existence of %s: %w", id, err)
+			return fmt.Errorf("checking existence of ID %q: %w", id, err)
 		}
 		if !exists {
 			newAdvisoryID = id

--- a/pkg/advisory/create_test.go
+++ b/pkg/advisory/create_test.go
@@ -18,8 +18,8 @@ func TestCreate(t *testing.T) {
 	testTime := v2.Timestamp(time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC))
 	brotliExistingEventTime := v2.Timestamp(time.Date(2022, 9, 15, 2, 40, 18, 0, time.UTC))
 
-	goodCGAID := "CGA-xoxo-xoxo-xoxo"
-	usedCGAID := "CGA-abcd-abcd-abcd"
+	goodCGAID := "CGA-cfgh-jmpq-rvwx"
+	usedCGAID := "CGA-2345-6789-xwvr"
 
 	advisoryClient := apitest.MockSecurityAdvisoryClient{
 		OnListDocuments: []apitest.DocumentsOnList{{
@@ -256,7 +256,7 @@ func TestCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sg := &StaticListIDGenerator{IDs: []string{goodCGAID}}
+			sg := &staticListIDGenerator{IDs: []string{goodCGAID}}
 			// Use the test case CGA IDs, if provided.
 			if len(tt.cgaIDs) > 0 {
 				sg.IDs = tt.cgaIDs

--- a/pkg/advisory/create_test.go
+++ b/pkg/advisory/create_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	advisoryapi "chainguard.dev/sdk/proto/platform/advisory/v1"
+	apitest "chainguard.dev/sdk/proto/platform/advisory/v1/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
@@ -16,9 +18,30 @@ func TestCreate(t *testing.T) {
 	testTime := v2.Timestamp(time.Date(2022, 9, 26, 0, 0, 0, 0, time.UTC))
 	brotliExistingEventTime := v2.Timestamp(time.Date(2022, 9, 15, 2, 40, 18, 0, time.UTC))
 
+	goodCGAID := "CGA-xoxo-xoxo-xoxo"
+	usedCGAID := "CGA-abcd-abcd-abcd"
+
+	advisoryClient := apitest.MockSecurityAdvisoryClient{
+		OnListDocuments: []apitest.DocumentsOnList{{
+			Given: &advisoryapi.DocumentFilter{
+				Cves: []string{goodCGAID},
+			},
+			List: &advisoryapi.DocumentList{Items: []*advisoryapi.Document{}},
+		}, {
+			Given: &advisoryapi.DocumentFilter{
+				Cves: []string{usedCGAID},
+			},
+			// This return value isn't checked, just that it exists. The details don't matter.
+			List: &advisoryapi.DocumentList{Items: []*advisoryapi.Document{{
+				Id: "package",
+			}}},
+		}},
+	}
+
 	tests := []struct {
 		name        string
 		req         Request
+		cgaIDs      []string
 		wantErr     bool
 		expectedDoc v2.Document
 	}{
@@ -41,7 +64,7 @@ func TestCreate(t *testing.T) {
 				Package:       v2.Package{Name: "crane"},
 				Advisories: v2.Advisories{
 					{
-						ID:      "CGA-xoxo-xoxo-xoxo", // will be ignored as we generate random ones
+						ID:      goodCGAID, // will be ignored as we generate random ones
 						Aliases: []string{"CVE-2023-1234"},
 						Events: []v2.Event{
 							{
@@ -103,7 +126,7 @@ func TestCreate(t *testing.T) {
 						},
 					},
 					{
-						ID:      "CGA-xoxo-xoxo-xoxo", // will be ignored as we generate random ones
+						ID:      goodCGAID, // will be ignored as we generate random ones
 						Aliases: []string{"CVE-2020-8927"},
 						Events: []v2.Event{
 							{
@@ -150,7 +173,7 @@ func TestCreate(t *testing.T) {
 						},
 					},
 					{
-						ID:      "CGA-xoxo-xoxo-xoxo", // will be ignored as we generate random ones
+						ID:      goodCGAID, // will be ignored as we generate random ones
 						Aliases: []string{"CVE-2020-8927"},
 						Events: []v2.Event{
 							{
@@ -169,7 +192,7 @@ func TestCreate(t *testing.T) {
 			name: "no events",
 			req: Request{
 				Package:    "brotli",
-				AdvisoryID: "CGA-xoxo-xoxo-xoxo",
+				AdvisoryID: goodCGAID,
 			},
 			wantErr: true,
 		},
@@ -187,12 +210,60 @@ func TestCreate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:   "generate a used CGA ID",
+			cgaIDs: []string{usedCGAID, goodCGAID},
+			req: Request{
+				Package: "crane",
+				Aliases: []string{"CVE-2023-1234"},
+				Event: v2.Event{
+					Timestamp: testTime,
+					Type:      v2.EventTypeDetection,
+					Data: v2.Detection{
+						Type: v2.DetectionTypeManual,
+					},
+				},
+			},
+			wantErr: false,
+			expectedDoc: v2.Document{
+				SchemaVersion: v2.SchemaVersion,
+				Package:       v2.Package{Name: "crane"},
+				Advisories: v2.Advisories{
+					{
+						ID:      goodCGAID, // will be ignored as we generate random ones
+						Aliases: []string{"CVE-2023-1234"},
+						Events: []v2.Event{
+							{
+								Timestamp: testTime,
+								Type:      v2.EventTypeDetection,
+								Data: v2.Detection{
+									Type: v2.DetectionTypeManual,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	dirFS := os.DirFS("testdata/create/advisories")
 
+	// Mock the API client init call.
+	getAdvisoryClients = func(_ context.Context) (advisoryapi.Clients, error) {
+		return apitest.MockSecurityAdvisoryClients{SecurityAdvisoryClient: advisoryClient}, nil
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			sg := &StaticListIDGenerator{IDs: []string{goodCGAID}}
+			// Use the test case CGA IDs, if provided.
+			if len(tt.cgaIDs) > 0 {
+				sg.IDs = tt.cgaIDs
+			}
+			DefaultIDGenerator = sg
+			defer func() { DefaultIDGenerator = &RandomIDGenerator{} }()
+
 			// We want a fresh memfs for each test case.
 			fsys := memfs.New(dirFS)
 			advisoryDocs, err := v2.NewIndex(context.Background(), fsys)


### PR DESCRIPTION
CGA IDs are intended to be unique per advisory. However, there have been a handful of advisories created with a preexisting CGA ID, usually when they are in different advisory repos. The advisory endpoints of the Chainguard API allow unauthenticated access to list advisory documents. We can use this to ensure that generated CGA IDs are in fact unique across all current advisories, regardless of originating repo.