### PR TITLE
chore(sbom): add more package CPEs for golang.org/x/net

### DIFF
--- a/pkg/sbom/cpe.go
+++ b/pkg/sbom/cpe.go
@@ -184,10 +184,17 @@ func cpesFromGolangOrgXModule(moduleName string) []string {
 	case "net":
 		products = []string{
 			"networking", // weird, but real! Check the NVD CPE dictionary if you don't believe it.
+			"bpf",
+			"dns",
 			"html",
 			"http",
+			"httpproxy",
 			"http2",
+			"hpack",
 			"proxy",
+			"route",
+			"trace",
+			"webdev",
 			"websocket",
 		}
 	case "oauth2":

--- a/pkg/sbom/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.syft.json
@@ -4994,6 +4994,14 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:bpf:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:dns:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:html:v0.23.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
@@ -5002,11 +5010,31 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:httpproxy:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:http2:v0.23.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:hpack:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:proxy:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:route:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:trace:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:webdev:v0.23.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {

--- a/pkg/sbom/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.syft.json
@@ -6982,6 +6982,14 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:bpf:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:dns:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:html:v0.17.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
@@ -6990,11 +6998,31 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:httpproxy:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:http2:v0.17.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:hpack:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:proxy:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:route:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:trace:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:webdev:v0.17.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {

--- a/pkg/sbom/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.syft.json
@@ -4998,6 +4998,14 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:bpf:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:dns:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:html:v0.23.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
@@ -5006,11 +5014,31 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:httpproxy:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:http2:v0.23.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:hpack:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:proxy:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:route:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:trace:v0.23.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:webdev:v0.23.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {

--- a/pkg/sbom/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.syft.json
@@ -6986,6 +6986,14 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:bpf:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:dns:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:html:v0.17.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
@@ -6994,11 +7002,31 @@
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:httpproxy:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:http2:v0.17.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {
+          "cpe": "cpe:2.3:a:golang:hpack:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
           "cpe": "cpe:2.3:a:golang:proxy:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:route:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:trace:v0.17.0:*:*:*:*:go:*:*",
+          "source": "wolfictl"
+        },
+        {
+          "cpe": "cpe:2.3:a:golang:webdev:v0.17.0:*:*:*:*:go:*:*",
           "source": "wolfictl"
         },
         {


### PR DESCRIPTION
We're not aware of any misses so far because of these, but this will help us get our SBOMs ready for future CPE-based matches for these commonly used packages.

Reference: https://pkg.go.dev/golang.org/x/net