### PR TITLE
checks: don't panic on a DT_SONAME without .so in it

### DIFF
--- a/pkg/checks/so_name.go
+++ b/pkg/checks/so_name.go
@@ -189,6 +189,13 @@ func (o *SoNameOptions) checkSonamesMatch(ctx context.Context, existingPackages 
 		log.Infof("checking soname file %s", soname)
 		sonameParts := strings.Split(soname, ".so")
 
+		// DT_SONAME is arbitrary metadata and isn't required to contain ".so",
+		// in which case there's no version to compare against.
+		if len(sonameParts) < 2 {
+			log.Infof("no version found in soname %s, skipping", soname)
+			continue
+		}
+
 		// Find the version and optional qualifier
 		matches := r.FindStringSubmatch(sonameParts[1])
 		if len(matches) > 0 {
@@ -203,6 +210,11 @@ func (o *SoNameOptions) checkSonamesMatch(ctx context.Context, existingPackages 
 	// now iterate over new soname files and compare with existing files
 	for _, soname := range newSonameFiles {
 		sonameParts := strings.Split(soname, ".so")
+		if len(sonameParts) < 2 {
+			log.Infof("no version found in soname %s, skipping", soname)
+			continue
+		}
+
 		name := sonameParts[0]
 		versionStr := strings.TrimPrefix(sonameParts[1], ".")
 		existingVersionStr := existingSonameMap[name]

--- a/pkg/checks/so_name_test.go
+++ b/pkg/checks/so_name_test.go
@@ -134,6 +134,14 @@ func TestSoNameOptions_checkSonamesMatch(t *testing.T) {
 			name: "ignore_non_standard_version_suffix", existingSonameFiles: []string{"libgs.so.10.02.debug"}, newSonameFiles: []string{"libgs.so.10.02.debug"},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "existing_dt_soname_without_so", existingSonameFiles: []string{"libevil"}, newSonameFiles: []string{"foo.so.1"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "new_dt_soname_without_so", existingSonameFiles: []string{"foo.so.1"}, newSonameFiles: []string{"badsoname"},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
`wolfictl check so-name` panics with `index out of range [1] with length 1` when an ELF in the apk has a DT_SONAME that doesn't contain `.so`.

getSonameFiles appends the raw DT_SONAME string to the file list as-is. Unlike the filenames picked up by the regex, that string is just whatever the linker was told to put there, so `libevil` or `badsoname` are both legal and neither splits on `.so`. checkSonamesMatch then does `strings.Split(soname, ".so")[1]` in both loops and blows up.

Fix is to skip a soname with no `.so` in it, since there's no version to compare in that case. Both loops needed it (the existing-package one at the map build, and the new-package one below it).

Added two rows to the existing checkSonamesMatch table test covering each side. They panic before the change and pass after. `go test ./pkg/checks/` is green.
