### PR TITLE
fix: return ErrNoEntries and capture it

### DIFF
--- a/pkg/scan/filter.go
+++ b/pkg/scan/filter.go
@@ -41,6 +41,10 @@ func FilterWithAdvisories(ctx context.Context, result Result, advGetter advisory
 		return nil, fmt.Errorf("getting advisories for package %q: %w", result.TargetAPK.Origin(), err)
 	}
 
+	if len(packageAdvisories) == 0 {
+		return filteredFindings, nil
+	}
+
 	switch advisoryFilterSet {
 	case AdvisoriesSetAll:
 		filteredFindings = filterFindingsWithAllAdvisories(filteredFindings, packageAdvisories)

--- a/pkg/scan/filter_test.go
+++ b/pkg/scan/filter_test.go
@@ -372,6 +372,50 @@ func TestFilterWithAdvisories(t *testing.T) {
 			},
 			errAssertion: assert.NoError,
 		},
+		{
+			name: "no advisory document available for package, return the same findings",
+			result: &Result{
+				TargetAPK: TargetAPK{
+					Name:    "withoutadvisory",
+					Version: "0.13.0-r30",
+				},
+				Findings: []Finding{
+					{
+						Vulnerability: Vulnerability{
+							ID: "GHSA-2h5h-59f5-c5x9",
+						},
+						Package: Package{
+							Type: "go-module",
+							PURL: "purl-value",
+						},
+					},
+					{
+						Vulnerability: Vulnerability{
+							ID: "CVE-1999-11111",
+						},
+					},
+				},
+			},
+			advisoryGetterFunc: getSingleAdvisoriesGetter,
+			advisoryFilterSet:  "resolved",
+			expectedFindings: []Finding{
+				{
+					Vulnerability: Vulnerability{
+						ID: "GHSA-2h5h-59f5-c5x9",
+					},
+					Package: Package{
+						Type: "go-module",
+						PURL: "purl-value",
+					},
+				},
+				{
+					Vulnerability: Vulnerability{
+						ID: "CVE-1999-11111",
+					},
+				},
+			},
+			errAssertion: assert.NoError,
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
This is related to one issue with the scanning of apks when it should have warned and continued. The IndexAdapter was returning a custom error when no advisory document were found for a package. However other advisory getters such as FSGetter was propagating the **ErrNoEntries** which was then captured in the calling functions. 
We must capture that error and return the same findings given in the function call when detected an **ErrNoEntries**.