### PR TITLE
feat(adv): new FSPutter constructor for automatic encode config

### DIFF
--- a/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/.yam.yaml
+++ b/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/.yam.yaml
@@ -1,0 +1,3 @@
+gap:
+  - ".advisories[].aliases"
+indent: 2

--- a/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/_expected.yam.yaml
+++ b/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/_expected.yam.yaml
@@ -1,0 +1,3 @@
+gap:
+  - ".advisories[].aliases"
+indent: 2

--- a/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/foo.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/foo.advisories.yaml
@@ -1,0 +1,16 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-xvg9-g29c-rr68
+    aliases:
+      - CVE-2016-7075
+      - GHSA-7w66-j2r2-vm3
+    events:
+      - timestamp: 2025-03-10T17:55:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift

--- a/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/automatic-encoder/with-config-file/foo_expected.advisories.yaml
@@ -1,0 +1,19 @@
+schema-version: 2.0.2
+package:
+  name: foo
+advisories:
+  - id: CGA-xvg9-g29c-rr68
+    aliases:
+      - CVE-2016-7075
+
+      - GHSA-7w66-j2r2-vm3
+    events:
+      - timestamp: 2025-03-10T17:55:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
+      - timestamp: 2025-03-11T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.2.3-r4

--- a/pkg/advisory/testdata/fs_putter/automatic-encoder/without-config-file/foo.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/automatic-encoder/without-config-file/foo.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+package:
+  name: foo
+advisories:
+  - id: CGA-xvg9-g29c-rr68
+    aliases:
+      - CVE-2016-7075
+      - GHSA-7w66-j2r2-vm3
+    events:
+      - timestamp: 2025-03-10T17:55:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift

--- a/pkg/advisory/testdata/fs_putter/automatic-encoder/without-config-file/foo_expected.advisories.yaml
+++ b/pkg/advisory/testdata/fs_putter/automatic-encoder/without-config-file/foo_expected.advisories.yaml
@@ -1,0 +1,20 @@
+schema-version: 2.0.2
+
+package:
+  name: foo
+
+advisories:
+  - id: CGA-xvg9-g29c-rr68
+    aliases:
+      - CVE-2016-7075
+      - GHSA-7w66-j2r2-vm3
+    events:
+      - timestamp: 2025-03-10T17:55:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
+      - timestamp: 2025-03-11T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.2.3-r4


### PR DESCRIPTION
Adds a new constructor, `advisory.NewFSPutterWithAutomaticEncoder(fsys rwfs.FS)`, as an easier way to create a fully-functional `FSPutter`. This avoids having to set up the yam encoder yourself, because it's done automatically for you on a best-effort basis, reading the `.yam.yaml` file from the FS you provide.