### PR TITLE
feat(adv): bulk create and update of adv data

### DIFF
--- a/docs/cmd/wolfictl_advisory_create.md
+++ b/docs/cmd/wolfictl_advisory_create.md
@@ -28,6 +28,10 @@ command line, the command will prompt for the missing values.
 If the --no-prompt flag is specified, then the command will fail if any
 required fields are missing.
 
+It's possible to create advisories for multiple packages and/or vulnerabilities 
+at once by using a comma-separated list of package names and vulnerabilities. 
+This is available for both the CLI flags and the interactive prompt fields.
+
 This command also performs a follow-up operation to discover aliases for the
 newly created advisory and any other advisories for the same package.
 
@@ -43,11 +47,11 @@ newly created advisory and any other advisories for the same package.
       --no-distro-detection          do not attempt to auto-detect the distro
       --no-prompt                    do not prompt the user for input
       --note string                  prose explanation to attach to the event data (can be used with any event type)
-  -p, --package string               package name
+  -p, --package strings              package names
   -r, --package-repo-url string      URL of the APK package repository
       --timestamp string             timestamp of the event (RFC3339 format) (default "now")
   -t, --type string                  type of event [detection, true-positive-determination, fixed, false-positive-determination, analysis-not-planned, fix-not-planned, pending-upstream-fix]
-  -V, --vuln string                  vulnerability ID for advisory
+  -V, --vuln strings                 vulnerability IDs for advisory
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/wolfictl_advisory_update.md
+++ b/docs/cmd/wolfictl_advisory_update.md
@@ -25,6 +25,10 @@ You can specify required values on the command line using the flags relevant to
 the advisory event you are adding. If not all required values are provided on
 the command line, the command will prompt for the missing values.
 
+It's possible to update advisories for multiple packages and/or vulnerabilities 
+at once by using a comma-separated list of package names and vulnerabilities. 
+This is available for both the CLI flags and the interactive prompt fields.
+
 If the --no-prompt flag is specified, then the command will fail if any
 required fields are missing.
 
@@ -40,11 +44,11 @@ required fields are missing.
       --no-distro-detection          do not attempt to auto-detect the distro
       --no-prompt                    do not prompt the user for input
       --note string                  prose explanation to attach to the event data (can be used with any event type)
-  -p, --package string               package name
+  -p, --package strings              package names
   -r, --package-repo-url string      URL of the APK package repository
       --timestamp string             timestamp of the event (RFC3339 format) (default "now")
   -t, --type string                  type of event [detection, true-positive-determination, fixed, false-positive-determination, analysis-not-planned, fix-not-planned, pending-upstream-fix]
