### PR TITLE
refactor(scan): update scan filtering to use new `advisory.Getter` abstraction

### DIFF
--- a/pkg/advisory/index_adapter.go
+++ b/pkg/advisory/index_adapter.go
@@ -1,0 +1,58 @@
+package advisory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+)
+
+type indexAdapter struct {
+	index *configs.Index[v2.Document]
+}
+
+// AdaptIndex creates an implementation of advisory.Getter using an existing
+// instance of `*configs.Index[v2.Document]`.
+func AdaptIndex(index *configs.Index[v2.Document]) Getter {
+	return indexAdapter{
+		index: index,
+	}
+}
+
+func (c indexAdapter) PackageNames(_ context.Context) ([]string, error) {
+	documents := c.index.Select().Configurations()
+
+	packageNames := make([]string, 0, len(documents))
+	for _, d := range documents {
+		packageNames = append(packageNames, d.Package.Name)
+	}
+
+	// Sort the package names for consistency
+	sort.Strings(packageNames)
+
+	return packageNames, nil
+}
+
+func (c indexAdapter) Advisories(_ context.Context, packageName string) ([]v2.PackageAdvisory, error) {
+	entry, err := c.index.Select().WhereName(packageName).First()
+	if err != nil {
+		return nil, fmt.Errorf("getting advisory document for %q: %w", packageName, err)
+	}
+
+	doc := entry.Configuration()
+
+	name := doc.Package.Name
+
+	pkgAdvs := make([]v2.PackageAdvisory, 0, len(doc.Advisories))
+	for _, adv := range doc.Advisories {
+		pkgAdv := v2.PackageAdvisory{
+			PackageName: name,
+			Advisory:    adv,
+		}
+		pkgAdvs = append(pkgAdvs, pkgAdv)
+	}
+
+	return pkgAdvs, nil
+}

