### PR TITLE
lint: add rule to make sure update identifier matches git repo

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"chainguard.dev/melange/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +20,64 @@ func TestLinter_Rules(t *testing.T) {
 		want        EvalResult
 		wantErr     bool
 	}{
+		{
+			file:        "update-identifier-not-matching-git-checkout-repository.yaml",
+			minSeverity: SeverityError,
+			want: EvalResult{
+				File: "update-identifier-not-matching-git-checkout-repository",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "update-identifier-must-match-git-repository",
+							Severity: SeverityError,
+						},
+						Error: fmt.Errorf("[update-identifier-must-match-git-repository]: update identifier does not match the repository URI (ERROR)"),
+					},
+				},
+			},
+			wantErr: false,
+			matches: 1,
+		},
+		{
+			file:        "update-identifier-not-matching-git-checkout-repository-nolint.yaml",
+			minSeverity: SeverityError,
+			want: EvalResult{
+				File:   "update-identifier-not-matching-git-checkout-repository-nolint",
+				Errors: EvalRuleErrors{},
+			},
+			wantErr: false,
+			matches: 0,
+		},
+		{
+			file:        "update-identifier-matching-git-checkout-repository.yaml",
+			minSeverity: SeverityError,
+			want: EvalResult{
+				File:   "update-identifier-matching-git-checkout-repository",
+				Errors: EvalRuleErrors{},
+			},
+			wantErr: false,
+			matches: 0,
+		},
+		{
+			file:        "update-identifier-matching-git-checkout-repository-mixed-case.yaml",
+			minSeverity: SeverityError,
+			want: EvalResult{
+				File:   "update-identifier-matching-git-checkout-repository-mixed-case",
+				Errors: EvalRuleErrors{},
+			},
+			wantErr: false,
+			matches: 0,
+		},
+		{
+			file:        "update-identifier-matching-git-checkout-repository-multiple-pipelines.yaml",
+			minSeverity: SeverityError,
+			want: EvalResult{
+				File:   "update-identifier-matching-git-checkout-repository-multiple-pipelines",
+				Errors: EvalRuleErrors{},
+			},
+			wantErr: false,
+			matches: 0,
+		},
 		{
 			file:        "missing-copyright.yaml",
 			minSeverity: SeverityInfo,
@@ -585,6 +644,87 @@ func TestLinter_Rules(t *testing.T) {
 				assert.Equal(t, e.Error, tt.want.Errors[i].Error, "Lint(): Error: got = %v, want %v", e.Error, tt.want.Errors[i].Error)
 				assert.Equal(t, e.Rule.Name, tt.want.Errors[i].Rule.Name, "Lint(): Rule.Name: got = %v, want %v", e.Rule.Name, tt.want.Errors[i].Rule.Name)
 				assert.Equal(t, e.Rule.Severity, tt.want.Errors[i].Rule.Severity, "Lint(): Rule.Severity: got = %v, want %v", e.Rule.Severity, tt.want.Errors[i].Rule.Severity)
+			}
+		})
+	}
+}
+
+func TestIdentifierFromRepoURI(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "https://github.com/wolfi-dev/os",
+			expected: "wolfi-dev/os",
+		},
+		{
+			name:     "https://github.com/wolfi-dev/os/",
+			expected: "wolfi-dev/os",
+		},
+		{
+			name:     "https://github.com/wolfi-dev/os.git",
+			expected: "wolfi-dev/os",
+		},
+		{
+			name:     "https://github.com/wolfi-dev/os.git/",
+			expected: "wolfi-dev/os",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := identifierFromRepoURI(c.name)
+			if got != c.expected {
+				assert.Equal(t, c.expected, got, "Error: got = %v, want %v", got, c.expected)
+			}
+		})
+	}
+}
+
+func TestPickPipelinesUsing(t *testing.T) {
+	cases := []struct {
+		name      string
+		pipelines []config.Pipeline
+		expected  int
+	}{
+		{
+			name:      "single pipeline that match",
+			pipelines: []config.Pipeline{{Uses: "desired"}},
+			expected:  1,
+		},
+		{
+			name:      "single pipeline that do not match",
+			pipelines: []config.Pipeline{{Uses: "skipped"}},
+			expected:  0,
+		},
+		{
+			name:      "multiple pipelines that all match",
+			pipelines: []config.Pipeline{{Uses: "desired"}, {Uses: "desired"}, {Uses: "desired"}},
+			expected:  3,
+		},
+		{
+			name:      "multiple pipelines that some match",
+			pipelines: []config.Pipeline{{Uses: "skipped"}, {Uses: "desired"}, {Uses: "desired"}},
+			expected:  2,
+		},
+		{
+			name:      "multiple pipelines that none match",
+			pipelines: []config.Pipeline{{Uses: "skipped"}, {Uses: "skipped"}, {Uses: "skipped"}},
+			expected:  0,
+		},
+		{
+			name:      "no pipelines",
+			pipelines: []config.Pipeline{},
+			expected:  0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pipelines := pickPipelinesUsing("desired", c.pipelines)
+			if len(pipelines) != c.expected {
+				assert.Equal(t, c.expected, len(pipelines), "Error: got %d pipelines but expected %d", len(c.pipelines), c.expected)
 			}
 		})
 	}

