### PR TITLE
feat(adv): on bulk operations for `create` and `update`, skip event additions that would be redundant by event type

### DIFF
--- a/docs/cmd/wolfictl_advisory_create.md
+++ b/docs/cmd/wolfictl_advisory_create.md
@@ -32,6 +32,11 @@ It's possible to create advisories for multiple packages and/or vulnerabilities
 at once by using a comma-separated list of package names and vulnerabilities. 
 This is available for both the CLI flags and the interactive prompt fields.
 
+When performing a bulk operation (i.e. on multiple advisories at once), if an
+advisory already has an event of the same type as the one being added, that
+advisory will be skipped, and a warning will be logged. This is to prevent
+adding redundant events to advisories that already have the same type of event.
+
 This command also performs a follow-up operation to discover aliases for the
 newly created advisory and any other advisories for the same package.
 

--- a/docs/cmd/wolfictl_advisory_update.md
+++ b/docs/cmd/wolfictl_advisory_update.md
@@ -25,9 +25,14 @@ You can specify required values on the command line using the flags relevant to
 the advisory event you are adding. If not all required values are provided on
 the command line, the command will prompt for the missing values.
 
-It's possible to update advisories for multiple packages and/or vulnerabilities 
-at once by using a comma-separated list of package names and vulnerabilities. 
+It's possible to update advisories for multiple packages and/or vulnerabilities
+at once by using a comma-separated list of package names and vulnerabilities.
 This is available for both the CLI flags and the interactive prompt fields.
+
+When performing a bulk operation (i.e. on multiple advisories at once), if an
+advisory already has an event of the same type as the one being added, that
+advisory will be skipped, and a warning will be logged. This is to prevent
+adding redundant events to advisories that already have the same type of event.
 
 If the --no-prompt flag is specified, then the command will fail if any
 required fields are missing.

--- a/docs/man/man1/wolfictl-advisory-create.1
+++ b/docs/man/man1/wolfictl-advisory-create.1
@@ -43,6 +43,12 @@ at once by using a comma\-separated list of package names and vulnerabilities.
 This is available for both the CLI flags and the interactive prompt fields.
 
 .PP
+When performing a bulk operation (i.e. on multiple advisories at once), if an
+advisory already has an event of the same type as the one being added, that
+advisory will be skipped, and a warning will be logged. This is to prevent
+adding redundant events to advisories that already have the same type of event.
+
+.PP
 This command also performs a follow\-up operation to discover aliases for the
 newly created advisory and any other advisories for the same package.
 

--- a/docs/man/man1/wolfictl-advisory-update.1
+++ b/docs/man/man1/wolfictl-advisory-update.1
@@ -39,6 +39,12 @@ at once by using a comma\-separated list of package names and vulnerabilities.
 This is available for both the CLI flags and the interactive prompt fields.
 
 .PP
+When performing a bulk operation (i.e. on multiple advisories at once), if an
+advisory already has an event of the same type as the one being added, that
+advisory will be skipped, and a warning will be logged. This is to prevent
+adding redundant events to advisories that already have the same type of event.
+
+.PP
 If the \-\-no\-prompt flag is specified, then the command will fail if any
 required fields are missing.
 

--- a/pkg/advisory/fs_getter.go
+++ b/pkg/advisory/fs_getter.go
@@ -60,6 +60,7 @@ func (g FSGetter) Advisories(_ context.Context, packageName string) ([]v2.Packag
 
 		return nil, fmt.Errorf("opening advisory file %q: %w", advFileName, err)
 	}