-  -V, --vuln string                  vulnerability ID for advisory
+  -V, --vuln strings                 vulnerability IDs for advisory
 ```
 
 ### Options inherited from parent commands

--- a/docs/man/man1/wolfictl-advisory-create.1
+++ b/docs/man/man1/wolfictl-advisory-create.1
@@ -38,6 +38,11 @@ If the \-\-no\-prompt flag is specified, then the command will fail if any
 required fields are missing.
 
 .PP
+It's possible to create advisories for multiple packages and/or vulnerabilities
+at once by using a comma\-separated list of package names and vulnerabilities.
+This is available for both the CLI flags and the interactive prompt fields.
+
+.PP
 This command also performs a follow\-up operation to discover aliases for the
 newly created advisory and any other advisories for the same package.
 
@@ -80,8 +85,8 @@ newly created advisory and any other advisories for the same package.
     prose explanation to attach to the event data (can be used with any event type)
 
 .PP
-\fB\-p\fP, \fB\-\-package\fP=""
-    package name
+\fB\-p\fP, \fB\-\-package\fP=[]
+    package names
 
 .PP
 \fB\-r\fP, \fB\-\-package\-repo\-url\fP=""
@@ -96,8 +101,8 @@ newly created advisory and any other advisories for the same package.
     type of event [detection, true\-positive\-determination, fixed, false\-positive\-determination, analysis\-not\-planned, fix\-not\-planned, pending\-upstream\-fix]
 
 .PP
-\fB\-V\fP, \fB\-\-vuln\fP=""
-    vulnerability ID for advisory
+\fB\-V\fP, \fB\-\-vuln\fP=[]
+    vulnerability IDs for advisory
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/docs/man/man1/wolfictl-advisory-update.1
+++ b/docs/man/man1/wolfictl-advisory-update.1
@@ -34,6 +34,11 @@ the advisory event you are adding. If not all required values are provided on
 the command line, the command will prompt for the missing values.
 
 .PP
+It's possible to update advisories for multiple packages and/or vulnerabilities
+at once by using a comma\-separated list of package names and vulnerabilities.
+This is available for both the CLI flags and the interactive prompt fields.
+
+.PP
 If the \-\-no\-prompt flag is specified, then the command will fail if any
 required fields are missing.
 
@@ -76,8 +81,8 @@ required fields are missing.
     prose explanation to attach to the event data (can be used with any event type)
 
 .PP
-\fB\-p\fP, \fB\-\-package\fP=""
-    package name
+\fB\-p\fP, \fB\-\-package\fP=[]
+    package names
 
 .PP
 \fB\-r\fP, \fB\-\-package\-repo\-url\fP=""
@@ -92,8 +97,8 @@ required fields are missing.
     type of event [detection, true\-positive\-determination, fixed, false\-positive\-determination, analysis\-not\-planned, fix\-not\-planned, pending\-upstream\-fix]
 
 .PP
-\fB\-V\fP, \fB\-\-vuln\fP=""
-    vulnerability ID for advisory
+\fB\-V\fP, \fB\-\-vuln\fP=[]
+    vulnerability IDs for advisory
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/pkg/advisory/alias_finder_test.go
+++ b/pkg/advisory/alias_finder_test.go
@@ -1,0 +1,103 @@
+package advisory
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteAliasSet(t *testing.T) {
+	ctx := t.Context()
+
+	af := mockAliasFinder{
+		cveByGHSA: map[string]string{
+			"GHSA-2222-2222-2222": "CVE-2222-2222",
+			"GHSA-3333-3333-3333": "CVE-3333-3333",
+			"GHSA-3r3r-3r3r-3r3r": "CVE-3333-3333",
+		},
+		ghsasByCVE: map[string][]string{
+			"CVE-2222-2222": {"GHSA-2222-2222-2222"},
+			"CVE-3333-3333": {"GHSA-3333-3333-3333", "GHSA-3r3r-3r3r-3r3r"},
+		},
+	}
+
+	cases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "single id, already complete",
+			input: []string{
+				"GHSA-pppp-pppp-pppp",
+			},
+			expected: []string{
+				"GHSA-pppp-pppp-pppp",
+			},
+		},
+		{
+			name: "single id, needs a CVE alias",
+			input: []string{
+				"GHSA-2222-2222-2222",
+			},
+			expected: []string{
+				"CVE-2222-2222",
+				"GHSA-2222-2222-2222",
+			},
+		},
+		{
+			name: "single id, needs a GHSA alias",
+			input: []string{
+				"CVE-2222-2222",
+			},
+			expected: []string{
+				"CVE-2222-2222",
+				"GHSA-2222-2222-2222",
+			},
+		},
+		{
+			name: "multiple in, and need to find aliases of aliases",
+			input: []string{
+				"GHSA-2222-2222-2222",
+				"GHSA-3333-3333-3333", // i.e. first resolve to CVE-3333-3333, and from there to GHSA-3r3r-3r3r-3r3r
+			},
+			expected: []string{
+				"CVE-2222-2222",
+				"CVE-3333-3333",
+				"GHSA-2222-2222-2222",
+				"GHSA-3333-3333-3333",
+				"GHSA-3r3r-3r3r-3r3r",
+			},
+		},
+		{
+			name: "multiple in, already complete",
+			input: []string{
+				"CVE-3333-3333",
+				"GHSA-3333-3333-3333",
+				"GHSA-3r3r-3r3r-3r3r",
+			},
+			expected: []string{
+				"CVE-3333-3333",
+				"GHSA-3333-3333-3333",
+				"GHSA-3r3r-3r3r-3r3r",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := CompleteAliasSet(ctx, af, tt.input)
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("unexpected results (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/advisory/discover_aliases_test.go
+++ b/pkg/advisory/discover_aliases_test.go
@@ -180,10 +180,10 @@ type mockAliasFinder struct {
 	ghsasByCVE map[string][]string
 }
 
-func (f *mockAliasFinder) CVEForGHSA(_ context.Context, ghsaID string) (string, error) {
+func (f mockAliasFinder) CVEForGHSA(_ context.Context, ghsaID string) (string, error) {
 	return f.cveByGHSA[ghsaID], nil
 }
 
-func (f *mockAliasFinder) GHSAsForCVE(_ context.Context, cveID string) ([]string, error) {
+func (f mockAliasFinder) GHSAsForCVE(_ context.Context, cveID string) ([]string, error) {
 	return f.ghsasByCVE[cveID], nil
 }

--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -142,8 +142,20 @@ func (req Request) ResolveAliases(ctx context.Context, af AliasFinder) (*Request
 type RequestParams struct {
 	PackageNames, Vulns []string
 
-	EventType, TruePositiveNote, FalsePositiveNote, FalsePositiveType, Timestamp, FixedVersion, Note string
+	Timestamp, EventType, FixedVersion, FalsePositiveType, FalsePositiveNote, TruePositiveNote, Note string
 }
+
+const (
+	RequestParamPackageNames      = "PackageNames"
+	RequestParamVulns             = "Vulns"
+	RequestParamTimestamp         = "Timestamp"
+	RequestParamEventType         = "EventType"
+	RequestParamFixedVersion      = "FixedVersion"
+	RequestParamFalsePositiveType = "FalsePositiveType"
+	RequestParamFalsePositiveNote = "FalsePositiveNote"
+	RequestParamTruePositiveNote  = "TruePositiveNote"
+	RequestParamNote              = "Note"
+)
 
 // MissingValues returns a slice of names of fields that are missing, such that
 // generating any Request data is not possible. If enough fields are present to
@@ -153,14 +165,50 @@ func (p RequestParams) MissingValues() []string {
 	var missing []string
 
 	if len(p.PackageNames) == 0 {
-		missing = append(missing, "PackageNames")
+		missing = append(missing, RequestParamPackageNames)
 	}
 
 	if len(p.Vulns) == 0 {
-		missing = append(missing, "Vulns")
+		missing = append(missing, RequestParamVulns)
 	}
 
-	// TODO: handle the rest of the values
+	if p.EventType == "" {
+		missing = append(missing, RequestParamEventType)
+	}
+
+	if p.Timestamp == "" {
+		missing = append(missing, RequestParamTimestamp)
+	}
+
+	if p.EventType == v2.EventTypeFixed && p.FixedVersion == "" {
+		missing = append(missing, RequestParamFixedVersion)
+	}
+
+	if p.EventType == v2.EventTypeFalsePositiveDetermination {
+		if p.FalsePositiveType == "" {
+			missing = append(missing, RequestParamFalsePositiveType)
+		}
+
+		if p.FalsePositiveNote == "" && p.Note == "" {
+			missing = append(missing, RequestParamFalsePositiveNote)
+		}
+	}
+
+	if p.EventType == v2.EventTypeTruePositiveDetermination && p.TruePositiveNote == "" && p.Note == "" {
+		missing = append(missing, RequestParamTruePositiveNote)
+	}
+
+	if p.EventType == v2.EventTypeAnalysisNotPlanned && p.Note == "" {
+		missing = append(missing, RequestParamNote)
+	}
+
+	if p.EventType == v2.EventTypeFixNotPlanned && p.Note == "" {
+		missing = append(missing, RequestParamNote)
+	}
+
+	if p.EventType == v2.EventTypePendingUpstreamFix && p.Note == "" {
+		missing = append(missing, RequestParamNote)
+	}
 
 	return missing
 }

--- a/pkg/advisory/request_test.go
+++ b/pkg/advisory/request_test.go
@@ -3,7 +3,9 @@ package advisory
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 )
 
 func TestRequest_Validate(t *testing.T) {
@@ -56,6 +58,128 @@ func TestRequest_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.errorAssertion(t, tt.req.Validate())
+		})
+	}
+}
+
+func TestRequestParams_MissingValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		reqParams RequestParams
+		expected  []string
+	}{
+		{
+			name:      "totally empty",
+			reqParams: RequestParams{},
+			expected: []string{
+				RequestParamPackageNames,
+				RequestParamVulns,
+				RequestParamEventType,
+				RequestParamTimestamp,
+			},
+		},
+		{
+			name: "have only vulns and event type of fixed",
+			reqParams: RequestParams{
+				Vulns:     []string{"CVE-2222-2222"},
+				EventType: v2.EventTypeFixed,
+			},
+			expected: []string{
+				RequestParamPackageNames,
+				RequestParamTimestamp,
+				RequestParamFixedVersion,
+			},
+		},
+		{
+			name: "have only package names, timestamp, and event type of false positive",
+			reqParams: RequestParams{
+				PackageNames: []string{"foo", "bar"},
+				Timestamp:    "2023-01-01T00:00:00Z",
+				EventType:    v2.EventTypeFalsePositiveDetermination,
+			},
+			expected: []string{
+				RequestParamVulns,
+				RequestParamFalsePositiveType,
+				RequestParamFalsePositiveNote,
+			},
+		},
+		{
+			name: "false positive using generic note field (which is acceptable)",
+			reqParams: RequestParams{
+				PackageNames:      []string{"foo"},
+				Vulns:             []string{"CVE-2222-2222"},
+				EventType:         v2.EventTypeFalsePositiveDetermination,
+				FalsePositiveType: v2.FPTypeVulnerabilityRecordAnalysisContested,
+				Timestamp:         "now",
+				Note:              "because because because because because",
+			},
+		},
+		{
+			name: "fix-not-planned without note",
+			reqParams: RequestParams{
+				PackageNames: []string{"foo"},
+				Vulns:        []string{"CVE-2222-2222"},
+				EventType:    v2.EventTypeFixNotPlanned,
+				Timestamp:    "now",
+			},
+			expected: []string{
+				RequestParamNote,
+			},
+		},
+		{
+			name: "fix-not-planned with note",
+			reqParams: RequestParams{
+				PackageNames: []string{"foo"},
+				Vulns:        []string{"CVE-2222-2222"},
+				EventType:    v2.EventTypeFixNotPlanned,
+				Timestamp:    "now",
+				Note:         "because because because because because",
+			},
+			expected: nil,
+		},
+		{
+			name: "fixed with fixed version",
+			reqParams: RequestParams{
+				PackageNames: []string{"foo"},
+				Vulns:        []string{"CVE-2222-2222"},
+				EventType:    v2.EventTypeFixed,
+				Timestamp:    "now",
+				FixedVersion: "1.0.0-r0",
+			},
+			expected: nil,
+		},
+		{
+			name: "true positive with note",
+			reqParams: RequestParams{
+				PackageNames: []string{"foo"},
+				Vulns:        []string{"CVE-2222-2222"},
+				EventType:    v2.EventTypeTruePositiveDetermination,
+				Timestamp:    "now",
+				Note:         "because because because because because",
+			},
+			expected: nil,
+		},
+		{
+			name: "true positive without note",
+			reqParams: RequestParams{
+				PackageNames: []string{"foo"},
+				Vulns:        []string{"CVE-2222-2222"},
+				EventType:    v2.EventTypeTruePositiveDetermination,
+				Timestamp:    "now",
+			},
+			expected: []string{
+				RequestParamTruePositiveNote,
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.reqParams.MissingValues()
+
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("RequestParams.MissingValues() mismatch (-expected +actual):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -24,3 +24,7 @@ type Getter interface {
 	// valid, non-empty data.
 	Advisories(ctx context.Context, packageName string) ([]v2.PackageAdvisory, error)
 }
+
+type Putter interface {
+	Upsert(ctx context.Context, request Request) (string, error)
+}

--- a/pkg/cli/components/advisory/field/field.go
+++ b/pkg/cli/components/advisory/field/field.go
@@ -16,7 +16,7 @@ type Field interface {
 	SetBlur() Field
 	SetFocus() (Field, tea.Cmd)
 	Update(tea.Msg) (Field, tea.Cmd)
-	UpdateRequest(request advisory.Request) advisory.Request
+	UpdateRequestParams(p advisory.RequestParams) advisory.RequestParams
 	SubmitValue() (Field, error)
 }
 

--- a/pkg/cli/components/advisory/field/list_field.go
+++ b/pkg/cli/components/advisory/field/list_field.go
@@ -11,20 +11,20 @@ import (
 )
 
 type ListField struct {
-	id             string
-	prompt         string
-	input          list.Model
-	done           bool
-	requestUpdater func(value string, req advisory.Request) advisory.Request
+	id                   string
+	prompt               string
+	input                list.Model
+	done                 bool
+	requestParamsUpdater func(value string, p advisory.RequestParams) advisory.RequestParams
 }
 
 type ListFieldConfiguration struct {
 	// ID is a unique identifier for the field.
 	ID string
 
-	Prompt         string
-	Options        []string
-	RequestUpdater func(value string, req advisory.Request) advisory.Request
+	Prompt               string
+	Options              []string
+	RequestParamsUpdater func(value string, p advisory.RequestParams) advisory.RequestParams
 }
 
 func NewListField(cfg ListFieldConfiguration) ListField {
@@ -33,10 +33,10 @@ func NewListField(cfg ListFieldConfiguration) ListField {
 	l.UnselectedStyle = styles.Secondary()
 
 	return ListField{
-		id:             cfg.ID,
-		prompt:         cfg.Prompt,
-		input:          l,
-		requestUpdater: cfg.RequestUpdater,
+		id:                   cfg.ID,
+		prompt:               cfg.Prompt,
+		input:                l,
+		requestParamsUpdater: cfg.RequestParamsUpdater,
 	}
 }
 
@@ -44,9 +44,9 @@ func (f ListField) ID() string {
 	return f.id
 }
 
-func (f ListField) UpdateRequest(req advisory.Request) advisory.Request {
+func (f ListField) UpdateRequestParams(p advisory.RequestParams) advisory.RequestParams {
 	value := f.Value()
-	return f.requestUpdater(value, req)
+	return f.requestParamsUpdater(value, p)
 }
 
 func (f ListField) SubmitValue() (Field, error) {

--- a/pkg/cli/components/advisory/prompt/model.go
+++ b/pkg/cli/components/advisory/prompt/model.go
@@ -2,6 +2,8 @@ package prompt
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,17 +17,20 @@ type Model struct {
 	// internal data
 	focusIndex                 int
 	fields                     []field.Field
-	allowedPackagesFunc        func() []string
-	allowedVulnerabilitiesFunc func(packageName string) []string
-	allowedFixedVersionsFunc   func(packageName string) []string
+	allowedPackagesFunc        func() ([]string, error)
+	allowedVulnerabilitiesFunc func(packageName string) ([]string, error)
+	allowedFixedVersionsFunc   func(packageName string) ([]string, error)
 
 	// input/output data
-	Request advisory.Request
+	RequestParams advisory.RequestParams
 
 	// output data
 
 	// EarlyExit is set to true if the user asks to exit the prompt early.
 	EarlyExit bool
+
+	// Err is set if an error occurs during the prompt.
+	Err error
 }
 
 const (
@@ -41,38 +46,54 @@ const (
 	fieldIDPendingUpstreamFixNote = "pending-upstream-fix-note"
 )
 
-func (m Model) newPackageFieldConfig() field.TextFieldConfiguration {
-	allowedValues := m.allowedPackagesFunc()
+func (m Model) newPackageFieldConfig() (field.TextFieldConfiguration, error) {
+	allowedValues, err := m.allowedPackagesFunc()
+	if err != nil {
+		return field.TextFieldConfiguration{}, fmt.Errorf("getting list of allowed packages: %w", err)
+	}
 
 	return field.TextFieldConfiguration{
 		ID:     fieldIDPackage,
 		Prompt: "Package: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			req.Package = value
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			names := strings.Split(value, ",")
+			for _, name := range names {
+				p.PackageNames = append(p.PackageNames, strings.TrimSpace(name))
+			}
+			return p
 		},
-		AllowedValues:     allowedValues,
 		EmptyValueHelpMsg: "Type to find a package.",
 		NoMatchHelpMsg:    "No matching package found.",
 		ValidationRules: []field.TextValidationRule{
 			field.NotEmpty,
 		},
-	}
+		AllowedValues: allowedValues,
+	}, nil
 }
 
-func (m Model) newVulnerabilityFieldConfig() field.TextFieldConfiguration {
-	allowedValues := m.allowedVulnerabilitiesFunc(m.Request.Package)
+func (m Model) newVulnerabilityFieldConfig() (field.TextFieldConfiguration, error) {
+	var allowedValues []string
+
+	// If there are multiple packages selected, disable the constraint on the
+	// vulnerability field; otherwise, obtain the allowed values using the one
+	// package name.
+	if len(m.RequestParams.PackageNames) == 1 {
+		allowed, err := m.allowedVulnerabilitiesFunc(m.RequestParams.PackageNames[0])
+		if err != nil {
+			return field.TextFieldConfiguration{}, fmt.Errorf("getting list of allowed vulnerabilities: %w", err)
+		}
+		allowedValues = allowed
+	}
 
 	return field.TextFieldConfiguration{
 		ID:     fieldIDVulnerability,
 		Prompt: "Vulnerability: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if vuln.RegexCGA.MatchString(value) {
-				req.AdvisoryID = value
-				return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			vulns := strings.Split(value, ",")
+			for _, v := range vulns {
+				p.Vulns = append(p.Vulns, strings.TrimSpace(v))
 			}
-			req.Aliases = append(req.Aliases, value)
-			return req
+			return p
 		},
 		EmptyValueHelpMsg: "Provide a valid vulnerability ID.",
 		ValidationRules: []field.TextValidationRule{
@@ -80,17 +101,22 @@ func (m Model) newVulnerabilityFieldConfig() field.TextFieldConfiguration {
 			vuln.ValidateID,
 		},
 		AllowedValues: allowedValues,
-	}
+	}, nil
 }
 
 func (m Model) newTypeFieldConfig() field.ListFieldConfiguration {
 	return field.ListFieldConfiguration{
-		ID:      fieldIDEventType,
-		Prompt:  "Type: ",
-		Options: v2.EventTypes,
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			req.Event.Type = value
-			return req
+		ID:     fieldIDEventType,
+		Prompt: "Type: ",
+		Options: []string{
+			v2.EventTypeFixed,
+			v2.EventTypeFalsePositiveDetermination,
+			v2.EventTypeFixNotPlanned,
+			v2.EventTypePendingUpstreamFix,
+		},
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.EventType = value
+			return p
 		},
 	}
 }
@@ -99,19 +125,9 @@ func (m Model) newTruePositiveNoteFieldConfig() field.TextFieldConfiguration {
 	return field.TextFieldConfiguration{
 		ID:     fieldIDTruePositiveNote,
 		Prompt: "Note: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if value == "" {
-				req.Event.Data = nil
-				return req
-			}
-
-			if req.Event.Data == nil {
-				req.Event.Data = v2.TruePositiveDetermination{
-					Note: value,
-				}
-			}
-
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.TruePositiveNote = value
+			return p
 		},
 	}
 }
@@ -120,16 +136,9 @@ func (m Model) newFixNotPlannedNoteFieldConfig() field.TextFieldConfiguration {
 	return field.TextFieldConfiguration{
 		ID:     fieldIDFixNotPlannedNote,
 		Prompt: "Note: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if req.Event.Data == nil {
-				req.Event.Data = v2.FixNotPlanned{
-					Note: value,
-				}
-			} else if data, ok := req.Event.Data.(v2.FixNotPlanned); ok {
-				data.Note = value
-				req.Event.Data = data
-			}
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.Note = value
+			return p
 		},
 		ValidationRules: []field.TextValidationRule{
 			field.NotEmpty,
@@ -141,16 +150,9 @@ func (m Model) newAnalysisNotPlannedNoteFieldConfig() field.TextFieldConfigurati
 	return field.TextFieldConfiguration{
 		ID:     fieldIDAnalysisNotPlannedNote,
 		Prompt: "Note: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if req.Event.Data == nil {
-				req.Event.Data = v2.AnalysisNotPlanned{
-					Note: value,
-				}
-			} else if data, ok := req.Event.Data.(v2.AnalysisNotPlanned); ok {
-				data.Note = value
-				req.Event.Data = data
-			}
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.Note = value
+			return p
 		},
 		ValidationRules: []field.TextValidationRule{
 			field.NotEmpty,
@@ -162,16 +164,9 @@ func (m Model) newPendingUpstreamReleaseNoteFieldConfig() field.TextFieldConfigu
 	return field.TextFieldConfiguration{
 		ID:     fieldIDPendingUpstreamFixNote,
 		Prompt: "Note: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if req.Event.Data == nil {
-				req.Event.Data = v2.PendingUpstreamFix{
-					Note: value,
-				}
-			} else if data, ok := req.Event.Data.(v2.PendingUpstreamFix); ok {
-				data.Note = value
-				req.Event.Data = data
-			}
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.Note = value
+			return p
 		},
 		ValidationRules: []field.TextValidationRule{
 			field.NotEmpty,
@@ -183,16 +178,9 @@ func (m Model) newFalsePositiveNoteFieldConfig() field.TextFieldConfiguration {
 	return field.TextFieldConfiguration{
 		ID:     fieldIDFalsePositiveNote,
 		Prompt: "Note: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if req.Event.Data == nil {
-				req.Event.Data = v2.FalsePositiveDetermination{
-					Note: value,
-				}
-			} else if data, ok := req.Event.Data.(v2.FalsePositiveDetermination); ok {
-				data.Note = value
-				req.Event.Data = data
-			}
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.FalsePositiveNote = value
+			return p
 		},
 		ValidationRules: []field.TextValidationRule{
 			field.NotEmpty,
@@ -205,33 +193,25 @@ func (m Model) newFalsePositiveTypeFieldConfig() field.ListFieldConfiguration {
 		ID:      fieldIDFalsePositiveType,
 		Prompt:  "False Positive Type: ",
 		Options: v2.FPTypes,
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if req.Event.Data == nil {
-				req.Event.Data = v2.FalsePositiveDetermination{
-					Type: value,
-				}
-			} else if data, ok := req.Event.Data.(v2.FalsePositiveDetermination); ok {
-				data.Type = value
-				req.Event.Data = data
-			}
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.FalsePositiveType = value
+			return p
 		},
 	}
 }
 
-func (m Model) newFixedVersionFieldConfig(packageName string) field.TextFieldConfiguration {
-	allowedVersions := m.allowedFixedVersionsFunc(packageName)
+func (m Model) newFixedVersionFieldConfig(packageName string) (field.TextFieldConfiguration, error) {
+	allowedVersions, err := m.allowedFixedVersionsFunc(packageName)
+	if err != nil {
+		return field.TextFieldConfiguration{}, fmt.Errorf("getting list of allowed fixed versions: %w", err)
+	}
 
 	cfg := field.TextFieldConfiguration{
 		ID:     fieldIDFixedVersion,
 		Prompt: "Fixed Version: ",
-		RequestUpdater: func(value string, req advisory.Request) advisory.Request {
-			if req.Event.Data == nil {
-				req.Event.Data = v2.Fixed{
-					FixedVersion: value,
-				}
-			}
-			return req
+		RequestParamsUpdater: func(value string, p advisory.RequestParams) advisory.RequestParams {
+			p.FixedVersion = value
+			return p
 		},
 		AllowedValues:  allowedVersions,
 		NoMatchHelpMsg: "No matching version found.",
@@ -241,7 +221,7 @@ func (m Model) newFixedVersionFieldConfig(packageName string) field.TextFieldCon
 		cfg.DefaultSuggestion = allowedVersions[0]
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 func (m Model) hasFieldWithID(id string) bool {
@@ -255,15 +235,15 @@ func (m Model) hasFieldWithID(id string) bool {
 }
 
 type Configuration struct {
-	Request                    advisory.Request
-	AllowedPackagesFunc        func() []string
-	AllowedVulnerabilitiesFunc func(packageName string) []string
-	AllowedFixedVersionsFunc   func(packageName string) []string
+	RequestParams              advisory.RequestParams
+	AllowedPackagesFunc        func() ([]string, error)
+	AllowedVulnerabilitiesFunc func(packageName string) ([]string, error)
+	AllowedFixedVersionsFunc   func(packageName string) ([]string, error)
 }
 
 func New(config Configuration) Model {
 	m := Model{
-		Request: config.Request,
+		RequestParams: config.RequestParams,
 
 		allowedPackagesFunc:        config.AllowedPackagesFunc,
 		allowedVulnerabilitiesFunc: config.AllowedVulnerabilitiesFunc,
@@ -280,28 +260,55 @@ func New(config Configuration) Model {
 // addMissingFields returns an updated model, and a bool indicating whether any
 // fields needed to be added.
 func (m Model) addMissingFields() (Model, bool) {
-	if m.Request.Package == "" {
-		f := field.NewTextField(m.newPackageFieldConfig())
+	if len(m.RequestParams.PackageNames) == 0 {
+		fieldConfig, err := m.newPackageFieldConfig()
+		if err != nil {
+			m.Err = fmt.Errorf("failed to create package field: %w", err)
+			m.EarlyExit = true
+			return m, false
+		}
+
+		f := field.NewTextField(fieldConfig)
 		m.fields = append(m.fields, f)
 		return m, true
 	}
 
-	if len(m.Request.VulnerabilityIDs()) == 0 {
-		f := field.NewTextField(m.newVulnerabilityFieldConfig())
+	if len(m.RequestParams.Vulns) == 0 {
+		fieldConfig, err := m.newVulnerabilityFieldConfig()
+		if err != nil {
+			m.Err = fmt.Errorf("failed to create vulnerability field: %w", err)
+			m.EarlyExit = true
+			return m, false
+		}
+
+		f := field.NewTextField(fieldConfig)
 		m.fields = append(m.fields, f)
 		return m, true
 	}
 
-	if m.Request.Event.Type == "" {
+	if m.RequestParams.EventType == "" {
 		f := field.NewListField(m.newTypeFieldConfig())
 		m.fields = append(m.fields, f)
 		return m, true
 	}
 
-	switch e := m.Request.Event; e.Type {
+	switch p := m.RequestParams; p.EventType {
 	case v2.EventTypeFixed:
-		if data, ok := e.Data.(v2.Fixed); !ok || data.FixedVersion == "" {
-			f := field.NewTextField(m.newFixedVersionFieldConfig(m.Request.Package))
+		if p.FixedVersion == "" {
+			if len(p.PackageNames) > 1 {
+				m.Err = errors.New("prompting doesn't support fixed events when specifying multiple packages")
+				m.EarlyExit = true
+				return m, false
+			}
+
+			fieldConfig, err := m.newFixedVersionFieldConfig(p.PackageNames[0])
+			if err != nil {
+				m.Err = fmt.Errorf("failed to create fixed version field: %w", err)
+				m.EarlyExit = true
+				return m, false
+			}
+
+			f := field.NewTextField(fieldConfig)
 			m.fields = append(m.fields, f)
 			return m, true
 		}
@@ -312,41 +319,41 @@ func (m Model) addMissingFields() (Model, bool) {
 			return m, false
 		}
 
-		if _, ok := e.Data.(v2.TruePositiveDetermination); !ok {
+		if p.TruePositiveNote == "" && p.Note == "" {
 			f := field.NewTextField(m.newTruePositiveNoteFieldConfig())
 			m.fields = append(m.fields, f)
 			return m, true
 		}
 
 	case v2.EventTypeFalsePositiveDetermination:
-		if data, ok := e.Data.(v2.FalsePositiveDetermination); !ok || data.Type == "" {
+		if p.FalsePositiveType == "" {
 			f := field.NewListField(m.newFalsePositiveTypeFieldConfig())
 			m.fields = append(m.fields, f)
 			return m, true
 		}
 
-		if data, ok := e.Data.(v2.FalsePositiveDetermination); !ok || data.Note == "" {
+		if p.FalsePositiveNote == "" && p.Note == "" {
 			f := field.NewTextField(m.newFalsePositiveNoteFieldConfig())
 			m.fields = append(m.fields, f)
 			return m, true
 		}
 
 	case v2.EventTypeFixNotPlanned:
-		if data, ok := e.Data.(v2.FixNotPlanned); !ok || data.Note == "" {
+		if p.Note == "" {
 			f := field.NewTextField(m.newFixNotPlannedNoteFieldConfig())
 			m.fields = append(m.fields, f)
 			return m, true
 		}
 
 	case v2.EventTypeAnalysisNotPlanned:
-		if data, ok := e.Data.(v2.AnalysisNotPlanned); !ok || data.Note == "" {
+		if p.Note == "" {
 			f := field.NewTextField(m.newAnalysisNotPlannedNoteFieldConfig())
 			m.fields = append(m.fields, f)
 			return m, true
 		}
 
 	case v2.EventTypePendingUpstreamFix:
-		if data, ok := e.Data.(v2.PendingUpstreamFix); !ok || data.Note == "" {
+		if p.Note == "" {
 			f := field.NewTextField(m.newPendingUpstreamReleaseNoteFieldConfig())
 			m.fields = append(m.fields, f)
 			return m, true
@@ -383,12 +390,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// TODO: Handle other errors
 			}
 
-			m.Request = sel.UpdateRequest(m.Request)
-
-			// We should move this business logic snippet somewhere else eventually.
-			if m.Request.Event.Type == v2.EventTypeDetection {
-				m.Request.Event.Data = v2.Detection{Type: v2.DetectionTypeManual}
-			}
+			m.RequestParams = sel.UpdateRequestParams(m.RequestParams)
 
 			m.fields[m.focusIndex] = sel
 

--- a/pkg/cli/components/advisory/prompt/model.go
+++ b/pkg/cli/components/advisory/prompt/model.go
@@ -160,7 +160,7 @@ func (m Model) newAnalysisNotPlannedNoteFieldConfig() field.TextFieldConfigurati
 	}
 }
 
-func (m Model) newPendingUpstreamReleaseNoteFieldConfig() field.TextFieldConfiguration {
+func (m Model) newPendingUpstreamFixNoteFieldConfig() field.TextFieldConfiguration {
 	return field.TextFieldConfiguration{
 		ID:     fieldIDPendingUpstreamFixNote,
 		Prompt: "Note: ",
@@ -354,7 +354,7 @@ func (m Model) addMissingFields() (Model, bool) {
 
 	case v2.EventTypePendingUpstreamFix:
 		if p.Note == "" {
-			f := field.NewTextField(m.newPendingUpstreamReleaseNoteFieldConfig())
+			f := field.NewTextField(m.newPendingUpstreamFixNoteFieldConfig())
 			m.fields = append(m.fields, f)
 			return m, true
 		}


### PR DESCRIPTION
This updates the `wolfictl adv create` and `... update` commands to be able to handle updates of multiple packages and/or vulnerabilities in one fell swoop — both via the CLI flags and the interactive prompts.

You can specify more than one item for both packages and vulnerabilities using a comma-separated list, e.g.:

```console
wolfictl adv create -p apko,age -V CVE-2025-1111,CVE-2025-1112 -t fix-not-planned --note 'insert reason'
```

`wolfictl` handles this by applying the given advisory event parameters to the cross product of any listed packages and vulnerabilities. So in the above example, we'll create a new advisory with the `fix-not-planned` event, for two packages, and two vulnerabilities for each of those two packages — resulting in the creation of **4 new advisories total**.

Less interesting things this PR also does:

- Removes `detection` and `analysis-not-planned` from the list of selectable event types from the interactive prompt (they shouldn't be needed)
- Uses the new readonly `Getter` abstraction in places where the `create` and `update` command logic have use for readonly advisory access
- Allows interactive prompt models to return an error to the user
- Adds a new handy `CompleteAliasSet` function for finding all aliases without using the heavier `DiscoverAliases` logic which depends on a `configs.Index[v2.Document]` instance
- Promotes the "Advisory Request Params" concept from a private type in the `cli` package to a public type in the `advisory` package, to allow for the separation of data gathering (including via e.g. interactive prompts) and data access (i.e. the `Request` type passed to `advisory.Create` and `advisory.Update`).