### PR TITLE
chore(sbom): resolve warning for directory source

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -123,7 +123,7 @@ func Generate(ctx context.Context, inputFilePath string, f io.Reader, distroID s
 		return nil, fmt.Errorf("expected APK package metadata to be of type pkg.ApkDBEntry, got %T", apkPackage.Metadata)
 	}
 
-	// Syft likes to have an "alias" -- an explicit way to identify the directory source.
+	// Syft logs a scary (but inconsequential) warning if we don't supply an "alias" -- an explicit way to identify the directory source.
 	alias := source.Alias{
 		Name:     fmt.Sprintf("%s/%s", apkPackageMetadata.Architecture, apkPackageMetadata.Package),
 		Version:  apkPackageMetadata.Version,

--- a/pkg/sbom/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/crane-0.19.1-r6.apk.syft.json
@@ -786,6 +786,7 @@
     "id": "(redacted for determinism)",
     "name": "crane",
     "version": "0.19.1-r6",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/crane-0.19.1-r6.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/jenkins-2.461-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/jenkins-2.461-r0.apk.syft.json
@@ -115116,6 +115116,7 @@
     "id": "(redacted for determinism)",
     "name": "jenkins",
     "version": "2.461-r0",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/jenkins-2.461-r0.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/jruby-9.4-9.4.7.0-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/jruby-9.4-9.4.7.0-r0.apk.syft.json
@@ -98163,6 +98163,7 @@
     "id": "(redacted for determinism)",
     "name": "jruby-9.4",
     "version": "9.4.7.0-r0",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/jruby-9.4-9.4.7.0-r0.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/openjdk-21-21.0.3-r3.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/openjdk-21-21.0.3-r3.apk.syft.json
@@ -196,6 +196,7 @@
     "id": "(redacted for determinism)",
     "name": "openjdk-21",
     "version": "21.0.3-r3",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/openjdk-21-21.0.3-r3.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/openssl-3.3.0-r8.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/openssl-3.3.0-r8.apk.syft.json
@@ -128,6 +128,7 @@
     "id": "(redacted for determinism)",
     "name": "openssl",
     "version": "3.3.0-r8",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/openssl-3.3.0-r8.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/perl-yaml-syck-1.34-r3.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/perl-yaml-syck-1.34-r3.apk.syft.json
@@ -171,6 +171,7 @@
     "id": "(redacted for determinism)",
     "name": "perl-yaml-syck",
     "version": "1.34-r3",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/perl-yaml-syck-1.34-r3.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/php-odbc-8.2.11-r1.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/php-odbc-8.2.11-r1.apk.syft.json
@@ -132,6 +132,7 @@
     "id": "(redacted for determinism)",
     "name": "php-odbc",
     "version": "8.2.11-r1",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/php-odbc-8.2.11-r1.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/powershell-7.4.1-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/powershell-7.4.1-r0.apk.syft.json
@@ -5549,6 +5549,7 @@
     "id": "(redacted for determinism)",
     "name": "powershell",
     "version": "7.4.1-r0",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/powershell-7.4.1-r0.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/py3-poetry-core-1.9.0-r1.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/py3-poetry-core-1.9.0-r1.apk.syft.json
@@ -2495,6 +2495,7 @@
     "id": "(redacted for determinism)",
     "name": "py3-poetry-core",
     "version": "1.9.0-r1",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/py3-poetry-core-1.9.0-r1.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/python-3.11-base-3.11.9-r6.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/python-3.11-base-3.11.9-r6.apk.syft.json
@@ -5389,6 +5389,7 @@
     "id": "(redacted for determinism)",
     "name": "python-3.11-base",
     "version": "3.11.9-r6",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/python-3.11-base-3.11.9-r6.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/terraform-1.5.7-r12.apk.syft.json
@@ -5960,6 +5960,7 @@
     "id": "(redacted for determinism)",
     "name": "terraform",
     "version": "1.5.7-r12",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/terraform-1.5.7-r12.apk"

--- a/pkg/sbom/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/aarch64/thanos-0.32-0.32.5-r4.apk.syft.json
@@ -7825,6 +7825,7 @@
     "id": "(redacted for determinism)",
     "name": "thanos-0.32",
     "version": "0.32.5-r4",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/aarch64/thanos-0.32-0.32.5-r4.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/crane-0.19.1-r6.apk.syft.json
@@ -790,6 +790,7 @@
     "id": "(redacted for determinism)",
     "name": "crane",
     "version": "0.19.1-r6",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/crane-0.19.1-r6.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/jenkins-2.461-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/jenkins-2.461-r0.apk.syft.json
@@ -115116,6 +115116,7 @@
     "id": "(redacted for determinism)",
     "name": "jenkins",
     "version": "2.461-r0",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/jenkins-2.461-r0.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/jruby-9.4-9.4.7.0-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/jruby-9.4-9.4.7.0-r0.apk.syft.json
@@ -98163,6 +98163,7 @@
     "id": "(redacted for determinism)",
     "name": "jruby-9.4",
     "version": "9.4.7.0-r0",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/jruby-9.4-9.4.7.0-r0.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/openjdk-21-21.0.3-r3.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/openjdk-21-21.0.3-r3.apk.syft.json
@@ -196,6 +196,7 @@
     "id": "(redacted for determinism)",
     "name": "openjdk-21",
     "version": "21.0.3-r3",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/openjdk-21-21.0.3-r3.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/openssl-3.3.0-r8.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/openssl-3.3.0-r8.apk.syft.json
@@ -128,6 +128,7 @@
     "id": "(redacted for determinism)",
     "name": "openssl",
     "version": "3.3.0-r8",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/openssl-3.3.0-r8.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/perl-yaml-syck-1.34-r3.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/perl-yaml-syck-1.34-r3.apk.syft.json
@@ -171,6 +171,7 @@
     "id": "(redacted for determinism)",
     "name": "perl-yaml-syck",
     "version": "1.34-r3",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/perl-yaml-syck-1.34-r3.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/php-odbc-8.2.11-r1.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/php-odbc-8.2.11-r1.apk.syft.json
@@ -131,6 +131,7 @@
     "id": "(redacted for determinism)",
     "name": "php-odbc",
     "version": "8.2.11-r1",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/php-odbc-8.2.11-r1.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/powershell-7.4.1-r0.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/powershell-7.4.1-r0.apk.syft.json
@@ -5549,6 +5549,7 @@
     "id": "(redacted for determinism)",
     "name": "powershell",
     "version": "7.4.1-r0",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/powershell-7.4.1-r0.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/py3-poetry-core-1.9.0-r1.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/py3-poetry-core-1.9.0-r1.apk.syft.json
@@ -2495,6 +2495,7 @@
     "id": "(redacted for determinism)",
     "name": "py3-poetry-core",
     "version": "1.9.0-r1",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/py3-poetry-core-1.9.0-r1.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/python-3.11-base-3.11.9-r6.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/python-3.11-base-3.11.9-r6.apk.syft.json
@@ -5389,6 +5389,7 @@
     "id": "(redacted for determinism)",
     "name": "python-3.11-base",
     "version": "3.11.9-r6",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/python-3.11-base-3.11.9-r6.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/terraform-1.5.7-r12.apk.syft.json
@@ -5964,6 +5964,7 @@
     "id": "(redacted for determinism)",
     "name": "terraform",
     "version": "1.5.7-r12",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/terraform-1.5.7-r12.apk"

--- a/pkg/sbom/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.syft.json
+++ b/pkg/sbom/testdata/goldenfiles/x86_64/thanos-0.32-0.32.5-r4.apk.syft.json
@@ -7829,6 +7829,7 @@
     "id": "(redacted for determinism)",
     "name": "thanos-0.32",
     "version": "0.32.5-r4",
+    "supplier": "chainguard",
     "type": "directory",
     "metadata": {
       "path": "testdata/apks/x86_64/thanos-0.32-0.32.5-r4.apk"


### PR DESCRIPTION
Syft logs a warning if you're using a directory source but don't set a `source.Alias` value for the source. This log message isn't warning about anything that impacts the accuracy of the analysis, but it's nonetheless noisy and annoying. This PR plugs in an alias value to avoid the warning. It also moves the Syft-to-clog wiring slightly earlier to make the effect of this change reproducible with the local CLI.

#### Before

```console
$ wolfictl sbom -D ./apko-0.25.1-r2.apk > /dev/null
2025/08/26 15:55:38 WARN no explicit name and version provided for directory source, deriving artifact ID from the given path (which is not ideal)
$
```

#### After

```console
$ wolfictl sbom -D ./apko-0.25.1-r2.apk > /dev/null
$
````