### PR TITLE
chore(scan): add only primary evidence locations to findings

### DIFF
--- a/pkg/scan/testdata/goldenfiles/aarch64/powershell-7.4.1-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/powershell-7.4.1-r0.apk.wolfictl-scan.json
@@ -12,7 +12,7 @@
         "Name": "System.IO.Packaging",
         "Version": "8.0.0",
         "Type": "dotnet",
-        "Location": "/usr/lib/powershell/pwsh.deps.json, /usr/lib/powershell/System.IO.Packaging.dll",
+        "Location": "/usr/lib/powershell/pwsh.deps.json",
         "PURL": "pkg:nuget/System.IO.Packaging@8.0.0"
       },
       "Vulnerability": {
@@ -30,7 +30,7 @@
         "Name": "System.IO.Packaging",
         "Version": "8.0.0",
         "Type": "dotnet",
-        "Location": "/usr/lib/powershell/pwsh.deps.json, /usr/lib/powershell/System.IO.Packaging.dll",
+        "Location": "/usr/lib/powershell/pwsh.deps.json",
         "PURL": "pkg:nuget/System.IO.Packaging@8.0.0"
       },
       "Vulnerability": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/powershell-7.4.1-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/powershell-7.4.1-r0.apk.wolfictl-scan.json
@@ -12,7 +12,7 @@
         "Name": "System.IO.Packaging",
         "Version": "8.0.0",
         "Type": "dotnet",
-        "Location": "/usr/lib/powershell/pwsh.deps.json, /usr/lib/powershell/System.IO.Packaging.dll",
+        "Location": "/usr/lib/powershell/pwsh.deps.json",
         "PURL": "pkg:nuget/System.IO.Packaging@8.0.0"
       },
       "Vulnerability": {
@@ -30,7 +30,7 @@
         "Name": "System.IO.Packaging",
         "Version": "8.0.0",
         "Type": "dotnet",
-        "Location": "/usr/lib/powershell/pwsh.deps.json, /usr/lib/powershell/System.IO.Packaging.dll",
+        "Location": "/usr/lib/powershell/pwsh.deps.json",
         "PURL": "pkg:nuget/System.IO.Packaging@8.0.0"
       },
       "Vulnerability": {


### PR DESCRIPTION
We've decided to discard other locations from the list, in part to keep the list of locations per finding minimal and thus easier to reason about as we're examining vulnerabilities for a package over time.