### PR TITLE
fix(dag): preserve provider-priority for local virtual providers

### DIFF
--- a/pkg/dag/graph.go
+++ b/pkg/dag/graph.go
@@ -13,7 +13,6 @@ import (
 	"path"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/dominikbraun/graph"
@@ -104,8 +103,6 @@ func NewGraph(ctx context.Context, pkgs *Packages, options ...GraphOptions) (*Gr
 			errs = append(errs, err)
 			continue
 		}
-		// add the origin package as its own resolver, so that the subpackage can resolve to it
-		g.resolvers[c.String()] = singlePackageResolver(ctx, c, opts.arch)
 		for i := range c.Subpackages {
 			subpkg := pkgs.Config(c.Subpackages[i].Name, false)
 			for _, subpkgVersion := range subpkg {
@@ -865,46 +862,6 @@ func getKeyMaterial(key string) ([]byte, error) {
 		return nil, fmt.Errorf("key scheme %s not supported", asURL.Scheme)
 	}
 	return b, nil
-}
-
-func getPriority(pkg *Configuration) uint64 {
-	val := pkg.Package.Dependencies.ProviderPriority
-	if val == "" {
-		return 0
-	}
-	priority, err := strconv.ParseUint(val, 10, 64)
-	if err != nil {
-		// I don't care to plumb this error around, sorry everyone.
-		// There are other places that will catch this not being an integer.
-		return 0
-	}
-	return priority
-}
-
-func singlePackageResolver(ctx context.Context, pkg *Configuration, arch string) *apk.PkgResolver {
-	repo := apk.NewRepositoryFromComponents(Local, "latest", "", arch)
-
-	packages := []*apk.Package{
-		{
-			Arch:             arch,
-			Name:             pkg.Package.Name,
-			Version:          fullVersion(&pkg.Package),
-			Description:      pkg.Package.Description,
-			License:          pkg.Package.LicenseExpression(),
-			Origin:           pkg.Package.Name,
-			URL:              pkg.Package.URL,
-			Dependencies:     pkg.Environment.Contents.Packages,
-			ProviderPriority: getPriority(pkg),
-			Provides:         pkg.Package.Dependencies.Provides,
-			RepoCommit:       pkg.Package.Commit,
-		},
-	}
-	index := &apk.APKIndex{
-		Description: pkg.String(),
-		Packages:    packages,
-	}
-	idx := apk.NewNamedRepositoryWithIndex("", repo.WithIndex(index))
-	return apk.NewPkgResolver(ctx, []apk.NamedIndex{idx})
 }
 
 // Targets returns a subgraph that flattens subpackages into their origins.

--- a/pkg/dag/graph.go
+++ b/pkg/dag/graph.go
@@ -89,7 +89,11 @@ func NewGraph(ctx context.Context, pkgs *Packages, options ...GraphOptions) (*Gr
 		opts.arch = "x86_64"
 	}
 
-	localRepo := pkgs.Repository(opts.arch)
+	localRepo, err := pkgs.Repository(opts.arch)
+	if err != nil {
+		return nil, fmt.Errorf("creating local repository: %w", err)
+	}
+
 	localRepoSource := localRepo.Source()
 	localOnlyResolver := apk.NewPkgResolver(ctx, []apk.NamedIndex{localRepo})
 	g.resolvers[localRepoSource] = localOnlyResolver

--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -432,7 +432,7 @@ func (p *Packages) WithArch(arch string) (*Packages, error) {
 
 // Repository provide the Packages as a apk.RepositoryWithIndex. To be used in other places that require
 // using alpine/go structs instead of ours.
-func (p *Packages) Repository(arch string) apk.NamedIndex {
+func (p *Packages) Repository(arch string) (apk.NamedIndex, error) {
 	repo := apk.NewRepositoryFromComponents(Local, "latest", "", arch)
 
 	// Precompute the number of packages to avoid growslice.
@@ -448,7 +448,8 @@ func (p *Packages) Repository(arch string) apk.NamedIndex {
 	for _, byVersion := range p.packages {
 		for _, cfg := range byVersion {
 			cfg := cfg
-			packages = append(packages, &apk.Package{
+
+			pkg := &apk.Package{
 				Arch:         arch,
 				Name:         cfg.Package.Name,
 				Version:      fullVersion(&cfg.Package),
@@ -459,10 +460,19 @@ func (p *Packages) Repository(arch string) apk.NamedIndex {
 				Dependencies: cfg.Environment.Contents.Packages,
 				Provides:     cfg.Package.Dependencies.Provides,
 				RepoCommit:   cfg.Package.Commit,
-			})
+			}
+
+			priority, err := parseProviderPriority(cfg.Package.Dependencies.ProviderPriority)
+			if err != nil {
+				return nil, fmt.Errorf("%s provider-priority: %w", cfg.Package.Name, err)
+			}
+			pkg.ProviderPriority = priority
+
+			packages = append(packages, pkg)
+
 			for i := range cfg.Subpackages {
 				sub := cfg.Subpackages[i]
-				packages = append(packages, &apk.Package{
+				subpkg := &apk.Package{
 					Arch:         arch,
 					Name:         sub.Name,
 					Version:      fullVersion(&cfg.Package),
@@ -473,7 +483,15 @@ func (p *Packages) Repository(arch string) apk.NamedIndex {
 					Dependencies: cfg.Environment.Contents.Packages,
 					Provides:     sub.Dependencies.Provides,
 					RepoCommit:   sub.Commit,
-				})
+				}
+
+				priority, err := parseProviderPriority(sub.Dependencies.ProviderPriority)
+				if err != nil {
+					return nil, fmt.Errorf("%s subpackage %s provider-priority: %w", cfg.Package.Name, sub.Name, err)
+				}
+				subpkg.ProviderPriority = priority
+
+				packages = append(packages, subpkg)
 			}
 		}
 	}
@@ -482,7 +500,7 @@ func (p *Packages) Repository(arch string) apk.NamedIndex {
 		Packages:    packages,
 	}
 
-	return apk.NewNamedRepositoryWithIndex("", repo.WithIndex(index))
+	return apk.NewNamedRepositoryWithIndex("", repo.WithIndex(index)), nil
 }
 
 func packageNameFromProvides(prov string) (name, version string) {
@@ -499,4 +517,24 @@ func packageNameFromProvides(prov string) (name, version string) {
 
 func fullVersion(pkg *config.Package) string {
 	return pkg.Version + "-r" + strconv.FormatUint(pkg.Epoch, 10)
+}
+
+// parseProviderPriority parses a melange provider-priority. melange permits a
+// signed integer, and a negative value resolves to the default priority of zero
+// in the built index, so treat it as zero here rather than rejecting it.
+func parseProviderPriority(val string) (uint64, error) {
+	if val == "" {
+		return 0, nil
+	}
+
+	priority, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %q: %w", val, err)
+	}
+
+	if priority < 0 {
+		return 0, nil
+	}
+
+	return uint64(priority), nil
 }

--- a/pkg/dag/packages_test.go
+++ b/pkg/dag/packages_test.go
@@ -37,3 +37,54 @@ func TestNewPackages(t *testing.T) {
 		}
 	})
 }
+
+func TestPackagesRepositoryPreservesSubpackageProviderPriority(t *testing.T) {
+	ctx := context.Background()
+	testdir := "testdata/provider-priority"
+
+	pkgs, err := NewPackages(ctx, os.DirFS(testdir), testdir, nil)
+	require.NoError(t, err)
+
+	repo, err := pkgs.Repository("x86_64")
+	require.NoError(t, err)
+
+	priorities := map[string]uint64{}
+	for _, pkg := range repo.Packages() {
+		priorities[pkg.Name] = pkg.ProviderPriority
+	}
+
+	require.Equal(t, map[string]uint64{
+		"gdal":            0,
+		"gdal-py3.13-dev": 313,
+		"gdal-compat":     0,
+	}, priorities)
+}
+
+func TestParseProviderPriority(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint64
+		wantErr string
+	}{
+		{name: "empty", input: "", want: 0},
+		{name: "positive", input: "313", want: 313},
+		{name: "negative clamps to zero", input: "-1", want: 0},
+		{name: "non-numeric", input: "invalid", wantErr: `parsing "invalid"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseProviderPriority(tt.input)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Zero(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/dag/testdata/provider-priority/gdal.yaml
+++ b/pkg/dag/testdata/provider-priority/gdal.yaml
@@ -1,0 +1,29 @@
+package:
+  name: gdal
+  version: "3.13.0"
+  epoch: 0
+  description: Geospatial Data Abstraction Library
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation:
+      license: MIT
+environment:
+  contents:
+    packages:
+      - build-base
+pipeline:
+  - runs: |
+      echo "pretending to build gdal"
+
+subpackages:
+  - name: gdal-py3.13-dev
+    dependencies:
+      provides:
+        - gdal-dev
+      provider-priority: 313
+  - name: gdal-compat
+    dependencies:
+      provider-priority: -1


### PR DESCRIPTION
## Problem

Package builders order package builds using the dependency graph produced by `pkg/dag`. That graph combines a synthetic local APK repository (the unbuilt configs) with the remote APK indexes named by the melange configs. For the ordering to be correct, apk's resolver has to choose the same provider from the synthetic repo that it would choose from a real `APKINDEX`. If it chooses a remote package instead, the edge points at an external package and is dropped when the graph is filtered to local packages, leaving the two packages unordered and free to build in parallel.

This went wrong for virtual dependencies that use `provider-priority`. The synthetic local packages did not copy `provider-priority` from the melange configuration, so every local provider defaulted to priority `0`. When an already-published remote package provided the same virtual dependency at a higher priority, the resolver preferred the remote package. Its edge was then filtered out, and the dependent package built against the published artifact rather than the local rebuild.

Here is a case that triggers it. A `*-dev` subpackage provides a virtual `<foo>-dev` with a non-zero `provider-priority`, and another package build-depends on `<foo>-dev`:

```yaml
# foo.yaml
package:
  name: foo
  version: "2.0.0"
  epoch: 0
# ...
subpackages:
  - name: foo-py3.13-dev
    dependencies:
      provides:
        - foo-dev
      provider-priority: 313
```

```yaml
# bar.yaml (reverse dependency)
package:
  name: bar
  version: "1.0.0"
  epoch: 0
environment:
  contents:
    packages:
      - foo-dev   # build against the local rebuild of foo
# ...
```

When `foo` is bumped so that it ships `so:libfoo.so.2` in place of `so:libfoo.so.1`, `bar` should be ordered after the local `foo` rebuild and link against the new library. Before this change the local `foo-py3.13-dev` advertised `foo-dev` at priority `0`, while the previously published `foo` in the index advertised it at `313`. The resolver picked the remote provider, the edge was filtered out, and `bar` built in parallel against `so:libfoo.so.1`.

## Fix

Copy `provider-priority` onto the synthetic APK packages for both origin packages and subpackages, so a local provider ties its remote counterpart on priority and then wins on version. `provider-priority` is parsed the way melange permits it, as a signed integer: a negative value resolves to the default priority of `0` in the built index (`unbound-mailcow-compat` and `debezium-3.5` use `-1`), so it is treated as `0` here rather than aborting graph construction, while a non-numeric value is still reported as an error.

The first commit removes an unused per-origin resolver. It was stored in the resolver map under a `name-version` key but never looked up, because reads only use the comma-joined repository-source key. Subpackage-to-origin ordering is added directly with `AddEdge`. Removing it first means the fix does not have to return an error from code that has no effect.

## Tests

Adds regression tests for provider-priority preservation on a subpackage provider and for the parsing helper.