--- a/pkg/lint/testdata/files/update-identifier-matching-git-checkout-repository-mixed-case.yaml
+++ b/pkg/lint/testdata/files/update-identifier-matching-git-checkout-repository-mixed-case.yaml
@@ -1,0 +1,22 @@
+package:
+  name: update-identifier-matching-git-checkout-repository-mixed-case
+  version: 1.0.0
+  epoch: 0
+  description: "a package where git checkout repository matches update identifier however the case is mixed"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/CHAINGUARD-DEV/test-repository
+      expected-commit: 90be8000070debb315ad97900da2f85dff58aced
+      tag: 1.0.0
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/test-repository

--- a/pkg/lint/testdata/files/update-identifier-matching-git-checkout-repository-multiple-pipelines.yaml
+++ b/pkg/lint/testdata/files/update-identifier-matching-git-checkout-repository-multiple-pipelines.yaml
@@ -1,0 +1,27 @@
+package:
+  name: update-identifier-matching-git-checkout-repository-multiple-pipelines
+  version: 1.0.0
+  epoch: 0
+  description: "a package where git checkout repository matches update identifier"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/test
+      expected-commit: 90be8000070debb315ad97900da2f85dff58aced
+      tag: 1.0.0
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/test-repository
+      expected-commit: 90be8000070debb315ad97900da2f85dff58aced
+      tag: 1.0.0
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/test-repository

--- a/pkg/lint/testdata/files/update-identifier-matching-git-checkout-repository.yaml
+++ b/pkg/lint/testdata/files/update-identifier-matching-git-checkout-repository.yaml
@@ -1,0 +1,22 @@
+package:
+  name: update-identifier-matching-git-checkout-repository
+  version: 1.0.0
+  epoch: 0
+  description: "a package where git checkout repository matches update identifier"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/test-repository
+      expected-commit: 90be8000070debb315ad97900da2f85dff58aced
+      tag: 1.0.0
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/test-repository

--- a/pkg/lint/testdata/files/update-identifier-not-matching-git-checkout-repository-nolint.yaml
+++ b/pkg/lint/testdata/files/update-identifier-not-matching-git-checkout-repository-nolint.yaml
@@ -1,0 +1,23 @@
+#nolint:update-identifier-must-match-git-repository
+package:
+  name: update-identifier-not-matching-git-checkout-repository-nolint
+  version: 1.0.0
+  epoch: 0
+  description: "a package wich git checkout repository does not match update identifier"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/test-repository
+      expected-commit: 90be8000070debb315ad97900da2f85dff58aced
+      tag: 1.0.0
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/test

--- a/pkg/lint/testdata/files/update-identifier-not-matching-git-checkout-repository.yaml
+++ b/pkg/lint/testdata/files/update-identifier-not-matching-git-checkout-repository.yaml
@@ -1,0 +1,22 @@
+package:
+  name: update-identifier-not-matching-git-checkout-repository
+  version: 1.0.0
+  epoch: 0
+  description: "a package wich git checkout repository does not match update identifier"
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/test-repository
+      expected-commit: 90be8000070debb315ad97900da2f85dff58aced
+      tag: 1.0.0
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/test


### PR DESCRIPTION
The update identifier must match the github repository because, otherwise, updating the package fails. Actualy, we have had a case already where a package definition was copied & pasted from another and these values were not updated to match.

To catch any further mismatches like that this commit adds a new linter rule: update-identifier-must-match-git-repository.

It checks, in a case insensitive manner, whether the GitHub repository URL contains a GitHub identifier that matches the one from the update section of the package yaml.

Furthermore, because a single package can have multiple pipelines, this linter looks for a single match, i.e. a single repository URL from all of the pipelines that are using git-checkout must match the update identifier in order to pass.

Note that is possible to opt-out from it by using the #nolint feature with this linter name. See:
update-identifier-not-matching-git-checkout-repository-nolint.yaml to see how that is done.