### PR TITLE
feat(sbom,scan): leverage CPE data for Go module matching

### DIFF
--- a/pkg/sbom/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.syft.json
@@ -4904,8 +4904,24 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/crypto:v0.21.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:crypto:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:bcrypt:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:openpgp:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:scrypt:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:ssh:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/crypto@v0.21.0",
@@ -4975,7 +4991,27 @@
       "cpes": [
         {
           "cpe": "cpe:2.3:a:golang:networking:v0.23.0:*:*:*:*:go:*:*",
-          "source": "nvd-cpe-dictionary"
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:html:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http2:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:proxy:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:websocket:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/net@v0.23.0",
@@ -5009,8 +5045,16 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/oauth2:v0.7.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:oauth2:v0.7.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jws:v0.7.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jwt:v0.7.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/oauth2@v0.7.0",

--- a/pkg/sbom/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.syft.json
@@ -6892,8 +6892,24 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/crypto:v0.17.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:crypto:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:bcrypt:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:openpgp:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:scrypt:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:ssh:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/crypto@v0.17.0",
@@ -6963,7 +6979,27 @@
       "cpes": [
         {
           "cpe": "cpe:2.3:a:golang:networking:v0.17.0:*:*:*:*:go:*:*",
-          "source": "nvd-cpe-dictionary"
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:html:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http2:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:proxy:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:websocket:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/net@v0.17.0",
@@ -6997,8 +7033,16 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/oauth2:v0.11.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:oauth2:v0.11.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jws:v0.11.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jwt:v0.11.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/oauth2@v0.11.0",

--- a/pkg/sbom/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.syft.json
@@ -4908,8 +4908,24 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/crypto:v0.21.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:crypto:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:bcrypt:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:openpgp:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:scrypt:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:ssh:v0.21.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/crypto@v0.21.0",
@@ -4979,7 +4995,27 @@
       "cpes": [
         {
           "cpe": "cpe:2.3:a:golang:networking:v0.23.0:*:*:*:*:go:*:*",
-          "source": "nvd-cpe-dictionary"
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:html:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http2:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:proxy:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:websocket:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/net@v0.23.0",
@@ -5013,8 +5049,16 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/oauth2:v0.7.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:oauth2:v0.7.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jws:v0.7.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jwt:v0.7.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/oauth2@v0.7.0",

--- a/pkg/sbom/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.syft.json
@@ -6896,8 +6896,24 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/crypto:v0.17.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:crypto:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:bcrypt:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:openpgp:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:scrypt:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:ssh:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/crypto@v0.17.0",
@@ -6967,7 +6983,27 @@
       "cpes": [
         {
           "cpe": "cpe:2.3:a:golang:networking:v0.17.0:*:*:*:*:go:*:*",
-          "source": "nvd-cpe-dictionary"
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:html:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:http2:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:proxy:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:websocket:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/net@v0.17.0",
@@ -7001,8 +7037,16 @@
       "language": "go",
       "cpes": [
         {
-          "cpe": "cpe:2.3:a:golang:x\\/oauth2:v0.11.0:*:*:*:*:*:*:*",
-          "source": "syft-generated"
+          "cpe": "cpe:2.3:a:golang:oauth2:v0.11.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jws:v0.11.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:jwt:v0.11.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
         }
       ],
       "purl": "pkg:golang/golang.org/x/oauth2@v0.11.0",


### PR DESCRIPTION
With a goal of finding more true positives for the Go ecosystem, this PR turns on CPE matching for Go modules.

With this, we are also investing in better CPE assignments during SBOM generation, particularly for the `golang.org/x/...` group of repositories.

Also, since we're still using some Syft-generated CPEs, we've added a step at the end of matching to filter out CPE-based matches that don't meet our standards.

⚠️ Like all changes of this nature, it's possible this will produce unexpected false positives/negatives in our APK scans. However, since we're in control of everything we've just added, we should be able to quickly respond to any behavioral changes we don't like.