### PR TITLE
feat(pkg/lint): log rule errors with level matching severity

### DIFF
--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -111,15 +111,21 @@ func (l *Linter) Lint(ctx context.Context, minSeverity Severity) (Result, error)
 // Print prints the result to stdout.
 func (l *Linter) Print(ctx context.Context, result Result) {
 	log := clog.FromContext(ctx)
-	foundAny := false
-	for _, res := range result {
-		if res.Errors.WrapErrors() != nil {
-			foundAny = true
-			log.Infof("Package: %s: %s", res.File, res.Errors.WrapErrors())
-		}
-	}
-	if !foundAny {
+	if !result.HasErrors() {
 		log.Infof("No linting issues found!")
+		return
+	}
+	for _, res := range result {
+		for _, v := range res.Errors {
+			switch v.Rule.Severity.Value {
+			case SeverityErrorLevel:
+				log.Errorf("Package: %s: %s", res.File, v.Error)
+			case SeverityWarningLevel:
+				log.Warnf("Package: %s: %s", res.File, v.Error)
+			case SeverityInfoLevel:
+				log.Infof("Package: %s: %s", res.File, v.Error)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Before this commit all rule errors were printed as info logs, leading to rule error and warnings being omitted even in case of a rule error leading to the whole lint command to fail.

This commit disables also rule error wrapping by rule id, in order to log each error with specific log level depending on the rule severity.

Fixes #1499 