### PR TITLE
fix(scan): avoid panic by handling err from SBOM gen

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -270,8 +270,10 @@ func scanEverything(ctx context.Context, p *scanParams, inputs []string, advisor
 			if err := errs[i]; err != nil {
 				if p.outputFormat == outputFormatOutline {
 					fmt.Printf("❌ Skipping scan because SBOM generation failed for %q: %v\n", input, err)
-					continue
 				}
+
+				// All errs will get joined and returned at the end of the outer function.
+				continue
 			}
 
 			file := files[i]


### PR DESCRIPTION
Before we were only handling this for the outline output format. We don't want this to depend on the output format.