### PR TITLE
feat(scan): deduplicate vulnerability findings with different IDs

### DIFF
--- a/pkg/scan/apk.go
+++ b/pkg/scan/apk.go
@@ -338,6 +338,9 @@ func (s *Scanner) APKSBOM(ctx context.Context, ssbom *sbomSyft.SBOM) (*Result, e
 		findings = append(findings, *finding)
 	}
 
+	// Merge related findings that represent the same vulnerability
+	findings = mergeRelatedFindings(findings)
+
 	result := &Result{
 		TargetAPK: apk,
 		Findings:  findings,

--- a/pkg/scan/finding.go
+++ b/pkg/scan/finding.go
@@ -167,13 +167,13 @@ func mergeRelatedFindings(findings []Finding) []Finding {
 
 	// Group findings by package (name, type, location)
 	packageGroups := make(map[packageKey][]Finding)
-	for _, f := range findings {
+	for i := range findings {
 		key := packageKey{
-			name:     f.Package.Name,
-			type_:    f.Package.Type,
-			location: f.Package.Location,
+			name:     findings[i].Package.Name,
+			typ:      findings[i].Package.Type,
+			location: findings[i].Package.Location,
 		}
-		packageGroups[key] = append(packageGroups[key], f)
+		packageGroups[key] = append(packageGroups[key], findings[i])
 	}
 
 	// Process each package group
@@ -195,7 +195,7 @@ func mergeRelatedFindings(findings []Finding) []Finding {
 // packageKey is used to group findings by package
 type packageKey struct {
 	name     string
-	type_    string
+	typ      string
 	location string
 }
 
@@ -221,8 +221,8 @@ func mergeRelatedInGroup(findings []Finding) []Finding {
 			}
 
 			// Check if this finding is related to any in the current group
-			for _, g := range group {
-				if findingsAreRelated(g, findings[j]) {
+			for k := range group {
+				if findingsAreRelated(group[k], findings[j]) {
 					group = append(group, findings[j])
 					merged[j] = true
 					break
@@ -245,10 +245,10 @@ func mergeGroup(group []Finding) Finding {
 
 	// Collect all unique aliases
 	aliasSet := make(map[string]struct{})
-	for _, f := range group {
+	for i := range group {
 		// Add all IDs and aliases to the set
-		aliasSet[f.Vulnerability.ID] = struct{}{}
-		for _, alias := range f.Vulnerability.Aliases {
+		aliasSet[group[i].Vulnerability.ID] = struct{}{}
+		for _, alias := range group[i].Vulnerability.Aliases {
 			aliasSet[alias] = struct{}{}
 		}
 	}
@@ -277,25 +277,25 @@ func selectRepresentative(findings []Finding) Finding {
 	maxAliases := -1
 	var candidates []Finding
 
-	for _, f := range findings {
-		aliasCount := len(f.Vulnerability.Aliases)
+	for i := range findings {
+		aliasCount := len(findings[i].Vulnerability.Aliases)
 		if aliasCount > maxAliases {
 			maxAliases = aliasCount
-			candidates = []Finding{f}
+			candidates = []Finding{findings[i]}
 		} else if aliasCount == maxAliases {
-			candidates = append(candidates, f)
+			candidates = append(candidates, findings[i])
 		}
 	}
 
 	// Among candidates with equal alias counts, prefer GHSA > CVE > others
-	for _, c := range candidates {
-		if strings.HasPrefix(c.Vulnerability.ID, "GHSA-") {
-			return c
+	for i := range candidates {
+		if strings.HasPrefix(candidates[i].Vulnerability.ID, "GHSA-") {
+			return candidates[i]
 		}
 	}
-	for _, c := range candidates {
-		if strings.HasPrefix(c.Vulnerability.ID, "CVE-") {
-			return c
+	for i := range candidates {
+		if strings.HasPrefix(candidates[i].Vulnerability.ID, "CVE-") {
+			return candidates[i]
 		}
 	}
 

--- a/pkg/scan/finding.go
+++ b/pkg/scan/finding.go
@@ -189,6 +189,8 @@ func mergeRelatedFindings(findings []Finding) []Finding {
 		result = append(result, merged...)
 	}
 
+	// Sort results to ensure deterministic ordering
+	sort.Sort(Findings(result))
 	return result
 }
 

--- a/pkg/scan/finding_merge_test.go
+++ b/pkg/scan/finding_merge_test.go
@@ -472,4 +472,3 @@ func TestFindingsAreRelated(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/scan/finding_merge_test.go
+++ b/pkg/scan/finding_merge_test.go
@@ -1,0 +1,475 @@
+package scan
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestMergeRelatedFindings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []Finding
+		expected []Finding
+	}{
+		{
+			name: "merge CVE and GHSA findings for same package",
+			input: []Finding{
+				{
+					Package: Package{
+						ID:       "pkg1",
+						Name:     "test-package",
+						Version:  "1.0.0",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+						PURL:     "pkg:apk/test-package@1.0.0",
+					},
+					Vulnerability: Vulnerability{
+						ID:           "CVE-2023-1234",
+						Severity:     "high",
+						Aliases:      []string{},
+						FixedVersion: "1.0.1",
+					},
+				},
+				{
+					Package: Package{
+						ID:       "pkg1",
+						Name:     "test-package",
+						Version:  "1.0.0",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+						PURL:     "pkg:apk/test-package@1.0.0",
+					},
+					Vulnerability: Vulnerability{
+						ID:           "GHSA-xxxx-yyyy-zzzz",
+						Severity:     "high",
+						Aliases:      []string{"CVE-2023-1234"},
+						FixedVersion: "1.0.1",
+					},
+				},
+			},
+			expected: []Finding{
+				{
+					Package: Package{
+						ID:       "pkg1",
+						Name:     "test-package",
+						Version:  "1.0.0",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+						PURL:     "pkg:apk/test-package@1.0.0",
+					},
+					Vulnerability: Vulnerability{
+						ID:           "GHSA-xxxx-yyyy-zzzz",
+						Severity:     "high",
+						Aliases:      []string{"CVE-2023-1234"},
+						FixedVersion: "1.0.1",
+					},
+				},
+			},
+		},
+		{
+			name: "no merge for different packages",
+			input: []Finding{
+				{
+					Package: Package{
+						Name:     "package-a",
+						Type:     "apk",
+						Location: "/usr/lib/a.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "package-b",
+						Type:     "apk",
+						Location: "/usr/lib/b.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234"},
+					},
+				},
+			},
+			expected: []Finding{
+				{
+					Package: Package{
+						Name:     "package-a",
+						Type:     "apk",
+						Location: "/usr/lib/a.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "package-b",
+						Type:     "apk",
+						Location: "/usr/lib/b.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234"},
+					},
+				},
+			},
+		},
+		{
+			name: "preserve all aliases in union",
+			input: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234", "GO-2023-5678"},
+					},
+				},
+			},
+			expected: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234", "GO-2023-5678"},
+					},
+				},
+			},
+		},
+		{
+			name: "three findings with transitive aliases",
+			input: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234"},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GO-2023-5678",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+			},
+			expected: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234", "GO-2023-5678"},
+					},
+				},
+			},
+		},
+		{
+			name: "no merge for different locations",
+			input: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/bin/test",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234"},
+					},
+				},
+			},
+			expected: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/bin/test",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "GHSA-xxxx-yyyy-zzzz",
+						Aliases: []string{"CVE-2023-1234"},
+					},
+				},
+			},
+		},
+		{
+			name:     "handle empty findings list",
+			input:    []Finding{},
+			expected: []Finding{},
+		},
+		{
+			name: "single finding unchanged",
+			input: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+			},
+			expected: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1234",
+						Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple unrelated vulnerabilities in same package",
+			input: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1111",
+						Aliases: []string{},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-2222",
+						Aliases: []string{},
+					},
+				},
+			},
+			expected: []Finding{
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-1111",
+						Aliases: []string{},
+					},
+				},
+				{
+					Package: Package{
+						Name:     "test-package",
+						Type:     "apk",
+						Location: "/usr/lib/test.so",
+					},
+					Vulnerability: Vulnerability{
+						ID:      "CVE-2023-2222",
+						Aliases: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeRelatedFindings(tt.input)
+
+			// Sort both slices for comparison
+			sort.Sort(Findings(result))
+			sort.Sort(Findings(tt.expected))
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("mergeRelatedFindings() = %#v, want %#v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCreateAliasSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		finding  Finding
+		expected map[string]struct{}
+	}{
+		{
+			name: "finding with aliases",
+			finding: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "CVE-2023-1234",
+					Aliases: []string{"GHSA-xxxx-yyyy-zzzz", "GO-2023-5678"},
+				},
+			},
+			expected: map[string]struct{}{
+				"CVE-2023-1234":       {},
+				"GHSA-xxxx-yyyy-zzzz": {},
+				"GO-2023-5678":        {},
+			},
+		},
+		{
+			name: "finding without aliases",
+			finding: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "CVE-2023-1234",
+					Aliases: []string{},
+				},
+			},
+			expected: map[string]struct{}{
+				"CVE-2023-1234": {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := createAliasSet(tt.finding)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("createAliasSet() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindingsAreRelated(t *testing.T) {
+	tests := []struct {
+		name     string
+		f1       Finding
+		f2       Finding
+		expected bool
+	}{
+		{
+			name: "related via direct ID match",
+			f1: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "CVE-2023-1234",
+					Aliases: []string{"GHSA-xxxx-yyyy-zzzz"},
+				},
+			},
+			f2: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "GHSA-xxxx-yyyy-zzzz",
+					Aliases: []string{"CVE-2023-1234"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "related via alias overlap",
+			f1: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "CVE-2023-1234",
+					Aliases: []string{},
+				},
+			},
+			f2: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "GHSA-xxxx-yyyy-zzzz",
+					Aliases: []string{"CVE-2023-1234"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "not related",
+			f1: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "CVE-2023-1111",
+					Aliases: []string{},
+				},
+			},
+			f2: Finding{
+				Vulnerability: Vulnerability{
+					ID:      "CVE-2023-2222",
+					Aliases: []string{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findingsAreRelated(tt.f1, tt.f2)
+			if result != tt.expected {
+				t.Errorf("findingsAreRelated() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+

--- a/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -8,6 +8,578 @@
   "Findings": [
     {
       "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24557",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24788",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.2-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-236w-p7wf-5ph8",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-2jwv-jmq4-4j3r",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-3f6r-qh9c-x6mm",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-3whm-j4xm-rv8x",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-49gw-vxvf-fc2g",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-5fq7-4mxc-535h",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-7wrw-r4p8-38rx",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8xfx-rj4p-23jm",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-crqm-pwhx-j97f",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-hw49-2p59-3mhj",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.2-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-j7vj-rw65-4v26",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xw73-rw38-6vjc",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d3b1ec258cb888a6",
+        "Name": "github.com/docker/distribution",
+        "Version": "v2.8.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-hqxw-f8mx-cpmw",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-2253"
+        ],
+        "FixedVersion": "2.8.2-beta.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-232p-vwff-86mp",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-28840"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-33pg-m6jh-5237",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28841"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-6wrf-mxfj-pf5p",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28842"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-jq35-85cj-fj4p",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "23.0.8"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-mq39-4gv4-mvpx",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-29018"
+        ],
+        "FixedVersion": "23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xw73-rw38-6vjc",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24557"
+        ],
+        "FixedVersion": "24.0.9"
+      }
+    },
+    {
+      "Package": {
         "ID": "57e92f1396f78859",
         "Name": "stdlib",
         "Version": "go1.20.2",
@@ -596,578 +1168,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24557",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24788",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.2-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-236w-p7wf-5ph8",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-2jwv-jmq4-4j3r",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-3f6r-qh9c-x6mm",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-3whm-j4xm-rv8x",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-49gw-vxvf-fc2g",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-5fq7-4mxc-535h",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-7wrw-r4p8-38rx",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8xfx-rj4p-23jm",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-crqm-pwhx-j97f",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-hw49-2p59-3mhj",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.2-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-j7vj-rw65-4v26",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xw73-rw38-6vjc",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq39-4gv4-mvpx",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-29018"
-        ],
-        "FixedVersion": "23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-232p-vwff-86mp",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-28840"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-33pg-m6jh-5237",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28841"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-6wrf-mxfj-pf5p",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28842"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-jq35-85cj-fj4p",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "23.0.8"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xw73-rw38-6vjc",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24557"
-        ],
-        "FixedVersion": "24.0.9"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d3b1ec258cb888a6",
-        "Name": "github.com/docker/distribution",
-        "Version": "v2.8.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-hqxw-f8mx-cpmw",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-2253"
-        ],
-        "FixedVersion": "2.8.2-beta.1"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -344,22 +344,6 @@
     },
     {
       "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r3"
-      }
-    },
-    {
-      "Package": {
         "ID": "57e92f1396f78859",
         "Name": "stdlib",
         "Version": "go1.20.2",
@@ -404,22 +388,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24557",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r1"
       }
     },
     {
@@ -472,22 +440,6 @@
     },
     {
       "Package": {
-        "ID": "fed6a37b93f939e0",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
         "ID": "57e92f1396f78859",
         "Name": "stdlib",
         "Version": "go1.20.2",
@@ -500,6 +452,198 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24557",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fed6a37b93f939e0",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=aarch64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
       }
     },
     {
@@ -536,22 +680,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -564,22 +692,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
       }
     },
     {
@@ -600,38 +712,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-29018",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc3, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -644,22 +724,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -680,22 +744,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -712,54 +760,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -776,22 +776,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -804,22 +788,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
       }
     },
     {
@@ -836,40 +804,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-232p-vwff-86mp",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-28840"
-        ],
-        "FixedVersion": "23.0.3"
       }
     },
     {
@@ -902,24 +836,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-33pg-m6jh-5237",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28841"
-        ],
-        "FixedVersion": "23.0.3"
       }
     },
     {
@@ -1004,24 +920,6 @@
     },
     {
       "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-6wrf-mxfj-pf5p",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28842"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -1070,24 +968,6 @@
     },
     {
       "Package": {
-        "ID": "d3b1ec258cb888a6",
-        "Name": "github.com/docker/distribution",
-        "Version": "v2.8.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-hqxw-f8mx-cpmw",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-2253"
-        ],
-        "FixedVersion": "2.8.2-beta.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -1120,40 +1000,6 @@
     },
     {
       "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-jq35-85cj-fj4p",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "23.0.8"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21006541b5815819",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq39-4gv4-mvpx",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-29018"
-        ],
-        "FixedVersion": "23.0.11"
-      }
-    },
-    {
-      "Package": {
         "ID": "fed6a37b93f939e0",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -1178,12 +1024,150 @@
         "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
       },
       "Vulnerability": {
+        "ID": "GHSA-mq39-4gv4-mvpx",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-29018"
+        ],
+        "FixedVersion": "23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-232p-vwff-86mp",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-28840"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-33pg-m6jh-5237",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28841"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-6wrf-mxfj-pf5p",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28842"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-jq35-85cj-fj4p",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "23.0.8"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21006541b5815819",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
         "ID": "GHSA-xw73-rw38-6vjc",
         "Severity": "Medium",
         "Aliases": [
           "CVE-2024-24557"
         ],
         "FixedVersion": "24.0.9"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d3b1ec258cb888a6",
+        "Name": "github.com/docker/distribution",
+        "Version": "v2.8.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-hqxw-f8mx-cpmw",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-2253"
+        ],
+        "FixedVersion": "2.8.2-beta.1"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.wolfictl-scan.json
@@ -232,6 +232,38 @@
     },
     {
       "Package": {
+        "ID": "efdccf152e0515fe",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "efdccf152e0515fe",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
+      }
+    },
+    {
+      "Package": {
         "ID": "384f119e54193e7a",
         "Name": "stdlib",
         "Version": "go1.22.4",
@@ -340,38 +372,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "efdccf152e0515fe",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "efdccf152e0515fe",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.wolfictl-scan.json
@@ -24,22 +24,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
         "ID": "e53b033316bed0e3",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -52,22 +36,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -88,22 +56,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "e53b033316bed0e3",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -120,54 +72,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "efdccf152e0515fe",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "efdccf152e0515fe",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "e53b033316bed0e3",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -184,22 +88,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "e53b033316bed0e3",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -212,22 +100,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
       }
     },
     {
@@ -244,22 +116,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     },
     {
@@ -372,6 +228,150 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "efdccf152e0515fe",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "efdccf152e0515fe",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -8,6 +8,4998 @@
   "Findings": [
     {
       "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -40,342 +5032,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -388,342 +5044,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
       }
     },
     {
@@ -744,342 +5064,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -1092,342 +5076,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
       }
     },
     {
@@ -1448,342 +5096,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -1796,342 +5108,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
       }
     },
     {
@@ -2152,1014 +5128,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -3172,342 +5140,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.21.5-r0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
       }
     },
     {
@@ -3528,342 +5160,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -3876,342 +5172,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
       }
     },
     {
@@ -4232,342 +5192,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -4580,342 +5204,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
       }
     },
     {
@@ -4936,342 +5224,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -5284,342 +5236,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
       }
     },
     {
@@ -5640,342 +5256,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -5992,342 +5272,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -6340,342 +5284,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "1.21.11-r0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
       }
     },
     {
@@ -6696,342 +5304,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -7044,342 +5316,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -7400,342 +5336,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -7748,342 +5348,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -8104,342 +5368,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -8456,342 +5384,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -8804,342 +5396,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1b84017a8a8d669f",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5981f96de1f2bb7",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     },
     {
@@ -9252,6 +5508,3750 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.21.5-r0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1b84017a8a8d669f",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -8,4998 +8,6 @@
   "Findings": [
     {
       "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "61f71d73be183fb4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e36045f2884c54e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0c8b429511c6989b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "895df37118102509",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "662f2aa4ed3cd6d9",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7f5ec53907004145",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "419337dc27e939a2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4ad4e3812297f453",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b06fa24fa96c08cd",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "89b0a5693bdad6e2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "23284e47bb774a0b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "83837f1e972cb800",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -5512,11 +520,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5528,11 +536,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5544,11 +552,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5560,11 +568,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5576,11 +584,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5592,11 +600,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5608,11 +616,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5624,11 +632,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5640,11 +648,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5656,11 +664,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5672,11 +680,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5688,11 +696,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5704,11 +712,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5720,11 +728,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5736,11 +744,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5752,11 +760,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5768,11 +776,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5784,11 +792,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5800,11 +808,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5816,11 +824,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5832,11 +840,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5848,11 +856,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5864,11 +872,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5880,11 +888,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5896,11 +904,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5912,2507 +920,11 @@
     },
     {
       "Package": {
-        "ID": "e5981f96de1f2bb7",
+        "ID": "a98bd34056bacc14",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d31df57779a8d1be",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0feabba7c698f42e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a3535f553e9c47e1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6e29743fb91e2748",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "f0033f95c8b8f8e4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "236142c3ebcb7166",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "Location": "/usr/lib/go/bin/go",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8840,6 +1352,1254 @@
     },
     {
       "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d31df57779a8d1be",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "662f2aa4ed3cd6d9",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7f5ec53907004145",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "1b84017a8a8d669f",
         "Name": "stdlib",
         "Version": "go1.21.0",
@@ -9245,6 +3005,6246 @@
         "Version": "go1.21.0",
         "Type": "go-module",
         "Location": "/usr/lib/go/pkg/tool/linux_arm64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "419337dc27e939a2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0feabba7c698f42e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "61f71d73be183fb4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a3535f553e9c47e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e36045f2884c54e1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0c8b429511c6989b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "895df37118102509",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4ad4e3812297f453",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b06fa24fa96c08cd",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6e29743fb91e2748",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "f0033f95c8b8f8e4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5981f96de1f2bb7",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "89b0a5693bdad6e2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "23284e47bb774a0b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "236142c3ebcb7166",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_arm64/vet",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {

--- a/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -8,6 +8,60 @@
   "Findings": [
     {
       "Package": {
+        "ID": "a145349ac56ab1b1",
+        "Name": "setuptools",
+        "Version": "65.5.0",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
+        "PURL": "pkg:pypi/setuptools@65.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-cx63-2mw6-8hw5",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-6345"
+        ],
+        "FixedVersion": "70.0.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a145349ac56ab1b1",
+        "Name": "setuptools",
+        "Version": "65.5.0",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
+        "PURL": "pkg:pypi/setuptools@65.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-r9hx-vwmv-q579",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2022-40897"
+        ],
+        "FixedVersion": "65.5.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "2c8263814eb0e9b8",
+        "Name": "pip",
+        "Version": "22.3.1",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
+        "PURL": "pkg:pypi/pip@22.3.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-mq26-g339-26xf",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-5752"
+        ],
+        "FixedVersion": "23.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "fd0d299cb0d51ec3",
         "Name": "python-3.11",
         "Version": "3.11.1-r5",
@@ -344,24 +398,6 @@
     },
     {
       "Package": {
-        "ID": "a145349ac56ab1b1",
-        "Name": "setuptools",
-        "Version": "65.5.0",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
-        "PURL": "pkg:pypi/setuptools@65.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-cx63-2mw6-8hw5",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-6345"
-        ],
-        "FixedVersion": "70.0.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fd0d299cb0d51ec3",
         "Name": "python-3.11",
         "Version": "3.11.1-r5",
@@ -426,24 +462,6 @@
     },
     {
       "Package": {
-        "ID": "2c8263814eb0e9b8",
-        "Name": "pip",
-        "Version": "22.3.1",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
-        "PURL": "pkg:pypi/pip@22.3.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq26-g339-26xf",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-5752"
-        ],
-        "FixedVersion": "23.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "fd0d299cb0d51ec3",
         "Name": "python-3.11",
         "Version": "3.11.1-r5",
@@ -456,24 +474,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "3.11.9-r8"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a145349ac56ab1b1",
-        "Name": "setuptools",
-        "Version": "65.5.0",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
-        "PURL": "pkg:pypi/setuptools@65.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-r9hx-vwmv-q579",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2022-40897"
-        ],
-        "FixedVersion": "65.5.1"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -8,60 +8,6 @@
   "Findings": [
     {
       "Package": {
-        "ID": "a145349ac56ab1b1",
-        "Name": "setuptools",
-        "Version": "65.5.0",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
-        "PURL": "pkg:pypi/setuptools@65.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-cx63-2mw6-8hw5",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-6345"
-        ],
-        "FixedVersion": "70.0.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a145349ac56ab1b1",
-        "Name": "setuptools",
-        "Version": "65.5.0",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
-        "PURL": "pkg:pypi/setuptools@65.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-r9hx-vwmv-q579",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2022-40897"
-        ],
-        "FixedVersion": "65.5.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "2c8263814eb0e9b8",
-        "Name": "pip",
-        "Version": "22.3.1",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
-        "PURL": "pkg:pypi/pip@22.3.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq26-g339-26xf",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-5752"
-        ],
-        "FixedVersion": "23.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "fd0d299cb0d51ec3",
         "Name": "python-3.11",
         "Version": "3.11.1-r5",
@@ -474,6 +420,60 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "3.11.9-r8"
+      }
+    },
+    {
+      "Package": {
+        "ID": "2c8263814eb0e9b8",
+        "Name": "pip",
+        "Version": "22.3.1",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
+        "PURL": "pkg:pypi/pip@22.3.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-mq26-g339-26xf",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-5752"
+        ],
+        "FixedVersion": "23.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a145349ac56ab1b1",
+        "Name": "setuptools",
+        "Version": "65.5.0",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
+        "PURL": "pkg:pypi/setuptools@65.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-cx63-2mw6-8hw5",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-6345"
+        ],
+        "FixedVersion": "70.0.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a145349ac56ab1b1",
+        "Name": "setuptools",
+        "Version": "65.5.0",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
+        "PURL": "pkg:pypi/setuptools@65.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-r9hx-vwmv-q579",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2022-40897"
+        ],
+        "FixedVersion": "65.5.1"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -8,774 +8,6 @@
   "Findings": [
     {
       "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-vvpx-j8f3-3w6h",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2022-41723"
-        ],
-        "FixedVersion": "0.7.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4374-p667-p6c8",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-39325"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-2wrh-6pvc-2jm9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-3978"
-        ],
-        "FixedVersion": "0.13.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-qppj-fm5r-hxr3",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-44487"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-45288"
-        ],
-        "FixedVersion": "0.23.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-45338"
-        ],
-        "FixedVersion": "0.33.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24531",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.0-0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24532",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.19.7, 1.20.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24534",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24536",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24537",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24538",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24539",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.9, 1.20.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24540",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.9, 1.20.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29400",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.9, 1.20.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29402",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29403",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29404",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29405",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29406",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.19.11, 1.20.6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29409",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.19.12, 1.20.7"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1, 1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fdbd885f855051c",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fdbd885f855051c",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fdbd885f855051c",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-45x7-px36-x8w8",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-48795"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1592,40 +824,6 @@
     },
     {
       "Package": {
-        "ID": "6f4393d26e6e9633",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v6v8-xj6m-xwqh",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-6104"
-        ],
-        "FixedVersion": "0.7.7"
-      }
-    },
-    {
-      "Package": {
-        "ID": "8dd7d9202105900a",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.0.0-20210819190943-2bc19b11175f",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "ae47447bd40e421f",
         "Name": "github.com/golang-jwt/jwt/v4",
         "Version": "v4.2.0",
@@ -1640,24 +838,6 @@
           "CVE-2024-51744"
         ],
         "FixedVersion": "4.5.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1f82da5bd4f85217",
-        "Name": "google.golang.org/protobuf",
-        "Version": "v1.27.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8r3f-844c-mc37",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24786"
-        ],
-        "FixedVersion": "1.33.0"
       }
     },
     {
@@ -1716,6 +896,218 @@
     },
     {
       "Package": {
+        "ID": "6f4393d26e6e9633",
+        "Name": "github.com/hashicorp/go-retryablehttp",
+        "Version": "v0.7.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v6v8-xj6m-xwqh",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-6104"
+        ],
+        "FixedVersion": "0.7.7"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5b58970b8e3cd265",
+        "Name": "github.com/hashicorp/go-slug",
+        "Version": "v0.10.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.10.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2025-0377"
+        ],
+        "FixedVersion": "0.16.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fdbd885f855051c",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fdbd885f855051c",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-45x7-px36-x8w8",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-48795"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fdbd885f855051c",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-2wrh-6pvc-2jm9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-3978"
+        ],
+        "FixedVersion": "0.13.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4374-p667-p6c8",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-39325"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-45288"
+        ],
+        "FixedVersion": "0.23.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-qppj-fm5r-hxr3",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-44487"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-vvpx-j8f3-3w6h",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2022-41723"
+        ],
+        "FixedVersion": "0.7.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8dd7d9202105900a",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.0.0-20210819190943-2bc19b11175f",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
         "ID": "e5bae27dd1749a7e",
         "Name": "google.golang.org/grpc",
         "Version": "v1.47.0",
