### PR TITLE
chore(scan): add CGAID field to Finding struct

### DIFF
--- a/pkg/cli/components/scanfindings/scanfindings.go
+++ b/pkg/cli/components/scanfindings/scanfindings.go
@@ -121,8 +121,8 @@ func Render(findings []scan.Finding) (string, error) {
 			),
 		}
 
-		if f.Advisory != nil {
-			pathParts = append(pathParts, renderAdvisoryPathParts(f.Advisory)...)
+		if f.Advisory != nil { //nolint:staticcheck // TODO: use advisory.Getter to lookup the advisory instead.
+			pathParts = append(pathParts, renderAdvisoryPathParts(f.Advisory)...) //nolint:staticcheck // TODO: use advisory.Getter to lookup the advisory instead.
 		}
 
 		return pathParts

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -429,7 +429,7 @@ func (p *scanParams) doScanCommandForSingleInput(
 
 				for _, alias := range f.Vulnerability.Aliases {
 					if adv, ok := advsByVulnID[alias]; ok {
-						f.Advisory = &adv.Advisory
+						f.Advisory = &adv.Advisory //nolint:staticcheck // TODO: use advisory.Getter to lookup the advisory instead.
 						result.Findings[i] = *f
 						break
 					}

--- a/pkg/scan/finding.go
+++ b/pkg/scan/finding.go
@@ -15,7 +15,11 @@ import (
 type Finding struct {
 	Package       Package
 	Vulnerability Vulnerability
-	Advisory      *v2.Advisory `json:",omitempty"`
+	CGAID         string `json:",omitempty"`
+
+	// Deprecated: This field will be removed soon. Plan to use CGAID to lookup the
+	// associated advisory out-of-band, instead of using this pointer.
+	Advisory *v2.Advisory `json:",omitempty"`
 
 	// Deprecated: This field will be removed soon.
 	TriageAssessments []TriageAssessment `json:",omitempty"`


### PR DESCRIPTION
And deprecate the existing Advisory field, which was a pointer to the entire advisory record.