### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -5,6 +5,7 @@ runs:
   steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
+        persist-credentials: false
         repository: wolfi-dev/wolfictl
         path: wolfictl-setup-gha
 

--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -17,8 +17,9 @@ runs:
     - id: build
       shell: bash
       run: |
-        cd wolfictl-setup-gha
-        make wolfictl
-        mv wolfictl /home/runner/go/bin/
-        cd ..
+        (
+          cd wolfictl-setup-gha || exit
+          make wolfictl
+          mv wolfictl /home/runner/go/bin/
+        )
         rm -rf wolfictl-setup-gha

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,15 @@ updates:
       - "/.github/actions/*"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     groups:
       chainguard:
         patterns:

--- a/.github/workflows/build-goreleaser.yaml
+++ b/.github/workflows/build-goreleaser.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,7 @@ jobs:
       - run: make wolfictl
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           repository: 'wolfi-dev/os'
           path: 'wolfi-os'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0 # fetch all history for all tags and branches
           token: ${{ steps.octo-sts.outputs.token }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
+          # Disable the Go build/module cache on this signed-release flow: a
+          # cache poisoned by a PR-reachable build could otherwise be restored
+          # into the tag/dispatch release that goreleaser signs and publishes.
+          cache: false
 
       - name: Check if any changes since last tag
         id: check

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  # Paired with cooldown.default-days: 3 in .github/dependabot.yml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
This PR applies GitHub Actions hardening fixes across the workflows in
`.github/workflows/`, surfaced by static analysis (zizmor).

## What this changes

- **`persist-credentials: false`** on checkout steps that don't push back to the
  repo, so the auto-persisted `GITHUB_TOKEN` isn't left in `.git/config`.
- **Repo-level zizmor config** disabling cosmetic pedantic-only rules, plus a
  `dependabot-cooldown` threshold.
- **Harden `cd` handling** in the composite-action build step (quote/guard the
  directory change so a failed `cd` can't run subsequent commands in the wrong
  place).
- **Disable the Go build/module cache on the signed-release flow**
  (`cache: false` on `actions/setup-go` in `release.yaml`). That workflow runs
  goreleaser to sign and publish; `setup-go`'s cache bundles the verified module
  cache with the unverified `~/.cache/go-build`, and PR-reachable build workflows
  write the same key scheme — so a poisoned build cache could be restored into
  the signed release. Releases are infrequent, so a clean rebuild is the right
  default.

## Test plan

- `zizmor .github/` — the release-flow cache-poisoning finding is resolved.
- `actionlint` — workflows still parse with no errors.

Refs: PSEC-923