### PR TITLE
advisories: add `FSPutter` implementation, use this to replace `configs.Index[v2.Document]` in `adv create` and `adv update` commands

### DIFF
--- a/pkg/advisory/fs_putter.go
+++ b/pkg/advisory/fs_putter.go
@@ -1,0 +1,184 @@
+package advisory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"sort"
+
+	"github.com/chainguard-dev/yam/pkg/yam/formatted"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	"github.com/wolfi-dev/wolfictl/pkg/configs/rwfs"
+)
+
+// DocumentEncoder writes a Document to an io.Writer in a specific format.
+type DocumentEncoder func(w io.Writer, doc v2.Document) error
+
+// NewYamDocumentEncoder creates a new DocumentEncoder that uses yan
+// (https://github.com/chainguard-dev/yam) to encode the document as YAML using
+// the specified formatting options.
+func NewYamDocumentEncoder(opts formatted.EncodeOptions) DocumentEncoder {
+	return func(w io.Writer, doc v2.Document) error {
+		enc := formatted.NewEncoder(w)
+
+		var err error
+		enc, err = enc.UseOptions(opts)
+		if err != nil {
+			return fmt.Errorf("using yam options: %w", err)
+		}
+
+		if err := enc.Encode(doc); err != nil {
+			return fmt.Errorf("encoding document: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// FSPutter is an implementation of Putter that creates or updates an advisory
+// using the given Request, operating on a `.advisories.yaml` file in the given
+// filesystem.
+type FSPutter struct {
+	fsys        rwfs.FS
+	enc         DocumentEncoder
+	idGenerator IDGenerator
+}
+
+// NewFSPutter creates and returns a new FSPutter that updates advisory data in
+// the given filesystem using the provided FileEncoder to marshal and format the
+// file data.
+func NewFSPutter(fsys rwfs.FS, enc DocumentEncoder) *FSPutter {
+	return &FSPutter{
+		fsys:        fsys,
+		enc:         enc,
+		idGenerator: DefaultIDGenerator,
+	}
+}
+
+func (p FSPutter) Upsert(_ context.Context, request Request) (string, error) {
+	if request.Package == "" {
+		return "", ErrEmptyPackage
+	}
+
+	// The advisories file might exist, or not. If it does exist, the advisory
+	// itself might exist, or not.
+
+	advisoryFileHadExisted := false
+
+	advFileName := fmt.Sprintf("%s.advisories.yaml", request.Package)
+	f, err := p.fsys.Open(advFileName)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("opening advisory file %q: %w", advFileName, err)
+	}
+
+	var doc *v2.Document
+	if err == nil {
+		advisoryFileHadExisted = true
+
+		doc, err = v2.DecodeDocument(f)
+		if err != nil {
+			return "", fmt.Errorf("decoding advisory file %q: %w", advFileName, err)
+		}
+	} else {
+		doc = &v2.Document{
+			Package: v2.Package{
+				Name: request.Package,
+			},
+		}
+	}
+
+	if advisoryFileHadExisted {
+		// Done reading. Depending on how far we get in the logic, we'll later open the
+		// file as writeable (if needed).
+		if err := f.Close(); err != nil {
+			return "", fmt.Errorf("closing advisory file %q: %w", advFileName, err)
+		}
+	}
+
+	// We set the schema to current whenever we're operating on the file.
+	doc.SchemaVersion = v2.SchemaVersion
+
+	// Find or create the advisory
+	var advisory *v2.Advisory
+	if reqID := request.AdvisoryID; reqID != "" {
+		adv, exists := doc.Advisories.Get(reqID)
+		if exists {
+			// We'll be updating this existing advisory.
+			advisory = &adv
+		} else {
+			return "", fmt.Errorf("advisory ID %q not found for package %q", reqID, request.Package)
+		}
+	} else {
+		adv, exists := doc.Advisories.GetByAnyVulnerability(request.Aliases...)
+		if exists {
+			// We'll be updating this existing advisory.
+			advisory = &adv
+		} else {
+			// We'll be creating a new advisory.
+			newID, err := p.idGenerator.GenerateCGAID()
+			if err != nil {
+				return "", fmt.Errorf("generating CGA ID when creating new advisory: %w", err)
+			}
+			advisory = &v2.Advisory{
+				ID: newID,
+			}
+		}
+	}
+
+	// Union the alias lists.
+	updatedAliases := union(advisory.Aliases, request.Aliases)
+	advisory.Aliases = updatedAliases
+
+	if !request.Event.IsZero() {
+		advisory.Events = append(advisory.Events, request.Event)
+	}
+
+	doc.Advisories = doc.Advisories.Upsert(advisory.ID, *advisory)
+
+	// Write the updated document back to the file system
+
+	var w rwfs.File
+	if advisoryFileHadExisted {
+		w, err = p.fsys.OpenAsWritable(advFileName)
+		if err != nil {
+			return "", fmt.Errorf("opening advisory file %q as writable: %w", advFileName, err)
+		}
+	} else {
+		w, err = p.fsys.Create(advFileName)
+		if err != nil {
+			return "", fmt.Errorf("creating advisory file %q: %w", advFileName, err)
+		}
+	}
+
+	if err := p.fsys.Truncate(advFileName, 0); err != nil {
+		return "", fmt.Errorf("truncating advisory file %q (prior to writing to it): %w", advFileName, err)
+	}
+
+	if err := p.enc(w, *doc); err != nil {
+		return "", fmt.Errorf("encoding advisory file %q with YAML: %w", advFileName, err)
+	}
+
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("closing advisory file %q: %w", advFileName, err)
+	}
+
+	return advisory.ID, nil
+}
+
+func union(slice1, slice2 []string) []string {
+	m := make(map[string]struct{})
+	for _, s := range slice1 {
+		m[s] = struct{}{}
+	}
+	for _, s := range slice2 {
+		m[s] = struct{}{}
+	}
+	result := make([]string, 0, len(m))
+	for s := range m {
+		result = append(result, s)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/pkg/advisory/fs_putter_test.go
+++ b/pkg/advisory/fs_putter_test.go
@@ -1,0 +1,149 @@
+package advisory
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chainguard-dev/yam/pkg/yam/formatted"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	"github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os/testerfs"
+)
+
+func TestFSPutter_Upsert(t *testing.T) {
+	ctx := t.Context()
+	testTime := v2.Timestamp(time.Date(2022, 9, 15, 2, 40, 18, 0, time.UTC))
+
+	cases := []struct {
+		name                 string
+		req                  Request
+		skipFsysConstruction bool // don't bother with a test fsys since we expect a failure before fsys access
+		expectedID           string
+		assertErr            assert.ErrorAssertionFunc
+	}{
+		{
+			name: "no package name",
+			req: Request{
+				Package: "",
+			},
+			skipFsysConstruction: true,
+			assertErr:            assert.Error,
+		},
+		{
+			name: "package name with nonexistent advisory ID",
+			req: Request{
+				Package:    "foo",
+				AdvisoryID: "CGA-4444-4444-4444",
+			},
+			assertErr: assert.Error,
+		},
+		{
+			name: "no-op update",
+			req: Request{
+				Package:    "foo",
+				AdvisoryID: "CGA-2222-2222-2222",
+				Aliases:    nil,
+				Event:      v2.Event{},
+			},
+			expectedID: "CGA-2222-2222-2222",
+			assertErr:  assert.NoError,
+		},
+		{
+			name: "create when no document exists",
+			req: Request{
+				Package: "foo",
+				Aliases: []string{"CVE-2020-8927"},
+				Event: v2.Event{
+					Timestamp: testTime,
+					Type:      v2.EventTypeFixed,
+					Data: v2.Fixed{
+						FixedVersion: "1.0.9-r0",
+					},
+				},
+			},
+			expectedID: "CGA-2222-2222-2222",
+			assertErr:  assert.NoError,
+		},
+		{
+			name: "create when document exists but not advisory",
+			req: Request{
+				Package: "foo",
+				Aliases: []string{"CVE-2020-8927"},
+				Event: v2.Event{
+					Timestamp: testTime,
+					Type:      v2.EventTypeFixed,
+					Data: v2.Fixed{
+						FixedVersion: "1.0.9-r0",
+					},
+				},
+			},
+			expectedID: "CGA-2222-2222-2222",
+			assertErr:  assert.NoError,
+		},
+		{
+			name: "update",
+			req: Request{
+				Package:    "foo",
+				AdvisoryID: "CGA-2222-2222-2222",
+				Aliases:    []string{"CVE-2020-8927"},
+				Event: v2.Event{
+					Timestamp: testTime,
+					Type:      v2.EventTypePendingUpstreamFix,
+					Data: v2.PendingUpstreamFix{
+						Note: "this is a note",
+					},
+				},
+			},
+			expectedID: "CGA-2222-2222-2222",
+			assertErr:  assert.NoError,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := filepath.Join("testdata", "fs_putter", strings.ReplaceAll(tt.name, " ", "-"))
+
+			var fsys *testerfs.FS
+			var err error
+			if !tt.skipFsysConstruction {
+				fsys, err = testerfs.New(os.DirFS(testDir))
+				require.NoError(t, err)
+			}
+
+			var enc DocumentEncoder = func(w io.Writer, doc v2.Document) error {
+				encoder := formatted.NewEncoder(w)
+
+				// Set up the formatting options we expect
+				encoder = encoder.SetIndent(2)
+				encoder, err = encoder.SetGapExpressions(".", ".advisories")
+				require.NoError(t, err)
+
+				return encoder.Encode(doc)
+			}
+
+			p := &FSPutter{
+				fsys:        fsys,
+				enc:         enc,
+				idGenerator: StaticIDGenerator{ID: "CGA-2222-2222-2222"},
+			}
+
+			id, err := p.Upsert(ctx, tt.req)
+			tt.assertErr(t, err)
+
+			if tt.expectedID != id {
+				t.Errorf("expected ID result to be %q, got %q", tt.expectedID, id)
+			}
+
+			if err == nil {
+				if diff := fsys.DiffAll(); diff != "" {
+					t.Errorf("filesystem in an unexpected state (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -278,11 +278,26 @@ func (p *RequestParams) GenerateRequests() ([]Request, error) {
 	}
 
 	for _, packageName := range p.PackageNames {
-		for _, vulnID := range p.Vulns {
+		for _, id := range p.Vulns {
+			cgaID := ""
+			var aliases []string
+
+			// If the vuln is a CGA ID, use it as the AdvisoryID and set the aliases to the
+			// empty slice. Otherwise, use the ID as an alias. The RequestParams type cannot
+			// be used to generate a Request that has both an AdvisoryID and an alias at the
+			// same time.
+
+			if vuln.RegexCGA.MatchString(id) {
+				cgaID = id
+			} else {
+				aliases = []string{id}
+			}
+
 			r := Request{
-				Package: packageName,
-				Aliases: []string{vulnID},
-				Event:   event,
+				Package:    packageName,
+				AdvisoryID: cgaID,
+				Aliases:    aliases,
+				Event:      event,
 			}
 
 			reqs = append(reqs, r)

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -9,8 +9,7 @@ import (
 // Store abstracts the storage and retrieval of advisory data.
 type Store interface {
 	Getter
-
-	// TODO: write-oriented interface
+	Putter
 }
 
 // Getter is the interface for retrieving advisory data.
@@ -25,6 +24,33 @@ type Getter interface {
 	Advisories(ctx context.Context, packageName string) ([]v2.PackageAdvisory, error)
 }
 
+// Putter is the interface for storing advisory data.
 type Putter interface {
+	// Upsert stores the advisory data from the given Request. Upsert creates a new
+	// advisory or updates an existing advisory, depending on whether an advisory
+	// already exists that matches the given Request.
+	//
+	// An existing advisory is considered to match the given Request if the named
+	// package in the Request matches the package name in the advisory, and the
+	// advisory ID or any of the aliases in the Request match the advisory ID or
+	// aliases in the advisory, respectively. If the Request specified both an
+	// advisory ID, the advisory referenced by the advisory ID must match the
+	// package name in the Request, or an error should be returned.
+	//
+	// If the advisory ID in the Request is specified, only updating an existing
+	// advisory (not creating a new advisory) is permitted.
+	//
+	// When updating an advisory, the updated set of aliases for the advisory is the
+	// union of the existing aliases and the aliases in the Request.
+	//
+	// If the event specified in the Request is not zero (as determined by the
+	// evaluation of the event's IsZero method), it is added to the advisory.
+	//
+	// If the advisory is unable to be created or updated because of the above rules
+	// or because of an error encountered by the underlying implementation, an empty
+	// string and the error are returned.
+	//
+	// Otherwise, the advisory ID for the newly created or updated advisory is
+	// returned.
 	Upsert(ctx context.Context, request Request) (string, error)
 }

--- a/pkg/advisory/testdata/fs_putter/create-when-document-exists-but-not-advisory/foo.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/create-when-document-exists-but-not-advisory/foo.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-4444-4444-4444
+    aliases:
+      - CVE-2025-4444
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.10-r0

--- a/pkg/advisory/testdata/fs_putter/create-when-document-exists-but-not-advisory/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/create-when-document-exists-but-not-advisory/foo_expected.advisories.yaml
@@ -1,0 +1,23 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0
+
+  - id: CGA-4444-4444-4444
+    aliases:
+      - CVE-2025-4444
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.10-r0

--- a/pkg/advisory/testdata/fs_putter/create-when-no-document-exists/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/create-when-no-document-exists/foo_expected.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/fs_putter/no-op-update/foo.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/no-op-update/foo.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/fs_putter/no-op-update/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/no-op-update/foo_expected.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/fs_putter/package-name-with-nonexistent-advisory-ID/foo.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/package-name-with-nonexistent-advisory-ID/foo.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-37qj-pjrf-fmrw
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/fs_putter/package-name-with-nonexistent-advisory-ID/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/package-name-with-nonexistent-advisory-ID/foo_expected.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-37qj-pjrf-fmrw
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/fs_putter/update/foo.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/update/foo.advisories.yaml
@@ -1,0 +1,23 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-14T00:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0
+
+  - id: CGA-4444-4444-4444
+    aliases:
+      - CVE-2025-4444
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.10-r0

--- a/pkg/advisory/testdata/fs_putter/update/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/update/foo_expected.advisories.yaml
@@ -1,0 +1,27 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-14T00:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0
+      - timestamp: 2022-09-15T02:40:18Z
+        type: pending-upstream-fix
+        data:
+          note: this is a note
+
+  - id: CGA-4444-4444-4444
+    aliases:
+      - CVE-2025-4444
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.10-r0

--- a/pkg/configs/rwfs/os/testerfs/fsys.go
+++ b/pkg/configs/rwfs/os/testerfs/fsys.go
@@ -301,6 +301,11 @@ func (fsys *FS) Open(name string) (fs.File, error) {
 			// be allowed to return EOF again.
 			f.writtenBackReader = bytes.NewReader(f.writtenBack.Bytes())
 		} else {
+			if f.missingOriginal {
+				// There is no original file. So if it hasn't been updated, we'd want to
+				// represent it as still not existing.
+				return nil, fs.ErrNotExist
+			}
 			f.originalReader = bytes.NewReader(f.originalBytes)
 		}
 		return f, nil
@@ -453,6 +458,7 @@ func (fsys *FS) addOnlyExpectedFileAtPath(expectedFilePath string) error {
 		return fmt.Errorf("loading expected file from existing fsys: %w", err)
 	}
 
+	tf.missingOriginal = true
 	tf.writtenBack = new(bytes.Buffer)
 	fsys.registerTestFile(tf.path, tf)
 	return nil


### PR DESCRIPTION
This finishes documenting the new `advisory.Putter` write-only abstraction, and it creates an implementation that uses an (abstract) writeable filesystem so that we no longer need to use the hefty `configs.Index[v2.Document]` implementation in order to programmatically create and update advisories.