@@ -1750,20 +1142,628 @@
     },
     {
       "Package": {
-        "ID": "5b58970b8e3cd265",
-        "Name": "github.com/hashicorp/go-slug",
-        "Version": "v0.10.0",
+        "ID": "1f82da5bd4f85217",
+        "Name": "google.golang.org/protobuf",
+        "Version": "v1.27.1",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.10.0"
+        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
       },
       "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
-        "Severity": "High",
+        "ID": "GHSA-8r3f-844c-mc37",
+        "Severity": "Medium",
         "Aliases": [
-          "CVE-2025-0377"
+          "CVE-2024-24786"
         ],
-        "FixedVersion": "0.16.3"
+        "FixedVersion": "1.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24531",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.0-0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24532",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.19.7, 1.20.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24534",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24536",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24537",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24538",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24539",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.9, 1.20.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24540",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.9, 1.20.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29400",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.9, 1.20.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29402",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29403",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29404",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29405",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29406",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.19.11, 1.20.6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29409",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.19.12, 1.20.7"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1, 1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -16,10 +16,102 @@
         "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
       },
       "Vulnerability": {
-        "ID": "CVE-2022-41723",
+        "ID": "GHSA-vvpx-j8f3-3w6h",
         "Severity": "High",
-        "Aliases": null,
+        "Aliases": [
+          "CVE-2022-41723"
+        ],
         "FixedVersion": "0.7.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4374-p667-p6c8",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-39325"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-2wrh-6pvc-2jm9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-3978"
+        ],
+        "FixedVersion": "0.13.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-qppj-fm5r-hxr3",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-44487"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-45288"
+        ],
+        "FixedVersion": "0.23.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc1fd97f6c48ba45",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
       }
     },
     {
@@ -312,22 +404,6 @@
     },
     {
       "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -340,22 +416,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.5-r6"
       }
     },
     {
@@ -376,54 +436,6 @@
     },
     {
       "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-3978",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.13.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-3978",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.5-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -436,22 +448,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r0"
       }
     },
     {
@@ -472,22 +468,6 @@
     },
     {
       "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.23.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -500,22 +480,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r6"
       }
     },
     {
@@ -536,22 +500,6 @@
     },
     {
       "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -564,38 +512,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-48795",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r3"
       }
     },
     {
@@ -616,22 +532,6 @@
     },
     {
       "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -648,22 +548,6 @@
     },
     {
       "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -676,38 +560,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24786",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r5"
       }
     },
     {
@@ -744,22 +596,6 @@
     },
     {
       "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r12"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -772,22 +608,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r12"
       }
     },
     {
@@ -808,22 +628,6 @@
     },
     {
       "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r15"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -840,22 +644,6 @@
     },
     {
       "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -868,22 +656,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -900,6 +672,362 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fdbd885f855051c",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fdbd885f855051c",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fdbd885f855051c",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-45x7-px36-x8w8",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-48795"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.5-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-3978",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.5-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-48795",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24786",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r12"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r12"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r15"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -936,38 +1064,6 @@
     },
     {
       "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fdbd885f855051c",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45337",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -980,22 +1076,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "1.5.7-r18"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45338",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.33.0"
       }
     },
     {
@@ -1016,22 +1096,6 @@
     },
     {
       "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1044,22 +1108,6 @@
         "Severity": "Low",
         "Aliases": null,
         "FixedVersion": "1.5.7-r17"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6f4393d26e6e9633",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-6104",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.7.7"
       }
     },
     {
@@ -1112,22 +1160,6 @@
     },
     {
       "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1140,38 +1172,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.5.7-r22"
-      }
-    },
-    {
-      "Package": {
-        "ID": "8dd7d9202105900a",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.0.0-20210819190943-2bc19b11175f",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fdbd885f855051c",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
       }
     },
     {
@@ -1192,24 +1192,6 @@
     },
     {
       "Package": {
-        "ID": "ae47447bd40e421f",
-        "Name": "github.com/golang-jwt/jwt/v4",
-        "Version": "v4.2.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-29wx-vh33-7x7r",
-        "Severity": "Low",
-        "Aliases": [
-          "CVE-2024-51744"
-        ],
-        "FixedVersion": "4.5.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1222,24 +1204,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r17"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-2wrh-6pvc-2jm9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-3978"
-        ],
-        "FixedVersion": "0.13.0"
       }
     },
     {
@@ -1308,24 +1272,6 @@
     },
     {
       "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4374-p667-p6c8",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-39325"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1338,24 +1284,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.5-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fdbd885f855051c",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-45x7-px36-x8w8",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-48795"
-        ],
-        "FixedVersion": "0.17.0"
       }
     },
     {
@@ -1392,24 +1320,6 @@
     },
     {
       "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-45288"
-        ],
-        "FixedVersion": "0.23.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1422,24 +1332,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1f82da5bd4f85217",
-        "Name": "google.golang.org/protobuf",
-        "Version": "v1.27.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8r3f-844c-mc37",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24786"
-        ],
-        "FixedVersion": "1.33.0"
       }
     },
     {
@@ -1556,40 +1448,6 @@
     },
     {
       "Package": {
-        "ID": "76d38aad17298ccd",
-        "Name": "github.com/hashicorp/go-getter",
-        "Version": "v1.6.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-jpxj-2jvg-6jv9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-0475"
-        ],
-        "FixedVersion": "1.7.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5bae27dd1749a7e",
-        "Name": "google.golang.org/grpc",
-        "Version": "v1.47.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-m425-mq94-257g",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.56.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1606,24 +1464,6 @@
     },
     {
       "Package": {
-        "ID": "76d38aad17298ccd",
-        "Name": "github.com/hashicorp/go-getter",
-        "Version": "v1.6.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-q64h-39hv-4cf7",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-3817"
-        ],
-        "FixedVersion": "1.7.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1636,42 +1476,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r8"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-qppj-fm5r-hxr3",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-44487"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5bae27dd1749a7e",
-        "Name": "google.golang.org/grpc",
-        "Version": "v1.47.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-qppj-fm5r-hxr3",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-44487"
-        ],
-        "FixedVersion": "1.56.3"
       }
     },
     {
@@ -1708,24 +1512,6 @@
     },
     {
       "Package": {
-        "ID": "6f4393d26e6e9633",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v6v8-xj6m-xwqh",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-6104"
-        ],
-        "FixedVersion": "0.7.7"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1738,24 +1524,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r13"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fdbd885f855051c",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
       }
     },
     {
@@ -1776,42 +1544,6 @@
     },
     {
       "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-vvpx-j8f3-3w6h",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2022-41723"
-        ],
-        "FixedVersion": "0.7.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc1fd97f6c48ba45",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-45338"
-        ],
-        "FixedVersion": "0.33.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1828,24 +1560,6 @@
     },
     {
       "Package": {
-        "ID": "5b58970b8e3cd265",
-        "Name": "github.com/hashicorp/go-slug",
-        "Version": "v0.10.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.10.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2025-0377"
-        ],
-        "FixedVersion": "0.16.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "b8dfb6c8b53af1d6",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1858,6 +1572,128 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r21"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b8dfb6c8b53af1d6",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xfhp-jf8p-mh5w",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r14"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6f4393d26e6e9633",
+        "Name": "github.com/hashicorp/go-retryablehttp",
+        "Version": "v0.7.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v6v8-xj6m-xwqh",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-6104"
+        ],
+        "FixedVersion": "0.7.7"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8dd7d9202105900a",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.0.0-20210819190943-2bc19b11175f",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ae47447bd40e421f",
+        "Name": "github.com/golang-jwt/jwt/v4",
+        "Version": "v4.2.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-29wx-vh33-7x7r",
+        "Severity": "Low",
+        "Aliases": [
+          "CVE-2024-51744"
+        ],
+        "FixedVersion": "4.5.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1f82da5bd4f85217",
+        "Name": "google.golang.org/protobuf",
+        "Version": "v1.27.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8r3f-844c-mc37",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24786"
+        ],
+        "FixedVersion": "1.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "76d38aad17298ccd",
+        "Name": "github.com/hashicorp/go-getter",
+        "Version": "v1.6.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-jpxj-2jvg-6jv9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-0475"
+        ],
+        "FixedVersion": "1.7.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "76d38aad17298ccd",
+        "Name": "github.com/hashicorp/go-getter",
+        "Version": "v1.6.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-q64h-39hv-4cf7",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-3817"
+        ],
+        "FixedVersion": "1.7.4"
       }
     },
     {
@@ -1880,18 +1716,54 @@
     },
     {
       "Package": {
-        "ID": "b8dfb6c8b53af1d6",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=aarch64\u0026origin=terraform"
+        "ID": "e5bae27dd1749a7e",
+        "Name": "google.golang.org/grpc",
+        "Version": "v1.47.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-xfhp-jf8p-mh5w",
-        "Severity": "Unknown",
+        "ID": "GHSA-m425-mq94-257g",
+        "Severity": "High",
         "Aliases": null,
-        "FixedVersion": "1.5.7-r14"
+        "FixedVersion": "1.56.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5bae27dd1749a7e",
+        "Name": "google.golang.org/grpc",
+        "Version": "v1.47.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-qppj-fm5r-hxr3",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-44487"
+        ],
+        "FixedVersion": "1.56.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5b58970b8e3cd265",
+        "Name": "github.com/hashicorp/go-slug",
+        "Version": "v0.10.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.10.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2025-0377"
+        ],
+        "FixedVersion": "0.16.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.wolfictl-scan.json
@@ -8,188 +8,6 @@
   "Findings": [
     {
       "Package": {
-        "ID": "604020f9a243bdf0",
-        "Name": "github.com/hashicorp/go-getter",
-        "Version": "v1.7.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.7.4"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xfhp-jf8p-mh5w",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-6257"
-        ],
-        "FixedVersion": "1.7.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d2c28a4da59036a5",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d2c28a4da59036a5",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3a6df904ce997cce",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v6v8-xj6m-xwqh",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-6104"
-        ],
-        "FixedVersion": "0.7.7"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "4c8bbb3251acb004",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -542,6 +360,112 @@
     },
     {
       "Package": {
+        "ID": "cd36405cb70a38d6",
+        "Name": "github.com/golang-jwt/jwt/v4",
+        "Version": "v4.2.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-29wx-vh33-7x7r",
+        "Severity": "Low",
+        "Aliases": [
+          "CVE-2024-51744"
+        ],
+        "FixedVersion": "4.5.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "604020f9a243bdf0",
+        "Name": "github.com/hashicorp/go-getter",
+        "Version": "v1.7.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.7.4"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xfhp-jf8p-mh5w",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-6257"
+        ],
+        "FixedVersion": "1.7.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3a6df904ce997cce",
+        "Name": "github.com/hashicorp/go-retryablehttp",
+        "Version": "v0.7.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v6v8-xj6m-xwqh",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-6104"
+        ],
+        "FixedVersion": "0.7.7"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a48140a901fca7f7",
+        "Name": "github.com/hashicorp/go-slug",
+        "Version": "v0.11.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.11.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2025-0377"
+        ],
+        "FixedVersion": "0.16.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d2c28a4da59036a5",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.21.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d2c28a4da59036a5",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.21.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
         "ID": "d1d9c96e749f7111",
         "Name": "golang.org/x/net",
         "Version": "v0.23.0",