+	defer f.Close()
 
 	doc, err := v2.DecodeDocument(f)
 	if err != nil {

--- a/pkg/advisory/fs_putter_test.go
+++ b/pkg/advisory/fs_putter_test.go
@@ -54,6 +54,17 @@ func TestFSPutter_Upsert(t *testing.T) {
 			assertErr:  assert.NoError,
 		},
 		{
+			name: "just update aliases",
+			req: Request{
+				Package:    "foo",
+				AdvisoryID: "CGA-2222-2222-2222",
+				Aliases:    []string{"GHSA-xxxx-xxxx-xxxx"},
+				Event:      v2.Event{},
+			},
+			expectedID: "CGA-2222-2222-2222",
+			assertErr:  assert.NoError,
+		},
+		{
 			name: "create when no document exists",
 			req: Request{
 				Package: "foo",

--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -320,15 +320,15 @@ func resolveTimestamp(ts string) (v2.Timestamp, error) {
 	return v2.Timestamp(t), nil
 }
 
-// MatchPackageAdvisoryToRequest takes an input slice of PackageAdvisory and a
-// Request and returns the first PackageAdvisory that matches the Request. If no
-// match is found, it returns nil.
+// MatchToRequest takes an input slice of PackageAdvisory and a Request and
+// returns the first PackageAdvisory that matches the Request. If no match is
+// found, it returns nil.
 //
 // A "match" is defined as meeting all the following criteria: having the same
 // Package name; if the Request's AdvisoryID is set, it must match the
 // PackageAdvisory's ID; and if the Request has Aliases and no AdvisoryID, at
 // least one of the Aliases must match the PackageAdvisory's Aliases.
-func MatchPackageAdvisoryToRequest(advs []v2.PackageAdvisory, req Request) *v2.PackageAdvisory {
+func MatchToRequest(advs []v2.PackageAdvisory, req Request) *v2.PackageAdvisory {
 	for _, adv := range advs {
 		if adv.PackageName != req.Package {
 			continue

--- a/pkg/advisory/request.go
+++ b/pkg/advisory/request.go
@@ -319,3 +319,37 @@ func resolveTimestamp(ts string) (v2.Timestamp, error) {
 
 	return v2.Timestamp(t), nil
 }
+
+// MatchPackageAdvisoryToRequest takes an input slice of PackageAdvisory and a
+// Request and returns the first PackageAdvisory that matches the Request. If no
+// match is found, it returns nil.
+//
+// A "match" is defined as meeting all the following criteria: having the same
+// Package name; if the Request's AdvisoryID is set, it must match the
+// PackageAdvisory's ID; and if the Request has Aliases and no AdvisoryID, at
+// least one of the Aliases must match the PackageAdvisory's Aliases.
+func MatchPackageAdvisoryToRequest(advs []v2.PackageAdvisory, req Request) *v2.PackageAdvisory {
+	for _, adv := range advs {
+		if adv.PackageName != req.Package {
+			continue
+		}
+
+		if req.AdvisoryID != "" && adv.ID != req.AdvisoryID {
+			continue
+		}
+
+		if len(req.Aliases) > 0 && req.AdvisoryID == "" {
+			for _, reqAlias := range req.Aliases {
+				if adv.DescribesVulnerability(reqAlias) {
+					return &adv
+				}
+			}
+
+			continue
+		}
+
+		return &adv
+	}
+
+	return nil
+}

--- a/pkg/advisory/request_test.go
+++ b/pkg/advisory/request_test.go
@@ -323,7 +323,7 @@ func TestRequestParams_GenerateRequests(t *testing.T) {
 	}
 }
 
-func TestMatchPackageAdvisoryToRequest(t *testing.T) {
+func TestMatchToRequest(t *testing.T) {
 	var (
 		pkgAdvA = v2.PackageAdvisory{
 			PackageName: "foo",
@@ -439,10 +439,10 @@ func TestMatchPackageAdvisoryToRequest(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := MatchPackageAdvisoryToRequest(tt.advs, tt.req)
+			actual := MatchToRequest(tt.advs, tt.req)
 
 			if diff := cmp.Diff(tt.expected, actual); diff != "" {
-				t.Errorf("MatchPackageAdvisoryToRequest() mismatch (-expected +actual):\n%s", diff)
+				t.Errorf("MatchToRequest() mismatch (-expected +actual):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/advisory/testdata/fs_putter/just-update-aliases/foo.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/just-update-aliases/foo.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/fs_putter/just-update-aliases/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/just-update-aliases/foo_expected.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2020-8927
+      - GHSA-xxxx-xxxx-xxxx
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -198,7 +198,7 @@ func doesRequestRepeatEventType(ctx context.Context, g advisory.Getter, req advi
 		return false, nil
 	}
 
-	pkgAdv := advisory.MatchPackageAdvisoryToRequest(pkgAdvs, req)
+	pkgAdv := advisory.MatchToRequest(pkgAdvs, req)
 	if pkgAdv != nil {
 		// We found an existing advisory for this package.
 		// Check if the latest event type is the same as the one we're adding.

--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -186,4 +187,25 @@ func getYamEncodeOptions(dir string) (formatted.EncodeOptions, error) {
 	}
 
 	return *readOpts, nil
+}
+
+func doesRequestRepeatEventType(ctx context.Context, g advisory.Getter, req advisory.Request) (bool, error) {
+	pkgAdvs, err := g.Advisories(ctx, req.Package)
+	if err != nil {
+		return false, fmt.Errorf("getting advisories for package %q: %w", req.Package, err)
+	}
+	if len(pkgAdvs) == 0 {
+		return false, nil
+	}
+
+	pkgAdv := advisory.MatchPackageAdvisoryToRequest(pkgAdvs, req)
+	if pkgAdv != nil {
+		// We found an existing advisory for this package.
+		// Check if the latest event type is the same as the one we're adding.
+		if pkgAdv.Latest().Type == req.Event.Type {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/cli/advisory_update.go
+++ b/pkg/cli/advisory_update.go
@@ -19,7 +19,7 @@ import (
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
 )
 
-func cmdAdvisoryUpdate() *cobra.Command {
+func cmdAdvisoryUpdate() *cobra.Command { //nolint:gocyclo
 	p := &updateParams{}
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -39,9 +39,14 @@ You can specify required values on the command line using the flags relevant to
 the advisory event you are adding. If not all required values are provided on
 the command line, the command will prompt for the missing values.
 
-It's possible to update advisories for multiple packages and/or vulnerabilities 
-at once by using a comma-separated list of package names and vulnerabilities. 
+It's possible to update advisories for multiple packages and/or vulnerabilities
+at once by using a comma-separated list of package names and vulnerabilities.
 This is available for both the CLI flags and the interactive prompt fields.
+
+When performing a bulk operation (i.e. on multiple advisories at once), if an
+advisory already has an event of the same type as the one being added, that
+advisory will be skipped, and a warning will be logged. This is to prevent
+adding redundant events to advisories that already have the same type of event.
 
 If the --no-prompt flag is specified, then the command will fail if any
 required fields are missing.`,
@@ -201,10 +206,44 @@ required fields are missing.`,
 				return fmt.Errorf("generating advisory data requests: %w", err)
 			}
 
+			// If there are multiple requests to process, this is a "bulk" operation, and we
+			// want to skip (but log a warning) cases where we'd be adding an event to an
+			// existing advisory with the same type as that advisory's latest pre-existing
+			// event. To make this determination, we'll need a Getter.
+
+			// Default behavior.
+			skipRedundantEventType := func(_ advisory.Request) (bool, error) {
+				return false, nil
+			}
+
+			if len(requests) >= 2 {
+				g := advisory.NewFSGetter(os.DirFS(advisoriesRepoDir))
+
+				// Behavior for bulk operation.
+				skipRedundantEventType = func(req advisory.Request) (bool, error) {
+					return doesRequestRepeatEventType(ctx, g, req)
+				}
+			}
+
 			// Do just a single pass at finding aliases, instead of per-request.
 			af := advisory.NewHTTPAliasFinder(http.DefaultClient)
 
 			for _, r := range requests {
+				skip, err := skipRedundantEventType(r)
+				if err != nil {
+					return fmt.Errorf("checking for redundant event type for package %q: %w", r.Package, err)
+				}
+				if skip {
+					clog.FromContext(ctx).Warn(
+						"skipping processing of advisory request with same event type as existing advisory's latest event",
+						"package", r.Package,
+						"advisoryID", r.AdvisoryID,
+						"aliases", r.Aliases,
+						"eventType", r.Event.Type,
+					)
+					continue
+				}
+
 				// Complete the alias set for the request. Use the singular AliasFinder to
 				// benefit from its cache across multiple requests' resolutions.
 				aliases, err := advisory.CompleteAliasSet(ctx, af, r.Aliases)


### PR DESCRIPTION
This was requested by the Sustaining team, to help ensure that if they're operating en masse on a set of advisories, bulk operations are resilient to the scenario where one or two of the advisories in the target set have already received their updates via some other mechanism. The command logs a warning when this happens, so the user knows that part of the requested update was skipped, in case they want to add an event to the skipped advisory after all.

This PR also catches up on the auto-gen'ed documentation.