### PR TITLE
fix(scan): capture architecture of scanned APK in results

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -77,9 +77,22 @@ type DataSource struct {
 }
 
 type TargetAPK struct {
-	Name              string
-	Version           string
+	// Name of the package in the APK (i.e., the value of pkgname in PKGINFO).
+	// Example: "libcrypto3".
+	Name string
+
+	// Version of the package in the APK (i.e., the value of pkgver in PKGINFO).
+	// Example: "3.0.11-r0".
+	Version string
+
+	// OriginPackageName is the name of the origin package for the package (i.e.,
+	// the value of origin in PKGINFO), which, for non-subpackages, would be the
+	// same as Name. Example: "openssl".
 	OriginPackageName string
+
+	// Arch is the architecture of the package (i.e., the value of arch in PKGINFO).
+	// Should be "aarch64" or "x86_64".
+	Arch string
 }
 
 // Origin returns the name of the origin package, if the package's metadata
@@ -112,6 +125,7 @@ func newTargetAPK(s *sbomSyft.SBOM) (TargetAPK, error) {
 		Name:              p.Name,
 		Version:           p.Version,
 		OriginPackageName: metadata.OriginPackage,
+		Arch:              metadata.Architecture,
 	}, nil
 }
 

--- a/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "crane",
     "Version": "0.14.0-r0",
-    "OriginPackageName": "crane"
+    "OriginPackageName": "crane",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "crane",
     "Version": "0.19.1-r6",
-    "OriginPackageName": "crane"
+    "OriginPackageName": "crane",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "go-1.21",
     "Version": "1.21.0-r0",
-    "OriginPackageName": "go-1.21"
+    "OriginPackageName": "go-1.21",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openjdk-10-jre",
     "Version": "10.0.2-r0",
-    "OriginPackageName": "openjdk-10"
+    "OriginPackageName": "openjdk-10",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/openjdk-21-21.0.3-r3.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/openjdk-21-21.0.3-r3.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openjdk-21",
     "Version": "21.0.3-r3",
-    "OriginPackageName": "openjdk-21"
+    "OriginPackageName": "openjdk-21",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/openssl-3.3.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/openssl-3.3.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openssl",
     "Version": "3.3.0-r0",
-    "OriginPackageName": "openssl"
+    "OriginPackageName": "openssl",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/openssl-3.3.0-r8.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/openssl-3.3.0-r8.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openssl",
     "Version": "3.3.0-r8",
-    "OriginPackageName": "openssl"
+    "OriginPackageName": "openssl",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/perl-yaml-syck-1.34-r3.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/perl-yaml-syck-1.34-r3.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "perl-yaml-syck",
     "Version": "1.34-r3",
-    "OriginPackageName": "perl-yaml-syck"
+    "OriginPackageName": "perl-yaml-syck",
+    "Arch": "aarch64"
   },
   "Findings": null,
   "DataSource": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/php-odbc-8.2.11-r1.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/php-odbc-8.2.11-r1.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "php-odbc",
     "Version": "8.2.11-r1",
-    "OriginPackageName": "php-8.2"
+    "OriginPackageName": "php-8.2",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/powershell-7.4.1-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/powershell-7.4.1-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "powershell",
     "Version": "7.4.1-r0",
-    "OriginPackageName": "powershell"
+    "OriginPackageName": "powershell",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/py3-poetry-core-1.8.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/py3-poetry-core-1.8.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "py3-poetry-core",
     "Version": "1.8.0-r0",
-    "OriginPackageName": "py3-poetry-core"
+    "OriginPackageName": "py3-poetry-core",
+    "Arch": "aarch64"
   },
   "Findings": null,
   "DataSource": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/py3-poetry-core-1.9.0-r1.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/py3-poetry-core-1.9.0-r1.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "py3-poetry-core",
     "Version": "1.9.0-r1",
-    "OriginPackageName": "py3-poetry-core"
+    "OriginPackageName": "py3-poetry-core",
+    "Arch": "aarch64"
   },
   "Findings": null,
   "DataSource": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "python-3.11",
     "Version": "3.11.1-r5",
-    "OriginPackageName": "python-3.11"
+    "OriginPackageName": "python-3.11",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "terraform",
     "Version": "1.3.9-r0",