@@ -576,38 +500,114 @@
     },
     {
       "Package": {
-        "ID": "cd36405cb70a38d6",
-        "Name": "github.com/golang-jwt/jwt/v4",
-        "Version": "v4.2.0",
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
+        "PURL": "pkg:golang/stdlib@1.22.4"
       },
       "Vulnerability": {
-        "ID": "GHSA-29wx-vh33-7x7r",
-        "Severity": "Low",
-        "Aliases": [
-          "CVE-2024-51744"
-        ],
-        "FixedVersion": "4.5.1"
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
       }
     },
     {
       "Package": {
-        "ID": "a48140a901fca7f7",
-        "Name": "github.com/hashicorp/go-slug",
-        "Version": "v0.11.1",
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.11.1"
+        "PURL": "pkg:golang/stdlib@1.22.4"
       },
       "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
         "Severity": "High",
-        "Aliases": [
-          "CVE-2025-0377"
-        ],
-        "FixedVersion": "0.16.3"
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.wolfictl-scan.json
@@ -8,6 +8,76 @@
   "Findings": [
     {
       "Package": {
+        "ID": "604020f9a243bdf0",
+        "Name": "github.com/hashicorp/go-getter",
+        "Version": "v1.7.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.7.4"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xfhp-jf8p-mh5w",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-6257"
+        ],
+        "FixedVersion": "1.7.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d2c28a4da59036a5",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.21.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d2c28a4da59036a5",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.21.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3a6df904ce997cce",
+        "Name": "github.com/hashicorp/go-retryablehttp",
+        "Version": "v0.7.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v6v8-xj6m-xwqh",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-6104"
+        ],
+        "FixedVersion": "0.7.7"
+      }
+    },
+    {
+      "Package": {
         "ID": "a5963ac4aad96084",
         "Name": "stdlib",
         "Version": "go1.22.4",
@@ -24,22 +94,6 @@
     },
     {
       "Package": {
-        "ID": "4c8bbb3251acb004",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r15"
-      }
-    },
-    {
-      "Package": {
         "ID": "a5963ac4aad96084",
         "Name": "stdlib",
         "Version": "go1.22.4",
@@ -52,22 +106,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4c8bbb3251acb004",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -88,22 +126,6 @@
     },
     {
       "Package": {
-        "ID": "4c8bbb3251acb004",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
-      }
-    },
-    {
-      "Package": {
         "ID": "a5963ac4aad96084",
         "Name": "stdlib",
         "Version": "go1.22.4",
@@ -116,22 +138,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4c8bbb3251acb004",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -152,18 +158,98 @@
     },
     {
       "Package": {
-        "ID": "d2c28a4da59036a5",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+        "PURL": "pkg:golang/stdlib@1.22.4"
       },
       "Vulnerability": {
-        "ID": "CVE-2024-45337",
-        "Severity": "Critical",
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
         "Aliases": null,
-        "FixedVersion": "0.31.0"
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4c8bbb3251acb004",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r15"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4c8bbb3251acb004",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4c8bbb3251acb004",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4c8bbb3251acb004",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -184,22 +270,6 @@
     },
     {
       "Package": {
-        "ID": "d1d9c96e749f7111",
-        "Name": "golang.org/x/net",
-        "Version": "v0.23.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.23.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45338",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.33.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "4c8bbb3251acb004",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -216,22 +286,6 @@
     },
     {
       "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "4c8bbb3251acb004",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -244,22 +298,6 @@
         "Severity": "Low",
         "Aliases": null,
         "FixedVersion": "1.5.7-r17"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3a6df904ce997cce",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-6104",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.7.7"
       }
     },
     {
@@ -312,22 +350,6 @@
     },
     {
       "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "4c8bbb3251acb004",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -340,56 +362,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.5.7-r22"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fea663fb4a99251",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.7.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.7.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d2c28a4da59036a5",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cd36405cb70a38d6",
-        "Name": "github.com/golang-jwt/jwt/v4",
-        "Version": "v4.2.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-29wx-vh33-7x7r",
-        "Severity": "Low",
-        "Aliases": [
-          "CVE-2024-51744"
-        ],
-        "FixedVersion": "4.5.1"
       }
     },
     {
@@ -490,24 +462,6 @@
     },
     {
       "Package": {
-        "ID": "3a6df904ce997cce",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v6v8-xj6m-xwqh",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-6104"
-        ],
-        "FixedVersion": "0.7.7"
-      }
-    },
-    {
-      "Package": {
         "ID": "4c8bbb3251acb004",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -524,24 +478,6 @@
     },
     {
       "Package": {
-        "ID": "d2c28a4da59036a5",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "4c8bbb3251acb004",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -554,6 +490,54 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r18"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4c8bbb3251acb004",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r19"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4c8bbb3251acb004",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r21"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4c8bbb3251acb004",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xfhp-jf8p-mh5w",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r14"
       }
     },
     {
@@ -576,18 +560,36 @@
     },
     {
       "Package": {
-        "ID": "4c8bbb3251acb004",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
+        "ID": "4fea663fb4a99251",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.7.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.7.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "Unknown",
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
         "Aliases": null,
-        "FixedVersion": "1.5.7-r19"
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cd36405cb70a38d6",
+        "Name": "github.com/golang-jwt/jwt/v4",
+        "Version": "v4.2.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-29wx-vh33-7x7r",
+        "Severity": "Low",
+        "Aliases": [
+          "CVE-2024-51744"
+        ],
+        "FixedVersion": "4.5.1"
       }
     },
     {
@@ -606,56 +608,6 @@
           "CVE-2025-0377"
         ],
         "FixedVersion": "0.16.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4c8bbb3251acb004",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r21"
-      }
-    },
-    {
-      "Package": {
-        "ID": "604020f9a243bdf0",
-        "Name": "github.com/hashicorp/go-getter",
-        "Version": "v1.7.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.7.4"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xfhp-jf8p-mh5w",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-6257"
-        ],
-        "FixedVersion": "1.7.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4c8bbb3251acb004",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=aarch64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xfhp-jf8p-mh5w",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r14"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -8,20 +8,20 @@
   "Findings": [
     {
       "Package": {
-        "ID": "68708acc29687484",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
+        "ID": "af23af31d30f3392",
+        "Name": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+        "Version": "v1.3.1",
         "Type": "go-module",
         "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
+        "PURL": "pkg:golang/github.com/Azure/azure-sdk-for-go@v1.3.1#sdk/azidentity"
       },
       "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
+        "ID": "GHSA-m5vv-6r4h-3vj9",
+        "Severity": "Medium",
         "Aliases": [
-          "CVE-2024-45337"
+          "CVE-2024-35255"
         ],
-        "FixedVersion": "0.31.0"
+        "FixedVersion": "1.6.0"
       }
     },
     {
@@ -42,54 +42,20 @@
     },
     {
       "Package": {
-        "ID": "35a6bdd4df9bc6d9",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.11.0",
+        "ID": "68708acc29687484",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.17.0",
         "Type": "go-module",
         "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
       },
       "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "761d1c96d4f94b57",
-        "Name": "google.golang.org/protobuf",
-        "Version": "v1.31.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/google.golang.org/protobuf@v1.31.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8r3f-844c-mc37",
-        "Severity": "Medium",
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
         "Aliases": [
-          "CVE-2024-24786"
+          "CVE-2024-45337"
         ],
-        "FixedVersion": "1.33.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "af23af31d30f3392",
-        "Name": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-        "Version": "v1.3.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/github.com/Azure/azure-sdk-for-go@v1.3.1#sdk/azidentity"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-m5vv-6r4h-3vj9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-35255"
-        ],
-        "FixedVersion": "1.6.0"
+        "FixedVersion": "0.31.0"
       }
     },
     {
@@ -126,6 +92,40 @@
           "CVE-2024-45338"
         ],
         "FixedVersion": "0.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "35a6bdd4df9bc6d9",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.11.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "761d1c96d4f94b57",
