### PR TITLE
wolfictl bump - drop all epoch-line comments by default.

### DIFF
--- a/pkg/cli/bump.go
+++ b/pkg/cli/bump.go
@@ -118,13 +118,10 @@ func bumpEpoch(ctx context.Context, opts bumpOptions, path string) error {
 	old := fmt.Sprintf(epochPattern, cfg.Package.Epoch)
 	for scanner.Scan() {
 		line := scanner.Text()
-		nocomment, comment, _ := strings.Cut(line, "#")
+		nocomment, _, _ := strings.Cut(line, "#")
 		if strings.TrimSpace(nocomment) == old {
 			found = true
-			comment = strings.TrimSpace(comment)
-			if strings.HasPrefix(comment, "CVE-") || strings.HasPrefix(comment, "GHSA-") {
-				line = strings.TrimRight(nocomment, " ")
-			}
+			line = strings.TrimRight(nocomment, " ")
 			newFile = append(
 				newFile, strings.ReplaceAll(line, old, fmt.Sprintf(epochPattern, cfg.Package.Epoch+1)),
 			)

--- a/pkg/cli/bump_test.go
+++ b/pkg/cli/bump_test.go
@@ -26,7 +26,7 @@ func TestBumpWithComment(t *testing.T) {
 	}{
 		{
 			testPkgDefinition("1 # a comment!"),
-			testPkgDefinition("2 # a comment!"),
+			testPkgDefinition("2"),
 		},
 		{
 			testPkgDefinition("1 # CVE-111-222"),


### PR DESCRIPTION
The vast majority of comments alongside an epoch bump are redundant with 'git log --oneline' or at very least are not relevant after the next epoch bump.