### PR TITLE
bug(scan/filter): filtering considered all advisories and not just the target package

### DIFF
--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -29,26 +29,24 @@ func FilterWithAdvisories(ctx context.Context, result Result, advGetter advisory
 	// Use a copy of the findings, so we don't mutate the original result.
 	filteredFindings := slices.Clone(result.Findings)
 
-	// Check for advisories in both the result target's name and origin package (to handle subpackages)
-	for _, name := range []string{result.TargetAPK.Name, result.TargetAPK.OriginPackageName} {
-		packageAdvisories, err := advGetter.Advisories(ctx, name)
-		if err != nil {
-			return nil, fmt.Errorf("getting advisories for package %q: %w", name, err)
-		}
+	// Check for advisories in the result target's origin
+	packageAdvisories, err := advGetter.Advisories(ctx, result.TargetAPK.Origin())
+	if err != nil {
+		return nil, fmt.Errorf("getting advisories for package %q: %w", result.TargetAPK.Origin(), err)
+	}
 
-		switch advisoryFilterSet {
-		case AdvisoriesSetAll:
-			filteredFindings = filterFindingsWithAllAdvisories(filteredFindings, packageAdvisories)
+	switch advisoryFilterSet {
+	case AdvisoriesSetAll:
+		filteredFindings = filterFindingsWithAllAdvisories(filteredFindings, packageAdvisories)
 
-		case AdvisoriesSetResolved:
-			filteredFindings = filterFindingsWithResolvedAdvisories(filteredFindings, packageAdvisories, result.TargetAPK.Version)
+	case AdvisoriesSetResolved:
+		filteredFindings = filterFindingsWithResolvedAdvisories(filteredFindings, packageAdvisories, result.TargetAPK.Version)
 
-		case AdvisoriesSetConcluded:
-			filteredFindings = filterFindingsWithConcludedAdvisories(filteredFindings, packageAdvisories, result.TargetAPK.Version)
+	case AdvisoriesSetConcluded:
+		filteredFindings = filterFindingsWithConcludedAdvisories(filteredFindings, packageAdvisories, result.TargetAPK.Version)
 
-		default:
-			return nil, fmt.Errorf("unknown advisory filter set: %s", advisoryFilterSet)
-		}
+	default:
+		return nil, fmt.Errorf("unknown advisory filter set: %s", advisoryFilterSet)
 	}
 
 	return filteredFindings, nil

--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -26,20 +26,11 @@ func FilterWithAdvisories(ctx context.Context, result Result, advGetter advisory
 		return nil, fmt.Errorf("advGetter cannot be nil")
 	}
 
-	packageNames, err := advGetter.PackageNames(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting package names for advisories: %w", err)
-	}
-
-	if len(packageNames) == 0 {
-		// No advisory configs for this package, so we know we wouldn't be able to filter anything.
-		return result.Findings, nil
-	}
-
 	// Use a copy of the findings, so we don't mutate the original result.
 	filteredFindings := slices.Clone(result.Findings)
 
-	for _, name := range packageNames {
+	// Check for advisories in both the result target's name and origin package (to handle subpackages)
+	for _, name := range []string{result.TargetAPK.Name, result.TargetAPK.OriginPackageName} {
 		packageAdvisories, err := advGetter.Advisories(ctx, name)
 		if err != nil {
 			return nil, fmt.Errorf("getting advisories for package %q: %w", name, err)

--- a/pkg/scan/testdata/advisories/foo.advisories.yaml
+++ b/pkg/scan/testdata/advisories/foo.advisories.yaml
@@ -1,0 +1,59 @@
+schema-version: "2"
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-9111-1111-1111
+    aliases:
+      - CVE-1999-11111
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+
+  - id: CGA-9222-2222-2222
+    aliases:
+      - CVE-2000-22222
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+
+  - id: CGA-1999-9999-9999
+    aliases:
+      - GHSA-2h5h-59f5-c5x9
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r3
+
+  - id: CGA-9333-3333-3333
+    aliases:
+      - CVE-2001-33333
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: fix-not-planned
+        data:
+          note: Just because.
+
+  - id: CGA-9444-4444-4444
+    aliases:
+      - CVE-2002-44444
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: analysis-not-planned
+        data:
+          note: Just because.
+
+  - id: CGA-9555-5555-5555
+    aliases:
+      - CVE-2003-55555
+    events:
+      - timestamp: 2023-05-04T10:34:34.169879-04:00
+        type: pending-upstream-fix
+        data:
+          note: Just because.


### PR DESCRIPTION
We noticed that filtering was accounting for all advisories, which unintentionally reduced the original result scan set.

For example, simply adding a new advisory file (e.g., under a new package name like `foo.advisories.yaml`) with matching vulnerability aliases would cause existing tests to fail. This happened because `advGetter.PackageNames` was collecting all advisories (e.g., from wolfi-dev/advisories) and applying them during filtering.

However, the correct behavior appears to be filter only using advisories that match the incoming `result.TargetAPK.Name` OR `result.TargetAPK.OriginPackageName` (to account for subpackages).

@luhring thoughts?