+        "Name": "google.golang.org/protobuf",
+        "Version": "v1.31.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/google.golang.org/protobuf@v1.31.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8r3f-844c-mc37",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24786"
+        ],
+        "FixedVersion": "1.33.0"
       }
     },
     {

--- a/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -8,6 +8,92 @@
   "Findings": [
     {
       "Package": {
+        "ID": "68708acc29687484",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.17.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "68708acc29687484",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.17.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "35a6bdd4df9bc6d9",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.11.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "761d1c96d4f94b57",
+        "Name": "google.golang.org/protobuf",
+        "Version": "v1.31.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/google.golang.org/protobuf@v1.31.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8r3f-844c-mc37",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24786"
+        ],
+        "FixedVersion": "1.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "af23af31d30f3392",
+        "Name": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+        "Version": "v1.3.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/github.com/Azure/azure-sdk-for-go@v1.3.1#sdk/azidentity"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-m5vv-6r4h-3vj9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-35255"
+        ],
+        "FixedVersion": "1.6.0"
+      }
+    },
+    {
+      "Package": {
         "ID": "6d9ed7391e114226",
         "Name": "golang.org/x/net",
         "Version": "v0.17.0",
@@ -16,10 +102,30 @@
         "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
       },
       "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-45288"
+        ],
         "FixedVersion": "0.23.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6d9ed7391e114226",
