### PR TITLE
config(scan/apk): disable maven searches until we resolve the 403 rate limit issues with the newer release of Grype

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -412,7 +412,7 @@ func createMatchers(useCPEs bool) []match.Matcher {
 			},
 			Java: java.MatcherConfig{
 				ExternalSearchConfig: java.ExternalSearchConfig{
-					SearchMavenUpstream: true,
+					SearchMavenUpstream: false, // temporary disable of maven searches until we figure out the 403 rate limit issues
 					MavenBaseURL:        mavenSearchBaseURL,
 					MavenRateLimit:      400 * time.Millisecond, // increased from the default of 300ms to avoid rate limiting with extremely large set of java packages such as druid
 				},


### PR DESCRIPTION
This PR temporarily disables Maven searches for java-archive packages. The reason for this is because in [v0.89.1 of Grype](https://github.com/anchore/grype/releases/tag/v0.89.1) these 403s rate limits are now surfaced as fatal errors, which would cause our scanning to fail as well. 