### PR TITLE
Add pre-commit-hook support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,7 @@
 -   id: wolfictl-lint
     name: Format files properly using wolfictl lint
     description: Helps to prevent any linting check failures in CI 
-    entry: wolfictl
-    args: ["lint"]
+    entry: wolfictl lint
     language: golang
     stages: [pre-commit, manual]
     types: ["text"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+-   id: wolfictl-lint
+    name: Format files properly using wolfictl lint
+    description: Helps to prevent any linting check failures in CI 
+    entry: wolfictl
+    args: ["lint"]
+    language: golang
+    stages: [pre-commit, manual]
+    types: ["text"]
+    


### PR DESCRIPTION
To enable https://github.com/chainguard-dev/internal-dev/issues/7536, we need a .pre-commit-hooks.yaml file to tell pre-commit how to build and run the tool.