+        "Name": "golang.org/x/net",
+        "Version": "v0.17.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
       }
     },
     {
@@ -248,38 +354,6 @@
     },
     {
       "Package": {
-        "ID": "68708acc29687484",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45337",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6d9ed7391e114226",
-        "Name": "golang.org/x/net",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45338",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.33.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "a381e9342c27e49a",
         "Name": "stdlib",
         "Version": "go1.21.5",
@@ -308,128 +382,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "35a6bdd4df9bc6d9",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.11.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "68708acc29687484",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6d9ed7391e114226",
-        "Name": "golang.org/x/net",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-45288"
-        ],
-        "FixedVersion": "0.23.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "761d1c96d4f94b57",
-        "Name": "google.golang.org/protobuf",
-        "Version": "v1.31.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/google.golang.org/protobuf@v1.31.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8r3f-844c-mc37",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24786"
-        ],
-        "FixedVersion": "1.33.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "af23af31d30f3392",
-        "Name": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-        "Version": "v1.3.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/github.com/Azure/azure-sdk-for-go@v1.3.1#sdk/azidentity"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-m5vv-6r4h-3vj9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-35255"
-        ],
-        "FixedVersion": "1.6.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "68708acc29687484",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6d9ed7391e114226",
-        "Name": "golang.org/x/net",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-45338"
-        ],
-        "FixedVersion": "0.33.0"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -8,6 +8,578 @@
   "Findings": [
     {
       "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24557",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24788",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.2-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-236w-p7wf-5ph8",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-2jwv-jmq4-4j3r",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-3f6r-qh9c-x6mm",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-3whm-j4xm-rv8x",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-49gw-vxvf-fc2g",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-5fq7-4mxc-535h",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-7wrw-r4p8-38rx",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.3-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8xfx-rj4p-23jm",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-crqm-pwhx-j97f",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-hw49-2p59-3mhj",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.2-r2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-j7vj-rw65-4v26",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xw73-rw38-6vjc",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "32b3acd5c71f06ca",
+        "Name": "github.com/docker/distribution",
+        "Version": "v2.8.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-hqxw-f8mx-cpmw",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-2253"
+        ],
+        "FixedVersion": "2.8.2-beta.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-232p-vwff-86mp",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-28840"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-33pg-m6jh-5237",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28841"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-6wrf-mxfj-pf5p",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28842"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-jq35-85cj-fj4p",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "23.0.8"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-mq39-4gv4-mvpx",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-29018"
+        ],
+        "FixedVersion": "23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xw73-rw38-6vjc",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24557"
+        ],
+        "FixedVersion": "24.0.9"
+      }
+    },
+    {
+      "Package": {
         "ID": "57e92f1396f78859",
         "Name": "stdlib",
         "Version": "go1.20.2",
@@ -596,578 +1168,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24557",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24788",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.2-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-236w-p7wf-5ph8",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-2jwv-jmq4-4j3r",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-3f6r-qh9c-x6mm",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-3whm-j4xm-rv8x",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-49gw-vxvf-fc2g",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-5fq7-4mxc-535h",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-7wrw-r4p8-38rx",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8xfx-rj4p-23jm",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-crqm-pwhx-j97f",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-hw49-2p59-3mhj",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.2-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-j7vj-rw65-4v26",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xw73-rw38-6vjc",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq39-4gv4-mvpx",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-29018"
-        ],
-        "FixedVersion": "23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-232p-vwff-86mp",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-28840"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-33pg-m6jh-5237",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28841"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-6wrf-mxfj-pf5p",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28842"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-jq35-85cj-fj4p",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "23.0.8"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xw73-rw38-6vjc",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24557"
-        ],
-        "FixedVersion": "24.0.9"
-      }
-    },
-    {
-      "Package": {
-        "ID": "32b3acd5c71f06ca",
-        "Name": "github.com/docker/distribution",
-        "Version": "v2.8.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-hqxw-f8mx-cpmw",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-2253"
-        ],
-        "FixedVersion": "2.8.2-beta.1"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/crane-0.14.0-r0.apk.wolfictl-scan.json
@@ -344,22 +344,6 @@
     },
     {
       "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r3"
-      }
-    },
-    {
-      "Package": {
         "ID": "57e92f1396f78859",
         "Name": "stdlib",
         "Version": "go1.20.2",
@@ -404,22 +388,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24557",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r1"
       }
     },
     {
@@ -472,22 +440,6 @@
     },
     {
       "Package": {
-        "ID": "1feba3fe8fa8d375",
-        "Name": "crane",
-        "Version": "0.14.0-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
         "ID": "57e92f1396f78859",
         "Name": "stdlib",
         "Version": "go1.20.2",
@@ -500,6 +452,198 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "57e92f1396f78859",
+        "Name": "stdlib",
+        "Version": "go1.20.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.20.2"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24557",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "1feba3fe8fa8d375",
+        "Name": "crane",
+        "Version": "0.14.0-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/crane@0.14.0-r0?arch=x86_64\u0026origin=crane"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "0.19.1-r5"
       }
     },
     {
@@ -536,22 +680,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -564,22 +692,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "0.19.1-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
       }
     },
     {
@@ -600,38 +712,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-29018",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc3, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -644,22 +724,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -680,22 +744,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -712,54 +760,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -776,22 +776,6 @@
     },
     {
       "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -804,22 +788,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
       }
     },
     {
@@ -836,40 +804,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "57e92f1396f78859",
-        "Name": "stdlib",
-        "Version": "go1.20.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.20.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-232p-vwff-86mp",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-28840"
-        ],
-        "FixedVersion": "23.0.3"
       }
     },
     {
@@ -902,24 +836,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "0.19.1-r5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-33pg-m6jh-5237",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28841"
-        ],
-        "FixedVersion": "23.0.3"
       }
     },
     {
@@ -1004,24 +920,6 @@
     },
     {
       "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-6wrf-mxfj-pf5p",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-28842"
-        ],
-        "FixedVersion": "23.0.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -1070,24 +968,6 @@
     },
     {
       "Package": {
-        "ID": "32b3acd5c71f06ca",
-        "Name": "github.com/docker/distribution",
-        "Version": "v2.8.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-hqxw-f8mx-cpmw",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-2253"
-        ],
-        "FixedVersion": "2.8.2-beta.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -1120,40 +1000,6 @@
     },
     {
       "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-jq35-85cj-fj4p",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "23.0.8"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b1f837467f3053c1",
-        "Name": "github.com/docker/docker",
-        "Version": "v23.0.1+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq39-4gv4-mvpx",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-29018"
-        ],
-        "FixedVersion": "23.0.11"
-      }
-    },
-    {
-      "Package": {
         "ID": "1feba3fe8fa8d375",
         "Name": "crane",
         "Version": "0.14.0-r0",
@@ -1178,12 +1024,150 @@
         "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
       },
       "Vulnerability": {
+        "ID": "GHSA-mq39-4gv4-mvpx",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-29018"
+        ],
+        "FixedVersion": "23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-232p-vwff-86mp",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-28840"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-33pg-m6jh-5237",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28841"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-6wrf-mxfj-pf5p",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-28842"
+        ],
+        "FixedVersion": "23.0.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-jq35-85cj-fj4p",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "23.0.8"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b1f837467f3053c1",
+        "Name": "github.com/docker/docker",
+        "Version": "v23.0.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v23.0.1%2Bincompatible"
+      },
+      "Vulnerability": {
         "ID": "GHSA-xw73-rw38-6vjc",
         "Severity": "Medium",
         "Aliases": [
           "CVE-2024-24557"
         ],
         "FixedVersion": "24.0.9"
+      }
+    },
+    {
+      "Package": {
+        "ID": "32b3acd5c71f06ca",
+        "Name": "github.com/docker/distribution",
+        "Version": "v2.8.1+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/distribution@v2.8.1%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-hqxw-f8mx-cpmw",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-2253"
+        ],
+        "FixedVersion": "2.8.2-beta.1"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.wolfictl-scan.json
@@ -24,22 +24,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
         "ID": "e6e5215687dff987",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -52,22 +36,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.2-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -88,22 +56,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "e6e5215687dff987",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -120,54 +72,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a2718d12120d8101",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a2718d12120d8101",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "e6e5215687dff987",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -184,22 +88,6 @@
     },
     {
       "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "e6e5215687dff987",
         "Name": "crane",
         "Version": "0.19.1-r6",
@@ -212,22 +100,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
       }
     },
     {
@@ -244,22 +116,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "0.20.3-r2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "384f119e54193e7a",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     },
     {
@@ -372,6 +228,150 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "0.20.2-r1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "384f119e54193e7a",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a2718d12120d8101",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a2718d12120d8101",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.wolfictl-scan.json
@@ -232,6 +232,38 @@
     },
     {
       "Package": {
+        "ID": "a2718d12120d8101",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36621",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a2718d12120d8101",
+        "Name": "github.com/docker/docker",
+        "Version": "v24.0.9+incompatible",
+        "Type": "go-module",
+        "Location": "/usr/bin/crane",
+        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-36623",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "26.0.0-rc1, 25.0.4"
+      }
+    },
+    {
+      "Package": {
         "ID": "384f119e54193e7a",
         "Name": "stdlib",
         "Version": "go1.22.4",
@@ -340,38 +372,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a2718d12120d8101",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36621",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc2, 25.0.5, 23.0.11"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a2718d12120d8101",
-        "Name": "github.com/docker/docker",
-        "Version": "v24.0.9+incompatible",
-        "Type": "go-module",
-        "Location": "/usr/bin/crane",
-        "PURL": "pkg:golang/github.com/docker/docker@v24.0.9%2Bincompatible"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-36623",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "26.0.0-rc1, 25.0.4"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -8,6 +8,3750 @@
   "Findings": [
     {
       "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbdf7278144cfa52",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7e50ba3e616fcbee",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ff742f1a6c479912",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -40,342 +3784,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -388,342 +3796,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
       }
     },
     {
@@ -744,342 +3816,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -1092,342 +3828,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
       }
     },
     {
@@ -1448,342 +3848,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -1796,342 +3860,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
       }
     },
     {
@@ -2152,1014 +3880,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -3172,342 +3892,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.21.5-r0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
       }
     },
     {
@@ -3528,342 +3912,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -3876,342 +3924,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
       }
     },
     {
@@ -4232,342 +3944,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -4580,342 +3956,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
       }
     },
     {
@@ -4936,342 +3976,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -5284,342 +3988,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
       }
     },
     {
@@ -5640,342 +4008,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -5992,342 +4024,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -6340,342 +4036,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "1.21.11-r0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
       }
     },
     {
@@ -6696,342 +4056,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -7044,342 +4068,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -7400,342 +4088,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -7748,342 +4100,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
       }
     },
     {
@@ -8104,342 +4120,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -8456,342 +4136,6 @@
     },
     {
       "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -8804,342 +4148,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": ""
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "4fc4c5af1303e631",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "25f5e07e6e27131b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "227afd710aea609e",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e5f660479968d534",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "bc1e51dd213cb3a8",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "3f9d74395b91c27d",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "793dfb0cfa636004",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6b20a8696a009636",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "e323698977a32bcc",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "0ab855cb0097cc22",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     },
     {
@@ -9252,6 +4260,4998 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.21.5-r0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "4fc4c5af1303e631",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/addr2line",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "25f5e07e6e27131b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/asm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "227afd710aea609e",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cgo",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6b20a8696a009636",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "bc1e51dd213cb3a8",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/distpack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "793dfb0cfa636004",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/objdump",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e5f660479968d534",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/go-1.21-1.21.0-r0.apk.wolfictl-scan.json
@@ -8,3750 +8,6 @@
   "Findings": [
     {
       "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbdf7278144cfa52",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c1592c345bbba2b1",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "353da9d8ac614768",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "67684da8d112c9d2",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a98bd34056bacc14",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/go",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7e50ba3e616fcbee",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "ff742f1a6c479912",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fbf556119f9872da",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "5eae6e6b20bdf42b",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "43f5067fde7f8e47",
         "Name": "go-1.21",
         "Version": "1.21.0-r0",
@@ -4264,6 +520,838 @@
     },
     {
       "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a98bd34056bacc14",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/go",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "78c1998233403ec3",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/bin/gofmt",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "4fc4c5af1303e631",
         "Name": "stdlib",
         "Version": "go1.21.0",
@@ -5096,6 +2184,422 @@
     },
     {
       "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9217bb4637c6d1c4",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "227afd710aea609e",
         "Name": "stdlib",
         "Version": "go1.21.0",
@@ -5512,11 +3016,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5528,11 +3032,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5544,11 +3048,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5560,11 +3064,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5576,11 +3080,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5592,11 +3096,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5608,11 +3112,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5624,11 +3128,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5640,11 +3144,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5656,11 +3160,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5672,11 +3176,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5688,11 +3192,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5704,11 +3208,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5720,11 +3224,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5736,11 +3240,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5752,11 +3256,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5768,11 +3272,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5784,11 +3288,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5800,11 +3304,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5816,11 +3320,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5832,11 +3336,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5848,11 +3352,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5864,11 +3368,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5880,11 +3384,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5896,11 +3400,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5912,11 +3416,11 @@
     },
     {
       "Package": {
-        "ID": "3f9d74395b91c27d",
+        "ID": "e5f660479968d534",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5928,11 +3432,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5944,11 +3448,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5960,11 +3464,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5976,11 +3480,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -5992,11 +3496,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6008,11 +3512,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6024,11 +3528,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6040,11 +3544,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6056,11 +3560,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6072,11 +3576,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6088,11 +3592,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6104,11 +3608,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6120,11 +3624,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6136,11 +3640,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6152,11 +3656,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6168,11 +3672,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6184,11 +3688,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6200,11 +3704,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6216,11 +3720,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6232,11 +3736,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6248,11 +3752,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6264,11 +3768,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6280,11 +3784,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6296,11 +3800,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6312,11 +3816,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6328,11 +3832,11 @@
     },
     {
       "Package": {
-        "ID": "6b20a8696a009636",
+        "ID": "7e50ba3e616fcbee",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/covdata",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6344,11 +3848,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6360,11 +3864,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6376,11 +3880,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6392,11 +3896,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6408,11 +3912,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6424,11 +3928,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6440,11 +3944,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6456,11 +3960,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6472,11 +3976,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6488,11 +3992,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6504,11 +4008,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6520,11 +4024,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6536,11 +4040,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6552,11 +4056,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6568,11 +4072,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6584,11 +4088,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6600,11 +4104,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6616,11 +4120,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6632,11 +4136,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6648,11 +4152,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6664,11 +4168,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6680,11 +4184,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6696,11 +4200,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6712,11 +4216,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6728,11 +4232,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6744,11 +4248,11 @@
     },
     {
       "Package": {
-        "ID": "e323698977a32bcc",
+        "ID": "ff742f1a6c479912",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/cover",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6760,11 +4264,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6776,11 +4280,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6792,11 +4296,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6808,11 +4312,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6824,11 +4328,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6840,11 +4344,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6856,11 +4360,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6872,11 +4376,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6888,11 +4392,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6904,11 +4408,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6920,11 +4424,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6936,11 +4440,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6952,11 +4456,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6968,11 +4472,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -6984,11 +4488,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7000,11 +4504,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7016,11 +4520,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7032,11 +4536,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7048,11 +4552,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7064,11 +4568,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7080,11 +4584,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7096,11 +4600,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7112,11 +4616,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7128,11 +4632,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7144,11 +4648,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -7160,843 +4664,11 @@
     },
     {
       "Package": {
-        "ID": "0ab855cb0097cc22",
+        "ID": "fbdf7278144cfa52",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "78c1998233403ec3",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/bin/gofmt",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39320",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39321",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39322",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
-        "PURL": "pkg:golang/stdlib@1.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9217bb4637c6d1c4",
-        "Name": "stdlib",
-        "Version": "go1.21.0",
-        "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/buildid",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/dist",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8424,6 +5096,1670 @@
     },
     {
       "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "3f9d74395b91c27d",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/doc",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c1592c345bbba2b1",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/fix",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fbf556119f9872da",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/link",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "353da9d8ac614768",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/nm",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "793dfb0cfa636004",
         "Name": "stdlib",
         "Version": "go1.21.0",
@@ -8840,11 +7176,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8856,11 +7192,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8872,11 +7208,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8888,11 +7224,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8904,11 +7240,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8920,11 +7256,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8936,11 +7272,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8952,11 +7288,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8968,11 +7304,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -8984,11 +7320,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9000,11 +7336,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9016,11 +7352,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9032,11 +7368,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9048,11 +7384,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9064,11 +7400,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9080,11 +7416,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9096,11 +7432,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9112,11 +7448,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9128,11 +7464,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9144,11 +7480,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9160,11 +7496,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9176,11 +7512,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9192,11 +7528,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9208,11 +7544,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9224,11 +7560,11 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {
@@ -9240,11 +7576,1675 @@
     },
     {
       "Package": {
-        "ID": "e5f660479968d534",
+        "ID": "6b20a8696a009636",
         "Name": "stdlib",
         "Version": "go1.21.0",
         "Type": "go-module",
-        "Location": "/usr/lib/go/pkg/tool/linux_amd64/compile",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pack",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "67684da8d112c9d2",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/pprof",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "e323698977a32bcc",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/test2json",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "5eae6e6b20bdf42b",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/trace",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39320",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39321",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39322",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.21.8, 1.22.1, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
+        "PURL": "pkg:golang/stdlib@1.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "0ab855cb0097cc22",
+        "Name": "stdlib",
+        "Version": "go1.21.0",
+        "Type": "go-module",
+        "Location": "/usr/lib/go/pkg/tool/linux_amd64/vet",
         "PURL": "pkg:golang/stdlib@1.21.0"
       },
       "Vulnerability": {

--- a/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -424,6 +424,24 @@
     },
     {
       "Package": {
+        "ID": "2c8263814eb0e9b8",
+        "Name": "pip",
+        "Version": "22.3.1",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
+        "PURL": "pkg:pypi/pip@22.3.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-mq26-g339-26xf",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-5752"
+        ],
+        "FixedVersion": "23.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "a145349ac56ab1b1",
         "Name": "setuptools",
         "Version": "65.5.0",
@@ -456,24 +474,6 @@
           "CVE-2022-40897"
         ],
         "FixedVersion": "65.5.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "2c8263814eb0e9b8",
-        "Name": "pip",
-        "Version": "22.3.1",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
-        "PURL": "pkg:pypi/pip@22.3.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq26-g339-26xf",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-5752"
-        ],
-        "FixedVersion": "23.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/python-3.11-3.11.1-r5.apk.wolfictl-scan.json
@@ -344,24 +344,6 @@
     },
     {
       "Package": {
-        "ID": "a145349ac56ab1b1",
-        "Name": "setuptools",
-        "Version": "65.5.0",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
-        "PURL": "pkg:pypi/setuptools@65.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-cx63-2mw6-8hw5",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-6345"
-        ],
-        "FixedVersion": "70.0.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fb73f3cf6020c0d4",
         "Name": "python-3.11",
         "Version": "3.11.1-r5",
@@ -426,24 +408,6 @@
     },
     {
       "Package": {
-        "ID": "2c8263814eb0e9b8",
-        "Name": "pip",
-        "Version": "22.3.1",
-        "Type": "python",
-        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
-        "PURL": "pkg:pypi/pip@22.3.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-mq26-g339-26xf",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-5752"
-        ],
-        "FixedVersion": "23.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "fb73f3cf6020c0d4",
         "Name": "python-3.11",
         "Version": "3.11.1-r5",
@@ -468,12 +432,48 @@
         "PURL": "pkg:pypi/setuptools@65.5.0"
       },
       "Vulnerability": {
+        "ID": "GHSA-cx63-2mw6-8hw5",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-6345"
+        ],
+        "FixedVersion": "70.0.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a145349ac56ab1b1",
+        "Name": "setuptools",
+        "Version": "65.5.0",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl",
+        "PURL": "pkg:pypi/setuptools@65.5.0"
+      },
+      "Vulnerability": {
         "ID": "GHSA-r9hx-vwmv-q579",
         "Severity": "High",
         "Aliases": [
           "CVE-2022-40897"
         ],
         "FixedVersion": "65.5.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "2c8263814eb0e9b8",
+        "Name": "pip",
+        "Version": "22.3.1",
+        "Type": "python",
+        "Location": "/usr/lib/python3.11/ensurepip/_bundled/pip-22.3.1-py3-none-any.whl",
+        "PURL": "pkg:pypi/pip@22.3.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-mq26-g339-26xf",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-5752"
+        ],
+        "FixedVersion": "23.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -8,808 +8,6 @@
   "Findings": [
     {
       "Package": {
-        "ID": "04e50b17c22c9d6e",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.0.0-20210819190943-2bc19b11175f",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "9b855c673286e43d",
-        "Name": "github.com/golang-jwt/jwt/v4",
-        "Version": "v4.2.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-29wx-vh33-7x7r",
-        "Severity": "Low",
-        "Aliases": [
-          "CVE-2024-51744"
-        ],
-        "FixedVersion": "4.5.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "43cc20844f878051",
-        "Name": "google.golang.org/protobuf",
-        "Version": "v1.27.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8r3f-844c-mc37",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24786"
-        ],
-        "FixedVersion": "1.33.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cff9b04f8022a510",
-        "Name": "google.golang.org/grpc",
-        "Version": "v1.47.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-m425-mq94-257g",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.56.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cff9b04f8022a510",
-        "Name": "google.golang.org/grpc",
-        "Version": "v1.47.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-qppj-fm5r-hxr3",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-44487"
-        ],
-        "FixedVersion": "1.56.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-vvpx-j8f3-3w6h",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2022-41723"
-        ],
-        "FixedVersion": "0.7.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4374-p667-p6c8",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-39325"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-2wrh-6pvc-2jm9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-3978"
-        ],
-        "FixedVersion": "0.13.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-qppj-fm5r-hxr3",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-44487"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-45288"
-        ],
-        "FixedVersion": "0.23.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-45338"
-        ],
-        "FixedVersion": "0.33.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24531",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.0-0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24532",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.19.7, 1.20.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24534",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24536",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24537",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24538",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.8, 1.20.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24539",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.9, 1.20.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-24540",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.9, 1.20.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29400",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.9, 1.20.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29402",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29403",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29404",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29405",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.19.10, 1.20.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29406",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.19.11, 1.20.6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-29409",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.19.12, 1.20.7"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39318",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39319",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.8, 1.21.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39323",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.9, 1.21.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39326",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45285",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.20.12, 1.21.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1, 1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24787",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.10, 1.22.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1626,72 +824,20 @@
     },
     {
       "Package": {
-        "ID": "21c9e7c519ef80f6",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
+        "ID": "9b855c673286e43d",
+        "Name": "github.com/golang-jwt/jwt/v4",
+        "Version": "v4.2.0",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
       },
       "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
+        "ID": "GHSA-29wx-vh33-7x7r",
+        "Severity": "Low",
         "Aliases": [
-          "CVE-2024-45337"
+          "CVE-2024-51744"
         ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21c9e7c519ef80f6",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21c9e7c519ef80f6",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-45x7-px36-x8w8",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-48795"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "2d3292a6549e8a25",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v6v8-xj6m-xwqh",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-6104"
-        ],
-        "FixedVersion": "0.7.7"
+        "FixedVersion": "4.5.1"
       }
     },
     {
@@ -1750,6 +896,24 @@
     },
     {
       "Package": {
+        "ID": "2d3292a6549e8a25",
+        "Name": "github.com/hashicorp/go-retryablehttp",
+        "Version": "v0.7.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v6v8-xj6m-xwqh",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-6104"
+        ],
+        "FixedVersion": "0.7.7"
+      }
+    },
+    {
+      "Package": {
         "ID": "692c8f36563df880",
         "Name": "github.com/hashicorp/go-slug",
         "Version": "v0.10.0",
@@ -1764,6 +928,842 @@
           "CVE-2025-0377"
         ],
         "FixedVersion": "0.16.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21c9e7c519ef80f6",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21c9e7c519ef80f6",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-45x7-px36-x8w8",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-48795"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "21c9e7c519ef80f6",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-2wrh-6pvc-2jm9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-3978"
+        ],
+        "FixedVersion": "0.13.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4374-p667-p6c8",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-39325"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-45288"
+        ],
+        "FixedVersion": "0.23.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-qppj-fm5r-hxr3",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-44487"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-vvpx-j8f3-3w6h",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2022-41723"
+        ],
+        "FixedVersion": "0.7.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "04e50b17c22c9d6e",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.0.0-20210819190943-2bc19b11175f",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cff9b04f8022a510",
+        "Name": "google.golang.org/grpc",
+        "Version": "v1.47.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-m425-mq94-257g",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.56.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cff9b04f8022a510",
+        "Name": "google.golang.org/grpc",
+        "Version": "v1.47.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-qppj-fm5r-hxr3",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-44487"
+        ],
+        "FixedVersion": "1.56.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "43cc20844f878051",
+        "Name": "google.golang.org/protobuf",
+        "Version": "v1.27.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8r3f-844c-mc37",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24786"
+        ],
+        "FixedVersion": "1.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24531",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.0-0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24532",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.19.7, 1.20.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24534",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24536",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24537",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24538",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.8, 1.20.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24539",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.9, 1.20.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-24540",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.9, 1.20.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29400",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.9, 1.20.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29402",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29403",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29404",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29405",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.19.10, 1.20.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29406",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.19.11, 1.20.6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-29409",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.19.12, 1.20.7"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39318",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39319",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.8, 1.21.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39323",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.9, 1.21.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39326",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.10, 1.21.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45285",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.20.12, 1.21.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.9, 1.22.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1, 1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.21.8, 1.22.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24787",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.10, 1.22.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.21.11, 1.22.4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.3.9-r0.apk.wolfictl-scan.json
@@ -8,6 +8,92 @@
   "Findings": [
     {
       "Package": {
+        "ID": "04e50b17c22c9d6e",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.0.0-20210819190943-2bc19b11175f",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "9b855c673286e43d",
+        "Name": "github.com/golang-jwt/jwt/v4",
+        "Version": "v4.2.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-29wx-vh33-7x7r",
+        "Severity": "Low",
+        "Aliases": [
+          "CVE-2024-51744"
+        ],
+        "FixedVersion": "4.5.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "43cc20844f878051",
+        "Name": "google.golang.org/protobuf",
+        "Version": "v1.27.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8r3f-844c-mc37",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24786"
+        ],
+        "FixedVersion": "1.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cff9b04f8022a510",
+        "Name": "google.golang.org/grpc",
+        "Version": "v1.47.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-m425-mq94-257g",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.56.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cff9b04f8022a510",
+        "Name": "google.golang.org/grpc",
+        "Version": "v1.47.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-qppj-fm5r-hxr3",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-44487"
+        ],
+        "FixedVersion": "1.56.3"
+      }
+    },
+    {
+      "Package": {
         "ID": "7358cc66ee4eb94f",
         "Name": "golang.org/x/net",
         "Version": "v0.5.0",
@@ -16,10 +102,102 @@
         "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
       },
       "Vulnerability": {
-        "ID": "CVE-2022-41723",
+        "ID": "GHSA-vvpx-j8f3-3w6h",
         "Severity": "High",
-        "Aliases": null,
+        "Aliases": [
+          "CVE-2022-41723"
+        ],
         "FixedVersion": "0.7.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4374-p667-p6c8",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2023-39325"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-2wrh-6pvc-2jm9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-3978"
+        ],
+        "FixedVersion": "0.13.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-qppj-fm5r-hxr3",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-44487"
+        ],
+        "FixedVersion": "0.17.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-45288"
+        ],
+        "FixedVersion": "0.23.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7358cc66ee4eb94f",
+        "Name": "golang.org/x/net",
+        "Version": "v0.5.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
       }
     },
     {
@@ -312,22 +490,6 @@
     },
     {
       "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -340,22 +502,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-39325",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.5-r6"
       }
     },
     {
@@ -376,54 +522,6 @@
     },
     {
       "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-3978",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.13.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-3978",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.5-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -436,22 +534,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.20.10, 1.21.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-44487",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r0"
       }
     },
     {
@@ -472,22 +554,6 @@
     },
     {
       "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.23.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -500,22 +566,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.21.9, 1.22.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r6"
       }
     },
     {
@@ -536,22 +586,6 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45289",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -564,38 +598,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-45290",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2023-48795",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r3"
       }
     },
     {
@@ -616,22 +618,6 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24783",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -648,22 +634,6 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24784",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -676,38 +646,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.21.8, 1.22.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24785",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24786",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r5"
       }
     },
     {
@@ -744,22 +682,6 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24789",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r12"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -772,22 +694,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "1.21.11, 1.22.4"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24790",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r12"
       }
     },
     {
@@ -808,22 +714,6 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r15"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -840,22 +730,6 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
-      }
-    },
-    {
-      "Package": {
         "ID": "fe00586043ed8c0c",
         "Name": "stdlib",
         "Version": "go1.20.1",
@@ -868,22 +742,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -900,6 +758,310 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "fe00586043ed8c0c",
+        "Name": "stdlib",
+        "Version": "go1.20.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.20.1"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-39325",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.5-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-3978",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.5-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-44487",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45288",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r6"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45289",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-45290",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2023-48795",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24783",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24784",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24785",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r4"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24786",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24789",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r12"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24790",
+        "Severity": "Critical",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r12"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r15"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -936,38 +1098,6 @@
     },
     {
       "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21c9e7c519ef80f6",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45337",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -980,22 +1110,6 @@
         "Severity": "Critical",
         "Aliases": null,
         "FixedVersion": "1.5.7-r18"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45338",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.33.0"
       }
     },
     {
@@ -1016,22 +1130,6 @@
     },
     {
       "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1044,22 +1142,6 @@
         "Severity": "Low",
         "Aliases": null,
         "FixedVersion": "1.5.7-r17"
-      }
-    },
-    {
-      "Package": {
-        "ID": "2d3292a6549e8a25",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-6104",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.7.7"
       }
     },
     {
@@ -1112,22 +1194,6 @@
     },
     {
       "Package": {
-        "ID": "fe00586043ed8c0c",
-        "Name": "stdlib",
-        "Version": "go1.20.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.20.1"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1140,38 +1206,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.5.7-r22"
-      }
-    },
-    {
-      "Package": {
-        "ID": "04e50b17c22c9d6e",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.0.0-20210819190943-2bc19b11175f",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.0.0-20210819190943-2bc19b11175f"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21c9e7c519ef80f6",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
       }
     },
     {
@@ -1192,24 +1226,6 @@
     },
     {
       "Package": {
-        "ID": "9b855c673286e43d",
-        "Name": "github.com/golang-jwt/jwt/v4",
-        "Version": "v4.2.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-29wx-vh33-7x7r",
-        "Severity": "Low",
-        "Aliases": [
-          "CVE-2024-51744"
-        ],
-        "FixedVersion": "4.5.1"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1222,24 +1238,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r17"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-2wrh-6pvc-2jm9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-3978"
-        ],
-        "FixedVersion": "0.13.0"
       }
     },
     {
@@ -1308,24 +1306,6 @@
     },
     {
       "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4374-p667-p6c8",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2023-39325"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1338,24 +1318,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.5-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "21c9e7c519ef80f6",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-45x7-px36-x8w8",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-48795"
-        ],
-        "FixedVersion": "0.17.0"
       }
     },
     {
@@ -1392,24 +1354,6 @@
     },
     {
       "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-45288"
-        ],
-        "FixedVersion": "0.23.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1422,24 +1366,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r6"
-      }
-    },
-    {
-      "Package": {
-        "ID": "43cc20844f878051",
-        "Name": "google.golang.org/protobuf",
-        "Version": "v1.27.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/protobuf@v1.27.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8r3f-844c-mc37",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24786"
-        ],
-        "FixedVersion": "1.33.0"
       }
     },
     {
@@ -1556,40 +1482,6 @@
     },
     {
       "Package": {
-        "ID": "ed3a65a940c73184",
-        "Name": "github.com/hashicorp/go-getter",
-        "Version": "v1.6.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-jpxj-2jvg-6jv9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-0475"
-        ],
-        "FixedVersion": "1.7.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cff9b04f8022a510",
-        "Name": "google.golang.org/grpc",
-        "Version": "v1.47.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-m425-mq94-257g",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.56.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1606,24 +1498,6 @@
     },
     {
       "Package": {
-        "ID": "ed3a65a940c73184",
-        "Name": "github.com/hashicorp/go-getter",
-        "Version": "v1.6.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-q64h-39hv-4cf7",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-3817"
-        ],
-        "FixedVersion": "1.7.4"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1636,42 +1510,6 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r8"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
-        "Version": "v0.5.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-qppj-fm5r-hxr3",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-44487"
-        ],
-        "FixedVersion": "0.17.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cff9b04f8022a510",
-        "Name": "google.golang.org/grpc",
-        "Version": "v1.47.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/google.golang.org/grpc@v1.47.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-qppj-fm5r-hxr3",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-44487"
-        ],
-        "FixedVersion": "1.56.3"
       }
     },
     {
@@ -1708,24 +1546,6 @@
     },
     {
       "Package": {
-        "ID": "2d3292a6549e8a25",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v6v8-xj6m-xwqh",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-6104"
-        ],
-        "FixedVersion": "0.7.7"
-      }
-    },
-    {
-      "Package": {
         "ID": "c62edb49d4d644cb",
         "Name": "terraform",
         "Version": "1.3.9-r0",
@@ -1738,6 +1558,70 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r13"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r18"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r19"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r21"
+      }
+    },
+    {
+      "Package": {
+        "ID": "c62edb49d4d644cb",
+        "Name": "terraform",
+        "Version": "1.3.9-r0",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xfhp-jf8p-mh5w",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r14"
       }
     },
     {
@@ -1760,104 +1644,90 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r18"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
+        "ID": "21c9e7c519ef80f6",
+        "Name": "golang.org/x/crypto",
         "Version": "v0.5.0",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-vvpx-j8f3-3w6h",
+        "ID": "CVE-2025-22869",
         "Severity": "High",
-        "Aliases": [
-          "CVE-2022-41723"
-        ],
-        "FixedVersion": "0.7.0"
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
       }
     },
     {
       "Package": {
-        "ID": "7358cc66ee4eb94f",
-        "Name": "golang.org/x/net",
+        "ID": "21c9e7c519ef80f6",
+        "Name": "golang.org/x/crypto",
         "Version": "v0.5.0",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.5.0"
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.5.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "High",
+        "ID": "GHSA-45x7-px36-x8w8",
+        "Severity": "Medium",
         "Aliases": [
-          "CVE-2024-45338"
+          "CVE-2023-48795"
         ],
-        "FixedVersion": "0.33.0"
+        "FixedVersion": "0.17.0"
       }
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r19"
-      }
-    },
-    {
-      "Package": {
-        "ID": "692c8f36563df880",
-        "Name": "github.com/hashicorp/go-slug",
-        "Version": "v0.10.0",
+        "ID": "2d3292a6549e8a25",
+        "Name": "github.com/hashicorp/go-retryablehttp",
+        "Version": "v0.7.1",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.10.0"
+        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.1"
       },
       "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
-        "Severity": "High",
+        "ID": "GHSA-v6v8-xj6m-xwqh",
+        "Severity": "Medium",
         "Aliases": [
-          "CVE-2025-0377"
+          "CVE-2024-6104"
         ],
-        "FixedVersion": "0.16.3"
+        "FixedVersion": "0.7.7"
       }
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+        "ID": "ed3a65a940c73184",
+        "Name": "github.com/hashicorp/go-getter",
+        "Version": "v1.6.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
       },
       "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r21"
