### PR TITLE
test(linter): reduce error messages ambiguity

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -582,9 +582,9 @@ func TestLinter_Rules(t *testing.T) {
 			require.Len(t, g.Errors, len(tt.want.Errors))
 
 			for i, e := range g.Errors {
-				assert.Equal(t, e.Error, tt.want.Errors[i].Error, "Lint(): Error: got = %v, want %v", e.Error, tt.want.Errors[i].Error)
-				assert.Equal(t, e.Rule.Name, tt.want.Errors[i].Rule.Name, "Lint(): Rule.Name: got = %v, want %v", e.Rule.Name, tt.want.Errors[i].Rule.Name)
-				assert.Equal(t, e.Rule.Severity, tt.want.Errors[i].Rule.Severity, "Lint(): Rule.Severity: got = %v, want %v", e.Rule.Severity, tt.want.Errors[i].Rule.Severity)
+				assert.Equal(t, tt.want.Errors[i].Error, e.Error, "Lint(): Error: got = %v, want %v", e.Error, tt.want.Errors[i].Error)
+				assert.Equal(t, tt.want.Errors[i].Rule.Name, e.Rule.Name, "Lint(): Rule.Name: got = %v, want %v", e.Rule.Name, tt.want.Errors[i].Rule.Name)
+				assert.Equal(t, tt.want.Errors[i].Rule.Severity, e.Rule.Severity, "Lint(): Rule.Severity: got = %v, want %v", e.Rule.Severity, tt.want.Errors[i].Rule.Severity)
 			}
 		})
 	}


### PR DESCRIPTION
The assert.Equal() expects the parameters to follow the "expected, actual" order. However, the test assertions for linter rules were written in the reversed order. While doing so has no functional consequences the output was confusing.

This commit fixes that by introducing the proper order of parameters.