### PR TITLE
feat(adv): introduce read-only abstraction, create a simple implementation, and use in `adv list` command

### DIFF
--- a/pkg/advisory/fs_getter.go
+++ b/pkg/advisory/fs_getter.go
@@ -1,0 +1,81 @@
+package advisory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+)
+
+// assert that FSGetter implements Getter
+var _ Getter = (*FSGetter)(nil)
+
+// FSGetter is a getter that loads advisory data from YAML files in an
+// fs.FS on-demand, avoiding file opens/reads until needed.
+type FSGetter struct {
+	fsys fs.FS
+}
+
+func NewFSGetter(fsys fs.FS) *FSGetter {
+	return &FSGetter{
+		fsys: fsys,
+	}
+}
+
+func (g FSGetter) PackageNames(_ context.Context) ([]string, error) {
+	// We'll trust the file names as authoritative for the referenced package name.
+	// If we find this to be insufficient, we can evolve to a partial decode of the
+	// document, but that will use more memory and be slower.
+
+	entries, err := fs.ReadDir(g.fsys, ".")
+	if err != nil {
+		return nil, fmt.Errorf("reading directory: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".advisories.yaml") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(entry.Name(), ".advisories.yaml"))
+	}
+
+	return names, nil
+}
+
+func (g FSGetter) Advisories(_ context.Context, packageName string) ([]v2.PackageAdvisory, error) {
+	advFileName := fmt.Sprintf("%s.advisories.yaml", packageName)
+	f, err := g.fsys.Open(advFileName)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("%w: opening advisory file %q: %w", ErrNoAdvisories, advFileName, err)
+		}
+
+		return nil, fmt.Errorf("opening advisory file %q: %w", advFileName, err)
+	}
+
+	doc, err := v2.DecodeDocument(f)
+	if err != nil {
+		return nil, fmt.Errorf("decoding advisory file %q: %w", advFileName, err)
+	}
+
+	result := make([]v2.PackageAdvisory, 0, len(doc.Advisories))
+	for _, adv := range doc.Advisories {
+		result = append(result, v2.PackageAdvisory{
+			PackageName: packageName,
+			Advisory: v2.Advisory{
+				ID:      adv.ID,
+				Aliases: adv.Aliases,
+				Events:  adv.Events,
+			},
+		})
+	}
+
+	return result, nil
+}

--- a/pkg/advisory/fs_getter.go
+++ b/pkg/advisory/fs_getter.go
@@ -54,7 +54,8 @@ func (g FSGetter) Advisories(_ context.Context, packageName string) ([]v2.Packag
 	f, err := g.fsys.Open(advFileName)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("%w: opening advisory file %q: %w", ErrNoAdvisories, advFileName, err)
+			// This is normal, just no advisories for this package.
+			return nil, nil
 		}
 
 		return nil, fmt.Errorf("opening advisory file %q: %w", advFileName, err)

--- a/pkg/advisory/fs_getter_test.go
+++ b/pkg/advisory/fs_getter_test.go
@@ -1,0 +1,64 @@
+package advisory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+)
+
+func TestFSGetter(t *testing.T) {
+	ctx := t.Context()
+	g := NewFSGetter(os.DirFS(filepath.Join("testdata", "fs_getter")))
+
+	t.Run("PackageNames", func(t *testing.T) {
+		names, err := g.PackageNames(ctx)
+		require.NoError(t, err)
+
+		expected := []string{"brotli"}
+		assert.Equal(t, expected, names)
+	})
+
+	t.Run("Advisories", func(t *testing.T) {
+		t.Run("found", func(t *testing.T) {
+			actual, err := g.Advisories(ctx, "brotli")
+			require.NoError(t, err)
+
+			testTime := v2.Timestamp(time.Date(2022, 9, 15, 2, 40, 18, 0, time.UTC))
+
+			expected := []v2.PackageAdvisory{
+				{
+					PackageName: "brotli",
+					Advisory: v2.Advisory{
+						ID: "CGA-xxxx-xxxx-xxxx",
+						Aliases: []string{
+							"CVE-2020-8927",
+						},
+						Events: []v2.Event{{
+							Timestamp: testTime,
+							Type:      v2.EventTypeFixed,
+							Data: v2.Fixed{
+								FixedVersion: "1.0.9-r0",
+							},
+						},
+						},
+					},
+				},
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Fatalf("unexpected advisories (-want +got):\n%s", diff)
+			}
+		})
+
+		t.Run("not found", func(t *testing.T) {
+			_, err := g.Advisories(ctx, "not-found")
+			assert.ErrorIs(t, err, ErrNoAdvisories)
+		})
+	})
+}