+        "ID": "GHSA-jpxj-2jvg-6jv9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-0475"
+        ],
+        "FixedVersion": "1.7.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "ed3a65a940c73184",
+        "Name": "github.com/hashicorp/go-getter",
+        "Version": "v1.6.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.6.2"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-q64h-39hv-4cf7",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-3817"
+        ],
+        "FixedVersion": "1.7.4"
       }
     },
     {
@@ -1880,18 +1750,20 @@
     },
     {
       "Package": {
-        "ID": "c62edb49d4d644cb",
-        "Name": "terraform",
-        "Version": "1.3.9-r0",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.3.9-r0?arch=x86_64\u0026origin=terraform"
+        "ID": "692c8f36563df880",
+        "Name": "github.com/hashicorp/go-slug",
+        "Version": "v0.10.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.10.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-xfhp-jf8p-mh5w",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r14"
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2025-0377"
+        ],
+        "FixedVersion": "0.16.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.wolfictl-scan.json
@@ -8,118 +8,6 @@
   "Findings": [
     {
       "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.21.12, 1.22.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45336",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "8965a15e14ddfc73",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -472,40 +360,6 @@
     },
     {
       "Package": {
-        "ID": "d20cff6e304c963f",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d20cff6e304c963f",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "d8ba928314d10dcf",
         "Name": "github.com/golang-jwt/jwt/v4",
         "Version": "v4.2.0",
@@ -524,38 +378,20 @@
     },
     {
       "Package": {
-        "ID": "5aed4950171a8b21",
-        "Name": "github.com/hashicorp/go-slug",
-        "Version": "v0.11.1",
+        "ID": "cabd61102c60e194",
+        "Name": "github.com/hashicorp/go-getter",
+        "Version": "v1.7.4",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.11.1"
+        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.7.4"
       },
       "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
+        "ID": "GHSA-xfhp-jf8p-mh5w",
         "Severity": "High",
         "Aliases": [
-          "CVE-2025-0377"
+          "CVE-2024-6257"
         ],
-        "FixedVersion": "0.16.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "18fe952e727fef44",
-        "Name": "golang.org/x/net",
-        "Version": "v0.23.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.23.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-45338"
-        ],
-        "FixedVersion": "0.33.0"
+        "FixedVersion": "1.7.5"
       }
     },
     {
@@ -578,6 +414,76 @@
     },
     {
       "Package": {
+        "ID": "5aed4950171a8b21",
+        "Name": "github.com/hashicorp/go-slug",
+        "Version": "v0.11.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-slug@v0.11.1"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2025-0377"
+        ],
+        "FixedVersion": "0.16.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d20cff6e304c963f",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.21.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "d20cff6e304c963f",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.21.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "18fe952e727fef44",
+        "Name": "golang.org/x/net",
+        "Version": "v0.23.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.23.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
+      }
+    },
+    {
+      "Package": {
         "ID": "7818d71605746aa8",
         "Name": "golang.org/x/oauth2",
         "Version": "v0.7.0",
@@ -594,20 +500,114 @@
     },
     {
       "Package": {
-        "ID": "cabd61102c60e194",
-        "Name": "github.com/hashicorp/go-getter",
-        "Version": "v1.7.4",
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-getter@v1.7.4"
+        "PURL": "pkg:golang/stdlib@1.22.4"
       },
       "Vulnerability": {
-        "ID": "GHSA-xfhp-jf8p-mh5w",
+        "ID": "CVE-2024-24791",
         "Severity": "High",
-        "Aliases": [
-          "CVE-2024-6257"
-        ],
-        "FixedVersion": "1.7.5"
+        "Aliases": null,
+        "FixedVersion": "1.21.12, 1.22.5"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.22.7, 1.23.1"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45336",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.wolfictl-scan.json
@@ -24,22 +24,6 @@
     },
     {
       "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-24791",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r15"
-      }
-    },
-    {
-      "Package": {
         "ID": "a5963ac4aad96084",
         "Name": "stdlib",
         "Version": "go1.22.4",
@@ -52,22 +36,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34155",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -88,22 +56,6 @@
     },
     {
       "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34156",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
-      }
-    },
-    {
-      "Package": {
         "ID": "a5963ac4aad96084",
         "Name": "stdlib",
         "Version": "go1.22.4",
@@ -116,22 +68,6 @@
         "Severity": "High",
         "Aliases": null,
         "FixedVersion": "1.22.7, 1.23.1"
-      }
-    },
-    {
-      "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-34158",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -152,18 +88,98 @@
     },
     {
       "Package": {
-        "ID": "d20cff6e304c963f",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
+        "PURL": "pkg:golang/stdlib@1.22.4"
       },
       "Vulnerability": {
-        "ID": "CVE-2024-45337",
-        "Severity": "Critical",
+        "ID": "CVE-2024-45341",
+        "Severity": "Medium",
         "Aliases": null,
-        "FixedVersion": "0.31.0"
+        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a5963ac4aad96084",
+        "Name": "stdlib",
+        "Version": "go1.22.4",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/stdlib@1.22.4"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22866",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-24791",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r15"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34155",
+        "Severity": "Medium",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34156",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2024-34158",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r16"
       }
     },
     {
@@ -184,22 +200,6 @@
     },
     {
       "Package": {
-        "ID": "18fe952e727fef44",
-        "Name": "golang.org/x/net",
-        "Version": "v0.23.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.23.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45338",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.33.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "8965a15e14ddfc73",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -216,22 +216,6 @@
     },
     {
       "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45341",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2"
-      }
-    },
-    {
-      "Package": {
         "ID": "8965a15e14ddfc73",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -244,22 +228,6 @@
         "Severity": "Low",
         "Aliases": null,
         "FixedVersion": "1.5.7-r17"
-      }
-    },
-    {
-      "Package": {
-        "ID": "45aa4945c27ee716",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-6104",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.7.7"
       }
     },
     {
@@ -312,22 +280,6 @@
     },
     {
       "Package": {
-        "ID": "a5963ac4aad96084",
-        "Name": "stdlib",
-        "Version": "go1.22.4",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/stdlib@1.22.4"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22866",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
         "ID": "8965a15e14ddfc73",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -340,56 +292,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.5.7-r22"
-      }
-    },
-    {
-      "Package": {
-        "ID": "7818d71605746aa8",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.7.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.7.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d20cff6e304c963f",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.21.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "d8ba928314d10dcf",
-        "Name": "github.com/golang-jwt/jwt/v4",
-        "Version": "v4.2.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-29wx-vh33-7x7r",
-        "Severity": "Low",
-        "Aliases": [
-          "CVE-2024-51744"
-        ],
-        "FixedVersion": "4.5.1"
       }
     },
     {
@@ -490,24 +392,6 @@
     },
     {
       "Package": {
-        "ID": "45aa4945c27ee716",
-        "Name": "github.com/hashicorp/go-retryablehttp",
-        "Version": "v0.7.2",
-        "Type": "go-module",
-        "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v6v8-xj6m-xwqh",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-6104"
-        ],
-        "FixedVersion": "0.7.7"
-      }
-    },
-    {
-      "Package": {
         "ID": "8965a15e14ddfc73",
         "Name": "terraform",
         "Version": "1.5.7-r12",
@@ -520,6 +404,70 @@
         "Severity": "Unknown",
         "Aliases": null,
         "FixedVersion": "1.5.7-r13"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r18"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r19"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-wpfp-cm49-9m9q",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r21"
+      }
+    },
+    {
+      "Package": {
+        "ID": "8965a15e14ddfc73",
+        "Name": "terraform",
+        "Version": "1.5.7-r12",
+        "Type": "apk",
+        "Location": "/.PKGINFO",
+        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-xfhp-jf8p-mh5w",
+        "Severity": "Unknown",
+        "Aliases": null,
+        "FixedVersion": "1.5.7-r14"
       }
     },
     {
@@ -542,52 +490,36 @@
     },
     {
       "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r18"
-      }
-    },
-    {
-      "Package": {
-        "ID": "18fe952e727fef44",
-        "Name": "golang.org/x/net",
-        "Version": "v0.23.0",
+        "ID": "d20cff6e304c963f",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.21.0",
         "Type": "go-module",
         "Location": "/usr/bin/terraform",
-        "PURL": "pkg:golang/golang.org/x/net@v0.23.0"
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.21.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
+        "ID": "CVE-2025-22869",
         "Severity": "High",
-        "Aliases": [
-          "CVE-2024-45338"
-        ],
-        "FixedVersion": "0.33.0"
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
       }
     },
     {
       "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+        "ID": "d8ba928314d10dcf",
+        "Name": "github.com/golang-jwt/jwt/v4",
+        "Version": "v4.2.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/golang-jwt/jwt@v4.2.0#v4"
       },
       "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r19"
