### PR TITLE
feat(pkg/sbom/cpe.go): Add exception for gitlab-operator to avoid matching as gitlab-* package and gitlab product

### DIFF
--- a/pkg/sbom/cpe.go
+++ b/pkg/sbom/cpe.go
@@ -54,7 +54,13 @@ func generateWfnAttributesForAPK(p pkgInfo) *wfn.Attributes {
 		return &attr
 	}
 
-	if strings.HasPrefix(name, "gitlab-") {
+	// Not all gitlab-* packages should be treated as GitLab, but most of them are.
+	// One notable exception is gitlab-operator, which is a Kubernetes operator
+	// for managing GitLab installations, and not part of GitLab itself.
+	// Source @ https://gitlab.com/gitlab-org/cloud-native/gitlab-operator
+	// Adding an explicit exception for this package here.
+	// If more exceptions are found, we might need a more robust way to handle them.
+	if strings.HasPrefix(name, "gitlab-") && name != "gitlab-operator" {
 		attr.Vendor = "gitlab"
 		attr.Product = "gitlab"
 		attr.SWEdition = "community"


### PR DESCRIPTION
Not all gitlab-* packages should be treated as GitLab, but most of them are - as seen in

```
if strings.HasPrefix(name, "gitlab-") {
		attr.Vendor = "gitlab"
		attr.Product = "gitlab"
		attr.SWEdition = "community"

		return &attr
	}
```

Added in https://github.com/wolfi-dev/wolfictl/commit/1c050aa7206e4e46a62ac27d2c969793c455a807

One notable exception is gitlab-operator, which is a Kubernetes operator
for managing GitLab installations, and not part of GitLab itself with
source @ https://gitlab.com/gitlab-org/cloud-native/gitlab-operator

Adding an explicit exception for this package to not match on `gitlab-*`

The reason for this change is because new gitlab-operator package was being matched with all older gitlab CVEs which is incorrect.

Signed-off-by: philroche <phil.roche@chainguard.dev>
