### PR TITLE
feat(yam): export lib method for reading and parsing yam config

### DIFF
--- a/pkg/cli/advisory.go
+++ b/pkg/cli/advisory.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
 	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/melange/pkg/config"
-	yamutil "github.com/chainguard-dev/yam/pkg/util"
-	"github.com/chainguard-dev/yam/pkg/yam/formatted"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/wolfictl/pkg/advisory"
@@ -169,27 +166,6 @@ func newAllowedFixedVersionsFunc(apkindexes []*apk.APKIndex, buildCfgs *configs.
 
 		return allowedVersions
 	}
-}
-
-// getYamEncodeOptions does a "best effort" retrieval of the yam encode options.
-// If no yam config is present in the given directory, no error is returned, and
-// a set of default options are returned. An error is only returned if there is
-// a problem reading the (present) yam config file.
-func getYamEncodeOptions(dir string) (formatted.EncodeOptions, error) {
-	defaultOpts := formatted.EncodeOptions{}
-
-	yamCfgPath := filepath.Join(dir, yamutil.ConfigFileName)
-	yamCfgFile, err := os.Open(yamCfgPath)
-	if err != nil {
-		return defaultOpts, nil
-	}
-
-	readOpts, err := formatted.ReadConfigFrom(yamCfgFile)
-	if err != nil {
-		return defaultOpts, fmt.Errorf("reading yam config from %q: %w", yamCfgPath, err)
-	}
-
-	return *readOpts, nil
 }
 
 func doesRequestRepeatEventType(ctx context.Context, g advisory.Getter, req advisory.Request) (bool, error) {

--- a/pkg/cli/advisory_create.go
+++ b/pkg/cli/advisory_create.go
@@ -16,6 +16,7 @@ import (
 	buildconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/build"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
+	"github.com/wolfi-dev/wolfictl/pkg/yam"
 )
 
 func cmdAdvisoryCreate() *cobra.Command { //nolint:gocyclo
@@ -117,7 +118,7 @@ newly created advisory and any other advisories for the same package.`,
 
 			advGetter := advisory.NewFSGetter(os.DirFS(advisoriesRepoDir))
 
-			encodeOpts, err := getYamEncodeOptions(advisoriesRepoDir)
+			encodeOpts, err := yam.TryReadingEncodeOptions(advisoriesRepoDir)
 			if err != nil {
 				return fmt.Errorf("getting yam encode options: %w", err)
 			}

--- a/pkg/cli/advisory_update.go
+++ b/pkg/cli/advisory_update.go
@@ -17,6 +17,7 @@ import (
 	buildconfigs "github.com/wolfi-dev/wolfictl/pkg/configs/build"
 	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
 	"github.com/wolfi-dev/wolfictl/pkg/distro"
+	"github.com/wolfi-dev/wolfictl/pkg/yam"
 )
 
 func cmdAdvisoryUpdate() *cobra.Command { //nolint:gocyclo
@@ -115,7 +116,7 @@ required fields are missing.`,
 
 			advGetter := advisory.NewFSGetter(os.DirFS(advisoriesRepoDir))
 
-			encodeOpts, err := getYamEncodeOptions(advisoriesRepoDir)
+			encodeOpts, err := yam.TryReadingEncodeOptions(advisoriesRepoDir)
 			if err != nil {
 				return fmt.Errorf("getting yam encode options: %w", err)
 			}

--- a/pkg/yam/yam.go
+++ b/pkg/yam/yam.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	osAdapter "github.com/chainguard-dev/yam/pkg/rwfs/os"
+	"github.com/chainguard-dev/yam/pkg/util"
 	"github.com/chainguard-dev/yam/pkg/yam"
 	"github.com/chainguard-dev/yam/pkg/yam/formatted"
 )
@@ -29,4 +30,25 @@ func FormatConfigurationFile(dir, filename string) error {
 		return fmt.Errorf("error formatting the file %s: %v", filename, err)
 	}
 	return nil
+}
+
+// TryReadingEncodeOptions does a "best effort" retrieval of the yam encode
+// options. If no yam config is present in the given directory, no error is
+// returned, and a set of default options are returned. An error is only
+// returned if there is a problem reading the (present) yam config file.
+func TryReadingEncodeOptions(dir string) (formatted.EncodeOptions, error) {
+	defaultOpts := formatted.EncodeOptions{}
+
+	yamCfgPath := filepath.Join(dir, util.ConfigFileName)
+	yamCfgFile, err := os.Open(yamCfgPath)
+	if err != nil {
+		return defaultOpts, nil
+	}
+
+	readOpts, err := formatted.ReadConfigFrom(yamCfgFile)
+	if err != nil {
+		return defaultOpts, fmt.Errorf("reading yam config from %q: %w", yamCfgPath, err)
+	}
+
+	return *readOpts, nil
 }


### PR DESCRIPTION
This func was previously just in the `cli` package as a helper, but it's useful beyond CLI operations. This lets us use this elsewhere to skip repeating redundant boilerplate code.