+        "ID": "GHSA-29wx-vh33-7x7r",
+        "Severity": "Low",
+        "Aliases": [
+          "CVE-2024-51744"
+        ],
+        "FixedVersion": "4.5.1"
       }
     },
     {
@@ -610,18 +542,54 @@
     },
     {
       "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
+        "ID": "18fe952e727fef44",
+        "Name": "golang.org/x/net",
+        "Version": "v0.23.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/net@v0.23.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-wpfp-cm49-9m9q",
-        "Severity": "Unknown",
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "45aa4945c27ee716",
+        "Name": "github.com/hashicorp/go-retryablehttp",
+        "Version": "v0.7.2",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.2"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v6v8-xj6m-xwqh",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-6104"
+        ],
+        "FixedVersion": "0.7.7"
+      }
+    },
+    {
+      "Package": {
+        "ID": "7818d71605746aa8",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.7.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/terraform",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.7.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
         "Aliases": null,
-        "FixedVersion": "1.5.7-r21"
+        "FixedVersion": "0.27.0"
       }
     },
     {
@@ -640,22 +608,6 @@
           "CVE-2024-6257"
         ],
         "FixedVersion": "1.7.5"
-      }
-    },
-    {
-      "Package": {
-        "ID": "8965a15e14ddfc73",
-        "Name": "terraform",
-        "Version": "1.5.7-r12",
-        "Type": "apk",
-        "Location": "/.PKGINFO",
-        "PURL": "pkg:apk/wolfi/terraform@1.5.7-r12?arch=x86_64\u0026origin=terraform"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-xfhp-jf8p-mh5w",
-        "Severity": "Unknown",
-        "Aliases": null,
-        "FixedVersion": "1.5.7-r14"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -16,10 +16,30 @@
         "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
       },
       "Vulnerability": {
-        "ID": "CVE-2023-45288",
-        "Severity": "High",
-        "Aliases": null,
+        "ID": "GHSA-4v7x-pqxf-cx7m",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2023-45288"
+        ],
         "FixedVersion": "0.23.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "6743558955678bb1",
+        "Name": "golang.org/x/net",
+        "Version": "v0.17.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-w32m-9786-jp63",
+        "Severity": "High",
+        "Aliases": [
+          "CVE-2024-45338"
+        ],
+        "FixedVersion": "0.33.0"
       }
     },
     {
@@ -248,38 +268,6 @@
     },
     {
       "Package": {
-        "ID": "a81fdd341b4ee1cc",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45337",
-        "Severity": "Critical",
-        "Aliases": null,
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6743558955678bb1",
-        "Name": "golang.org/x/net",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2024-45338",
-        "Severity": "Medium",
-        "Aliases": null,
-        "FixedVersion": "0.33.0"
-      }
-    },
-    {
-      "Package": {
         "ID": "a381e9342c27e49a",
         "Name": "stdlib",
         "Version": "go1.21.5",
@@ -312,18 +300,20 @@
     },
     {
       "Package": {
-        "ID": "b3c03fb8b6606b5a",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.11.0",
+        "ID": "a81fdd341b4ee1cc",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.17.0",
         "Type": "go-module",
         "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
       },
       "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
       }
     },
     {
@@ -344,20 +334,18 @@
     },
     {
       "Package": {
-        "ID": "6743558955678bb1",
-        "Name": "golang.org/x/net",
-        "Version": "v0.17.0",
+        "ID": "b3c03fb8b6606b5a",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.11.0",
         "Type": "go-module",
         "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
       },
       "Vulnerability": {
-        "ID": "GHSA-4v7x-pqxf-cx7m",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2023-45288"
-        ],
-        "FixedVersion": "0.23.0"
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
       }
     },
     {
@@ -394,42 +382,6 @@
           "CVE-2024-35255"
         ],
         "FixedVersion": "1.6.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a81fdd341b4ee1cc",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "6743558955678bb1",
