### PR TITLE
fix(scan): increase allowed age for Grype DB

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -171,7 +171,7 @@ func NewScanner(opts Options) (*Scanner, error) {
 		DBRootDir:               dbDestDir,
 		ValidateChecksum:        true,
 		ValidateAge:             !opts.DisableDatabaseAgeValidation,
-		MaxAllowedBuiltAge:      24 * time.Hour,
+		MaxAllowedBuiltAge:      48 * time.Hour,
 		UpdateCheckMaxFrequency: 1 * time.Hour,
 	}
 


### PR DESCRIPTION
When Anchore fails to build a DB on a given day, the 24 hour max age becomes too small for our ability to scan successfully. Increase to 48 hours to allow for more resilience without risking silently scanning with overly stale data.