--- a/pkg/advisory/index_adapter_test.go
+++ b/pkg/advisory/index_adapter_test.go
@@ -1,0 +1,84 @@
+package advisory
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+	rwos "github.com/wolfi-dev/wolfictl/pkg/configs/rwfs/os"
+)
+
+func Test_indexAdapter(t *testing.T) {
+	ctx := t.Context()
+
+	fsys := rwos.DirFS(filepath.Join("testdata", "index_adapter", "advisories"))
+	index, err := v2.NewIndex(ctx, fsys)
+	require.NoError(t, err)
+
+	adapter := AdaptIndex(index)
+
+	t.Run("PackageNames", func(t *testing.T) {
+		names, err := adapter.PackageNames(ctx)
+		require.NoError(t, err)
+
+		expected := []string{
+			"brotli",
+			"ko",
+			"openssl",
+		}
+
+		if diff := cmp.Diff(expected, names); diff != "" {
+			t.Errorf("PackageNames() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Advisories", func(t *testing.T) {
+		advisories, err := adapter.Advisories(ctx, "ko")
+		require.NoError(t, err)
+
+		testTime, err := time.Parse(time.RFC3339, "2023-05-04T14:34:34Z")
+		require.NoError(t, err)
+
+		expected := []v2.PackageAdvisory{
+			{
+				PackageName: "ko",
+				Advisory: v2.Advisory{
+					ID:      "CGA-5f5c-53mg-6p2v",
+					Aliases: []string{"GHSA-33pg-m6jh-5237"},
+					Events: []v2.Event{
+						{
+							Timestamp: v2.Timestamp(testTime),
+							Type:      v2.EventTypeFixed,
+							Data: v2.Fixed{
+								FixedVersion: "0.13.0-r3",
+							},
+						},
+					},
+				},
+			},
+			{
+				PackageName: "ko",
+				Advisory: v2.Advisory{
+					ID:      "CGA-4j8r-gcwr-9w6v",
+					Aliases: []string{"GHSA-232p-vwff-86mp"},
+					Events: []v2.Event{
+						{
+							Timestamp: v2.Timestamp(testTime),
+							Type:      v2.EventTypeFixed,
+							Data: v2.Fixed{
+								FixedVersion: "0.13.0-r5",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if diff := cmp.Diff(expected, advisories); diff != "" {
+			t.Errorf("Advisories() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -54,3 +54,19 @@ type Putter interface {
 	// returned.
 	Upsert(ctx context.Context, request Request) (string, error)
 }
+
+// MapByVulnID maps the given advisories by their vulnerability ID, creating a
+// pre-indexed collection of advisories for performant lookup. The map keys are
+// the vulnerability IDs, and the values are pointers to the corresponding
+// PackageAdvisory structs.
+func MapByVulnID(advisories []v2.PackageAdvisory) map[string]*v2.PackageAdvisory {
+	advsByAlias := make(map[string]*v2.PackageAdvisory, len(advisories)) // even though we'll exceed this capacity if there are multiple aliases.
+
+	for _, adv := range advisories {
+		for _, alias := range adv.Aliases {
+			advsByAlias[alias] = &adv
+		}
+	}
+
+	return advsByAlias
+}

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -66,6 +66,7 @@ func MapByVulnID(advisories []v2.PackageAdvisory) map[string]*v2.PackageAdvisory
 		advCopy := adv // Create a copy of the loop variable
 		for _, alias := range adv.Aliases {
 			advsByAlias[alias] = &advCopy
+		}
 	}
 
 	return advsByAlias

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -63,9 +63,9 @@ func MapByVulnID(advisories []v2.PackageAdvisory) map[string]*v2.PackageAdvisory
 	advsByAlias := make(map[string]*v2.PackageAdvisory, len(advisories)) // even though we'll exceed this capacity if there are multiple aliases.
 
 	for _, adv := range advisories {
+		advCopy := adv // Create a copy of the loop variable
 		for _, alias := range adv.Aliases {
-			advsByAlias[alias] = &adv
-		}
+			advsByAlias[alias] = &advCopy
 	}
 
 	return advsByAlias

--- a/pkg/advisory/store.go
+++ b/pkg/advisory/store.go
@@ -54,20 +54,3 @@ type Putter interface {
 	// returned.
 	Upsert(ctx context.Context, request Request) (string, error)
 }
-
-// MapByVulnID maps the given advisories by their vulnerability ID, creating a
-// pre-indexed collection of advisories for performant lookup. The map keys are
-// the vulnerability IDs, and the values are pointers to the corresponding
-// PackageAdvisory structs.
-func MapByVulnID(advisories []v2.PackageAdvisory) map[string]*v2.PackageAdvisory {
-	advsByAlias := make(map[string]*v2.PackageAdvisory, len(advisories)) // even though we'll exceed this capacity if there are multiple aliases.
-
-	for _, adv := range advisories {
-		advCopy := adv // Create a copy of the loop variable
-		for _, alias := range adv.Aliases {
-			advsByAlias[alias] = &advCopy
-		}
-	}
-
-	return advsByAlias
-}

--- a/pkg/advisory/testdata/index_adapter/advisories/brotli.advisories.yaml
+++ b/pkg/advisory/testdata/index_adapter/advisories/brotli.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: "2"
+
+package:
+  name: brotli
+
+advisories:
+  - id: CGA-37qj-pjrf-fmrw
+    aliases:
+      - CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/pkg/advisory/testdata/index_adapter/advisories/ko.advisories.yaml
+++ b/pkg/advisory/testdata/index_adapter/advisories/ko.advisories.yaml
@@ -1,0 +1,23 @@
+schema-version: "2"
+
+package:
+  name: ko
+
+advisories:
+  - id: CGA-5f5c-53mg-6p2v
+    aliases:
+      - GHSA-33pg-m6jh-5237
+    events:
+      - timestamp: 2023-05-04T14:34:34Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r3
+
+  - id: CGA-4j8r-gcwr-9w6v
+    aliases:
+      - GHSA-232p-vwff-86mp
+    events:
+      - timestamp: 2023-05-04T14:34:34Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r5

--- a/pkg/advisory/testdata/index_adapter/advisories/openssl.advisories.yaml
+++ b/pkg/advisory/testdata/index_adapter/advisories/openssl.advisories.yaml
@@ -1,0 +1,150 @@
+schema-version: "2"
+
+package:
+  name: openssl
+
+advisories:
+  - id: CGA-5g25-7735-97mh
+    aliases:
+      - CVE-2023-0464
+    events:
+      - timestamp: 2023-03-23T09:31:00Z
+        type: fixed
+        data:
+          fixed-version: 3.1.0-r1
+
+  - id: CGA-7jpc-77v9-8xwj
+    aliases:
+      - CVE-2023-1255
+    events:
+      - timestamp: 2023-04-20T16:29:24Z
+        type: fixed
+        data:
+          fixed-version: 3.1.0-r5
+
+  - id: CGA-gwv4-h62f-5frj
+    aliases:
+      - CVE-2022-3358
+    events:
+      - timestamp: 2022-11-01T16:49:56Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
+
+  - id: CGA-5x4g-4gp8-3frx
+    aliases:
+      - CVE-2022-3602
+    events:
+      - timestamp: 2022-11-01T16:49:56Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
+
+  - id: CGA-grqc-5h6x-rch8
+    aliases:
+      - CVE-2023-0216
+    events:
+      - timestamp: 2023-02-07T16:50:29Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-7w75-jqq5-8pj3
+    aliases:
+      - CVE-2022-4203
+    events:
+      - timestamp: 2023-02-07T16:50:00Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-mpmv-pqf6-j3w9
+    aliases:
+      - CVE-2023-0215
+    events:
+      - timestamp: 2023-02-07T16:50:08Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-fv8r-8vjj-mgx6
+    aliases:
+      - CVE-2023-0286
+    events:
+      - timestamp: 2023-02-07T16:49:30Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-fc7r-gjw8-c4xp
+    aliases:
+      - CVE-2023-0401
+    events:
+      - timestamp: 2023-02-07T16:50:53Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-vj68-6p3f-8xmr
+    aliases:
+      - CVE-2023-0465
+    events:
+      - timestamp: 2023-03-28T14:54:27Z
+        type: fixed
+        data:
+          fixed-version: 3.1.0-r2
+
+  - id: CGA-mm7m-x6cw-5fg4
+    aliases:
+      - CVE-2023-0466
+    events:
+      - timestamp: 2023-04-08T16:32:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
+
+  - id: CGA-j59r-vcf2-x9p7
+    aliases:
+      - CVE-2022-3786
+    events:
+      - timestamp: 2022-11-01T16:49:56Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
+
+  - id: CGA-mpp5-xvx9-xj5q
+    aliases:
+      - CVE-2022-4304
+    events:
+      - timestamp: 2023-02-07T16:49:50Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-c6mv-x33h-2rw7
+    aliases:
+      - CVE-2023-0217
+    events:
+      - timestamp: 2023-02-07T16:50:39Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-7p3g-p2r2-p42c
+    aliases:
+      - CVE-2022-3996
+    events:
+      - timestamp: 2022-12-22T17:26:45Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r1
+
+  - id: CGA-6mjr-v678-c6gm
+    aliases:
+      - CVE-2022-4450
+    events:
+      - timestamp: 2023-02-07T16:50:17Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0

--- a/pkg/advisory/utils.go
+++ b/pkg/advisory/utils.go
@@ -1,0 +1,20 @@
+package advisory
+
+import v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
+
+// MapByVulnID maps the given advisories by their vulnerability ID, creating a
+// pre-indexed collection of advisories for performant lookup. The map keys are
+// the vulnerability IDs, and the values are pointers to the corresponding
+// PackageAdvisory structs.
+func MapByVulnID(advisories []v2.PackageAdvisory) map[string]*v2.PackageAdvisory {
+	advsByAlias := make(map[string]*v2.PackageAdvisory, len(advisories)) // even though we'll exceed this capacity if there are multiple aliases.
+
+	for _, adv := range advisories {
+		advCopy := adv // Create a copy of the loop variable
+		for _, alias := range adv.Aliases {
+			advsByAlias[alias] = &advCopy
+		}
+	}
+
+	return advsByAlias
+}

--- a/pkg/cli/advisory_guide.go
+++ b/pkg/cli/advisory_guide.go
@@ -471,7 +471,7 @@ func filterCollatedVulnerabilities(ctx context.Context, apkResults []resultWithA
 		filteredFindings, err := scan.FilterWithAdvisories(
 			ctx,
 			ar.Result,
-			sess.Index(),
+			advisory.AdaptIndex(sess.Index()),
 			scan.AdvisoriesSetConcluded,
 		)
 		if err != nil {

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 
 	"github.com/samber/lo"
-	"github.com/wolfi-dev/wolfictl/pkg/configs"
+	"github.com/wolfi-dev/wolfictl/pkg/advisory"
 	v2 "github.com/wolfi-dev/wolfictl/pkg/configs/advisory/v2"
 )
 
@@ -19,18 +19,19 @@ const (
 var ValidAdvisoriesSets = []string{AdvisoriesSetResolved, AdvisoriesSetAll, AdvisoriesSetConcluded}
 
 // FilterWithAdvisories filters the findings in the result based on the advisories for the target APK.
-func FilterWithAdvisories(_ context.Context, result Result, advisoryDocIndex *configs.Index[v2.Document], advisoryFilterSet string) ([]Finding, error) {
+func FilterWithAdvisories(ctx context.Context, result Result, advGetter advisory.Getter, advisoryFilterSet string) ([]Finding, error) {
 	// TODO: consider using the context for more detailed logging of the filtering logic.
 
-	if advisoryDocIndex == nil {
-		return nil, fmt.Errorf("advisory document index cannot be nil")
+	if advGetter == nil {
+		return nil, fmt.Errorf("advGetter cannot be nil")
 	}
 
-	documents := advisoryDocIndex.Select().WhereName(result.TargetAPK.Origin()).Configurations()
+	packageNames, err := advGetter.PackageNames(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting package names for advisories: %w", err)
+	}
 
-	// TODO: Should we error out if we end up with multiple documents for a single package?
-
-	if len(documents) == 0 {
+	if len(packageNames) == 0 {
 		// No advisory configs for this package, so we know we wouldn't be able to filter anything.
 		return result.Findings, nil
 	}
@@ -38,8 +39,11 @@ func FilterWithAdvisories(_ context.Context, result Result, advisoryDocIndex *co
 	// Use a copy of the findings, so we don't mutate the original result.
 	filteredFindings := slices.Clone(result.Findings)
 
-	for _, document := range documents {
-		packageAdvisories := document.Advisories
+	for _, name := range packageNames {
+		packageAdvisories, err := advGetter.Advisories(ctx, name)
+		if err != nil {
+			return nil, fmt.Errorf("getting advisories for package %q: %w", name, err)
+		}
 
 		switch advisoryFilterSet {
 		case AdvisoriesSetAll:
@@ -59,17 +63,28 @@ func FilterWithAdvisories(_ context.Context, result Result, advisoryDocIndex *co
 	return filteredFindings, nil
 }
 
-func filterFindingsWithAllAdvisories(findings []Finding, packageAdvisories v2.Advisories) []Finding {
+func filterFindingsWithAllAdvisories(findings []Finding, packageAdvisories []v2.PackageAdvisory) []Finding {
+	if len(packageAdvisories) == 0 {
+		return findings
+	}
+
+	advsByVulnID := advisory.MapByVulnID(packageAdvisories)
+	for _, adv := range packageAdvisories {
+		for _, alias := range adv.Aliases {
+			advsByVulnID[alias] = &adv
+		}
+	}
+
 	return lo.Filter(findings, func(finding Finding, _ int) bool {
-		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
-		// If the advisory contains any events, filter it out!
+		adv, ok := advsByVulnID[finding.Vulnerability.ID]
 		if ok && len(adv.Events) >= 1 {
+			// If the advisory contains any events, filter it out!
 			return false
 		}
 
 		// Also check any listed aliases
 		for _, alias := range finding.Vulnerability.Aliases {
-			adv, ok := packageAdvisories.GetByVulnerability(alias)
+			adv, ok := advsByVulnID[alias]
 			if !ok {
 				continue
 			}
@@ -83,16 +98,22 @@ func filterFindingsWithAllAdvisories(findings []Finding, packageAdvisories v2.Ad
 	})
 }
 
-func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []Finding {
+func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories []v2.PackageAdvisory, currentPackageVersion string) []Finding {
+	if len(packageAdvisories) == 0 {
+		return findings
+	}
+
+	advsByVulnID := advisory.MapByVulnID(packageAdvisories)
+
 	return lo.Filter(findings, func(finding Finding, _ int) bool {
-		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
+		adv, ok := advsByVulnID[finding.Vulnerability.ID]
 		if ok && adv.ResolvedAtVersion(currentPackageVersion, finding.Package.Type) {
 			return false
 		}
 
 		// Also check any listed aliases
 		for _, alias := range finding.Vulnerability.Aliases {
-			adv, ok := packageAdvisories.GetByVulnerability(alias)
+			adv, ok := advsByVulnID[alias]
 			if !ok {
 				continue
 			}
@@ -106,16 +127,22 @@ func filterFindingsWithResolvedAdvisories(findings []Finding, packageAdvisories 
 	})
 }
 
-func filterFindingsWithConcludedAdvisories(findings []Finding, packageAdvisories v2.Advisories, currentPackageVersion string) []Finding {
+func filterFindingsWithConcludedAdvisories(findings []Finding, packageAdvisories []v2.PackageAdvisory, currentPackageVersion string) []Finding {
+	if len(packageAdvisories) == 0 {
+		return findings
+	}
+
+	advsByVulnID := advisory.MapByVulnID(packageAdvisories)
+
 	return lo.Filter(findings, func(finding Finding, _ int) bool {
-		adv, ok := packageAdvisories.GetByVulnerability(finding.Vulnerability.ID)
+		adv, ok := advsByVulnID[finding.Vulnerability.ID]
 		if ok && adv.ConcludedAtVersion(currentPackageVersion, finding.Package.Type) {
 			return false
 		}
 
 		// Also check any listed aliases
 		for _, alias := range finding.Vulnerability.Aliases {
-			adv, ok := packageAdvisories.GetByVulnerability(alias)
+			adv, ok := advsByVulnID[alias]
 			if !ok {
 				continue
 			}

--- a/pkg/scan/testdata/advisories/ko.advisories.yaml
+++ b/pkg/scan/testdata/advisories/ko.advisories.yaml
@@ -4,42 +4,54 @@ package:
   name: ko
 
 advisories:
-  - id: CVE-1999-11111
+  - id: CGA-1111-1111-1111
+    aliases:
+      - CVE-1999-11111
     events:
       - timestamp: 2023-05-04T10:34:34.169879-04:00
         type: detection
         data:
           type: manual
 
-  - id: CVE-2000-22222
+  - id: CGA-2222-2222-2222
+    aliases:
+      - CVE-2000-22222
     events:
       - timestamp: 2023-05-04T10:34:34.169879-04:00
         type: false-positive-determination
         data:
           type: component-vulnerability-mismatch
 
-  - id: GHSA-2h5h-59f5-c5x9
+  - id: CGA-9999-9999-9999
+    aliases:
+      - GHSA-2h5h-59f5-c5x9
     events:
       - timestamp: 2023-05-04T10:34:34.169879-04:00
         type: fixed
         data:
           fixed-version: 0.13.0-r3
 
-  - id: CVE-2001-33333
+  - id: CGA-3333-3333-3333
+    aliases:
+      - CVE-2001-33333
     events:
       - timestamp: 2023-05-04T10:34:34.169879-04:00
         type: fix-not-planned
         data:
           note: Just because.
 
-  - id: CVE-2002-44444
+  - id: CGA-4444-4444-4444
+    aliases:
+      - CVE-2002-44444
     events:
       - timestamp: 2023-05-04T10:34:34.169879-04:00
         type: analysis-not-planned
         data:
           note: Just because.
 
-  - id: CVE-2003-55555
+  - id: CGA-5555-5555-5555
+    aliases:
+      - CVE-2003-55555
     events:
       - timestamp: 2023-05-04T10:34:34.169879-04:00
         type: pending-upstream-fix


### PR DESCRIPTION
This also introduces a nifty mechanism for taking an existing, old-style `*configs.Index[v2.Document]` and adapting it to the new `advisory.Getter` interface so that consuming code can move ahead to the abstraction-based model when possible.