--- a/pkg/advisory/fs_getter_test.go
+++ b/pkg/advisory/fs_getter_test.go
@@ -58,7 +58,7 @@ func TestFSGetter(t *testing.T) {
 
 		t.Run("not found", func(t *testing.T) {
 			_, err := g.Advisories(ctx, "not-found")
-			assert.ErrorIs(t, err, ErrNoAdvisories)
+			assert.NoError(t, err)
 		})
 	})
 }

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -2,21 +2,9 @@ package advisory
 
 import (
 	"context"
-	"errors"
 
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 )
-
-// ErrNoAdvisories is returned by Getter implementations when there is no
-// advisory data available for the requested package. If a more serious error
-// with data access occurs (e.g. a permissions issue), a different error should
-// be returned.
-//
-// It is not required for implementations to return this error when returning a
-// zero-length slice of advisory data: this is merely a sentinel error to signal
-// to the caller that the rest of the error chain represents a normal "no data"
-// condition.
-var ErrNoAdvisories = errors.New("no advisories found")
 
 // Store abstracts the storage and retrieval of advisory data.
 type Store interface {

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -15,9 +15,12 @@ type Store interface {
 
 // Getter is the interface for retrieving advisory data.
 type Getter interface {
-	// PackageNames returns the list of package names that have advisories.
+	// PackageNames returns the list of package names that have advisories. The
+	// order of the results is not guaranteed.
 	PackageNames(ctx context.Context) ([]string, error)
 
-	// Advisories returns the advisories for the given package name.
+	// Advisories returns the advisories for the given package name. If no error is
+	// returned, it is guaranteed that all elements of the result slice contain
+	// valid, non-empty data.
 	Advisories(ctx context.Context, packageName string) ([]v2.PackageAdvisory, error)
 }

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -1,0 +1,35 @@
+package advisory
+
+import (
+	"context"
+	"errors"
+
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+)
+
+// ErrNoAdvisories is returned by Getter implementations when there is no
+// advisory data available for the requested package. If a more serious error
+// with data access occurs (e.g. a permissions issue), a different error should
+// be returned.
+//
+// It is not required for implementations to return this error when returning a
+// zero-length slice of advisory data: this is merely a sentinel error to signal
+// to the caller that the rest of the error chain represents a normal "no data"
+// condition.
+var ErrNoAdvisories = errors.New("no advisories found")
+
+// Store abstracts the storage and retrieval of advisory data.
+type Store interface {
+	Getter
+
+	// TODO: write-oriented interface
+}
+
+// Getter is the interface for retrieving advisory data.
+type Getter interface {
+	// PackageNames returns the list of package names that have advisories.
+	PackageNames(ctx context.Context) ([]string, error)
+
+	// Advisories returns the advisories for the given package name.
+	Advisories(ctx context.Context, packageName string) ([]v2.PackageAdvisory, error)
+}

--- a/pkg/advisory/testdata/fs_getter/brotli.advisories.yaml
+++ b/pkg/advisory/testdata/fs_getter/brotli.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: "2"
+
+package:
+  name: brotli
+
+advisories:
+  - id: CGA-xxxx-xxxx-xxxx
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/configs/advisory/v2/document.go
+++ b/pkg/configs/advisory/v2/document.go
@@ -63,7 +63,7 @@ func (doc Document) ValidateSchemaVersion() error {
 	return nil
 }
 
-func decodeDocument(r io.Reader) (*Document, error) {
+func DecodeDocument(r io.Reader) (*Document, error) {
 	doc := &Document{}
 	decoder := yaml.NewDecoder(r)
 	decoder.KnownFields(true)

--- a/pkg/configs/advisory/v2/document_test.go
+++ b/pkg/configs/advisory/v2/document_test.go
@@ -266,7 +266,7 @@ func TestDocument_full_coverage(t *testing.T) {
 	t.Run("decode", func(t *testing.T) {
 		expected := testDocument
 
-		actual, err := decodeDocument(f)
+		actual, err := DecodeDocument(f)
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(expected, *actual); diff != "" {

--- a/pkg/configs/advisory/v2/index.go
+++ b/pkg/configs/advisory/v2/index.go
@@ -23,6 +23,6 @@ func newConfigurationDecodeFunc(fsys fs.FS) func(context.Context, string) (*Docu
 			return nil, err
 		}
 
-		return decodeDocument(file)
+		return DecodeDocument(file)
 	}
 }

--- a/pkg/configs/advisory/v2/package_advisory.go
+++ b/pkg/configs/advisory/v2/package_advisory.go
@@ -1,0 +1,12 @@
+package v2
+
+// PackageAdvisory is an Advisory that includes the package name for that
+// advisory. (The Advisory type does not include the package's name.)
+type PackageAdvisory struct {
+	PackageName string `yaml:"packageName" json:"packageName"`
+	Advisory
+}
+
+func (pa PackageAdvisory) IsZero() bool {
+	return pa.PackageName == "" && pa.Advisory.IsZero()
+}

--- a/pkg/configs/advisory/v2/package_advisory.go
+++ b/pkg/configs/advisory/v2/package_advisory.go
@@ -7,6 +7,7 @@ type PackageAdvisory struct {
 	Advisory
 }
 
+// IsZero returns true if the package advisory has no data.
 func (pa PackageAdvisory) IsZero() bool {
 	return pa.PackageName == "" && pa.Advisory.IsZero()
 }


### PR DESCRIPTION
- Begin new advisory interface design — using a `Store` abstraction, which will be decomposed into read (`Getter`) and write (name TBD) interfaces (since so many consumers' needs are read-only)
- Update `adv list` command to use advisory `Getter`
- Implement a simple `Getter` using `fs.FS` with just open and decode calls