-        "Name": "golang.org/x/net",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/net@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-w32m-9786-jp63",
-        "Severity": "High",
-        "Aliases": [
-          "CVE-2024-45338"
-        ],
-        "FixedVersion": "0.33.0"
       }
     }
   ],

--- a/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
+++ b/pkg/scan/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.wolfictl-scan.json
@@ -8,6 +8,58 @@
   "Findings": [
     {
       "Package": {
+        "ID": "2d2b04355924ae57",
+        "Name": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+        "Version": "v1.3.1",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/github.com/Azure/azure-sdk-for-go@v1.3.1#sdk/azidentity"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-m5vv-6r4h-3vj9",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-35255"
+        ],
+        "FixedVersion": "1.6.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a81fdd341b4ee1cc",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.17.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22869",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.35.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "a81fdd341b4ee1cc",
+        "Name": "golang.org/x/crypto",
+        "Version": "v0.17.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-v778-237x-gjrc",
+        "Severity": "Critical",
+        "Aliases": [
+          "CVE-2024-45337"
+        ],
+        "FixedVersion": "0.31.0"
+      }
+    },
+    {
+      "Package": {
         "ID": "6743558955678bb1",
         "Name": "golang.org/x/net",
         "Version": "v0.17.0",
@@ -40,6 +92,40 @@
           "CVE-2024-45338"
         ],
         "FixedVersion": "0.33.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "b3c03fb8b6606b5a",
+        "Name": "golang.org/x/oauth2",
+        "Version": "v0.11.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
+      },
+      "Vulnerability": {
+        "ID": "CVE-2025-22868",
+        "Severity": "High",
+        "Aliases": null,
+        "FixedVersion": "0.27.0"
+      }
+    },
+    {
+      "Package": {
+        "ID": "cc12b684c4cc6a86",
+        "Name": "google.golang.org/protobuf",
+        "Version": "v1.31.0",
+        "Type": "go-module",
+        "Location": "/usr/bin/thanos",
+        "PURL": "pkg:golang/google.golang.org/protobuf@v1.31.0"
+      },
+      "Vulnerability": {
+        "ID": "GHSA-8r3f-844c-mc37",
+        "Severity": "Medium",
+        "Aliases": [
+          "CVE-2024-24786"
+        ],
+        "FixedVersion": "1.33.0"
       }
     },
     {
@@ -296,92 +382,6 @@
         "Severity": "Medium",
         "Aliases": null,
         "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a81fdd341b4ee1cc",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-v778-237x-gjrc",
-        "Severity": "Critical",
-        "Aliases": [
-          "CVE-2024-45337"
-        ],
-        "FixedVersion": "0.31.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "a81fdd341b4ee1cc",
-        "Name": "golang.org/x/crypto",
-        "Version": "v0.17.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/crypto@v0.17.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22869",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.35.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "b3c03fb8b6606b5a",
-        "Name": "golang.org/x/oauth2",
-        "Version": "v0.11.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/golang.org/x/oauth2@v0.11.0"
-      },
-      "Vulnerability": {
-        "ID": "CVE-2025-22868",
-        "Severity": "High",
-        "Aliases": null,
-        "FixedVersion": "0.27.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "cc12b684c4cc6a86",
-        "Name": "google.golang.org/protobuf",
-        "Version": "v1.31.0",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/google.golang.org/protobuf@v1.31.0"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-8r3f-844c-mc37",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-24786"
-        ],
-        "FixedVersion": "1.33.0"
-      }
-    },
-    {
-      "Package": {
-        "ID": "2d2b04355924ae57",
-        "Name": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-        "Version": "v1.3.1",
-        "Type": "go-module",
-        "Location": "/usr/bin/thanos",
-        "PURL": "pkg:golang/github.com/Azure/azure-sdk-for-go@v1.3.1#sdk/azidentity"
-      },
-      "Vulnerability": {
-        "ID": "GHSA-m5vv-6r4h-3vj9",
-        "Severity": "Medium",
-        "Aliases": [
-          "CVE-2024-35255"
-        ],
-        "FixedVersion": "1.6.0"
       }
     }
   ],


### PR DESCRIPTION
Add logic to merge findings that represent the same vulnerability but are
reported under different identifiers (e.g., CVE-2023-1234 vs GHSA-xxxx).
This reduces noise in scan results when Grype reports the same vulnerability
multiple times through different matchers.

The implementation:
- Groups findings by package (name, type, location) before merging
- Identifies related findings when their ID/alias sets overlap
- Preserves the union of all aliases seen across merged findings
- Prefers findings with more complete alias data (GHSA > CVE)

This ensures that vulnerability filtering and advisory matching work
correctly by having access to all known aliases for each vulnerability,
while presenting cleaner output to users.