-    "OriginPackageName": "terraform"
+    "OriginPackageName": "terraform",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "terraform",
     "Version": "1.5.7-r12",
-    "OriginPackageName": "terraform"
+    "OriginPackageName": "terraform",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "thanos-0.32",
     "Version": "0.32.5-r4",
-    "OriginPackageName": "thanos-0.32"
+    "OriginPackageName": "thanos-0.32",
+    "Arch": "aarch64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "crane",
     "Version": "0.14.0-r0",
-    "OriginPackageName": "crane"
+    "OriginPackageName": "crane",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "crane",
     "Version": "0.19.1-r6",
-    "OriginPackageName": "crane"
+    "OriginPackageName": "crane",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "go-1.21",
     "Version": "1.21.0-r0",
-    "OriginPackageName": "go-1.21"
+    "OriginPackageName": "go-1.21",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/openjdk-10-jre-10.0.2-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openjdk-10-jre",
     "Version": "10.0.2-r0",
-    "OriginPackageName": "openjdk-10"
+    "OriginPackageName": "openjdk-10",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/openjdk-21-21.0.3-r3.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/openjdk-21-21.0.3-r3.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openjdk-21",
     "Version": "21.0.3-r3",
-    "OriginPackageName": "openjdk-21"
+    "OriginPackageName": "openjdk-21",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/openssl-3.3.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/openssl-3.3.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openssl",
     "Version": "3.3.0-r0",
-    "OriginPackageName": "openssl"
+    "OriginPackageName": "openssl",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/openssl-3.3.0-r8.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/openssl-3.3.0-r8.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "openssl",
     "Version": "3.3.0-r8",
-    "OriginPackageName": "openssl"
+    "OriginPackageName": "openssl",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/perl-yaml-syck-1.34-r3.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/perl-yaml-syck-1.34-r3.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "perl-yaml-syck",
     "Version": "1.34-r3",
-    "OriginPackageName": "perl-yaml-syck"
+    "OriginPackageName": "perl-yaml-syck",
+    "Arch": "x86_64"
   },
   "Findings": null,
   "DataSource": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/php-odbc-8.2.11-r1.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/php-odbc-8.2.11-r1.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "php-odbc",
     "Version": "8.2.11-r1",
-    "OriginPackageName": "php-8.2"
+    "OriginPackageName": "php-8.2",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/powershell-7.4.1-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/powershell-7.4.1-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "powershell",
     "Version": "7.4.1-r0",
-    "OriginPackageName": "powershell"
+    "OriginPackageName": "powershell",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/py3-poetry-core-1.8.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/py3-poetry-core-1.8.0-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "py3-poetry-core",
     "Version": "1.8.0-r0",
-    "OriginPackageName": "py3-poetry-core"
+    "OriginPackageName": "py3-poetry-core",
+    "Arch": "x86_64"
   },
   "Findings": null,
   "DataSource": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/py3-poetry-core-1.9.0-r1.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/py3-poetry-core-1.9.0-r1.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "py3-poetry-core",
     "Version": "1.9.0-r1",
-    "OriginPackageName": "py3-poetry-core"
+    "OriginPackageName": "py3-poetry-core",
+    "Arch": "x86_64"
   },
   "Findings": null,
   "DataSource": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "python-3.11",
     "Version": "3.11.1-r5",
-    "OriginPackageName": "python-3.11"
+    "OriginPackageName": "python-3.11",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "terraform",
     "Version": "1.3.9-r0",
-    "OriginPackageName": "terraform"
+    "OriginPackageName": "terraform",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "terraform",
     "Version": "1.5.7-r12",
-    "OriginPackageName": "terraform"
+    "OriginPackageName": "terraform",
+    "Arch": "x86_64"
   },
   "Findings": [
     {

--- a/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -2,7 +2,8 @@
   "TargetAPK": {
     "Name": "thanos-0.32",
     "Version": "0.32.5-r4",
-    "OriginPackageName": "thanos-0.32"
+    "OriginPackageName": "thanos-0.32",
+    "Arch": "x86_64"
   },
   "Findings": [
     {


### PR DESCRIPTION
Add `Arch` as a field to `TargetAPK`, the data structure that describes the APK that was examined by the scanning operation. This makes it easier to locate specific APK files that were scanned using scan results as input.

This also adds doc comments for the rest of the fields in `TargetAPK`.