### PR TITLE
Feat: Add UpsertToFile and AdvisoriesFromFile methods to FSPutter and FSGetter respectively.

### DIFF
--- a/pkg/advisory/fs_getter.go
+++ b/pkg/advisory/fs_getter.go
@@ -51,6 +51,15 @@ func (g FSGetter) PackageNames(_ context.Context) ([]string, error) {
 
 func (g FSGetter) Advisories(_ context.Context, packageName string) ([]v2.PackageAdvisory, error) {
 	advFileName := fmt.Sprintf("%s.advisories.yaml", packageName)
+	return g.AdvisoriesFromFile(advFileName, packageName)
+}
+
+// AdvisoriesFromFile is a function not part of the Getter interface. It allows
+// one to explicitly decode advisories from  a file with the given name. This
+// obviously does not make sense to belong to a generic interface that does
+// not have files.
+
+func (g FSGetter) AdvisoriesFromFile(advFileName, packageName string) ([]v2.PackageAdvisory, error) {
 	f, err := g.fsys.Open(advFileName)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {

--- a/pkg/advisory/fs_putter.go
+++ b/pkg/advisory/fs_putter.go
@@ -87,6 +87,14 @@ func NewFSPutterWithAutomaticEncoder(fsys rwfs.FS) *FSPutter {
 }
 
 func (p FSPutter) Upsert(_ context.Context, request Request) (string, error) {
+	advFileName := fmt.Sprintf("%s.advisories.yaml", request.Package)
+	return p.UpsertToFile(advFileName, request)
+}
+
+// UpsertToFile is a function not part of the Putter interface. It allows one to
+// explicitly update a file with the given name. This obviously does not make
+// sense to belong to a generic interface that does not have files.
+func (p FSPutter) UpsertToFile(advFileName string, request Request) (string, error) {
 	if request.Package == "" {
 		return "", ErrEmptyPackage
 	}
@@ -96,7 +104,6 @@ func (p FSPutter) Upsert(_ context.Context, request Request) (string, error) {
 
 	advisoryFileHadExisted := false
 
-	advFileName := fmt.Sprintf("%s.advisories.yaml", request.Package)
 	f, err := p.fsys.Open(advFileName)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("opening advisory file %q: %w", advFileName, err)


### PR DESCRIPTION
Today the name of the filename for put/get operation is assumed to be 1:1 for filename. It would be more flexible to be able to specify the filename separate from the packagename. The code gets tested with existing tests since the existing methods just call it by creating the same filename as before.