### PR TITLE
feat(dag): add WithDependenciesOnly option; sort the local index's order

### DIFF
--- a/pkg/dag/packages.go
+++ b/pkg/dag/packages.go
@@ -167,6 +167,13 @@ func NewPackages(ctx context.Context, fsys fs.FS, dirPath string, pipelineDirs [
 		index:    make(map[string]*Configuration),
 	}
 
+	// Resolved here because the walk below shadows the build package with a
+	// local of the same name.
+	var compileOpts []build.CompileOption
+	if options.dependenciesOnly {
+		compileOpts = append(compileOpts, build.WithDependenciesOnly())
+	}
+
 	var g errgroup.Group
 	g.SetLimit(runtime.GOMAXPROCS(0))
 	err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
@@ -262,7 +269,7 @@ func NewPackages(ctx context.Context, fsys fs.FS, dirPath string, pipelineDirs [
 				PipelineDirs:  pipelineDirs,
 				Configuration: c.Configuration,
 			}
-			if err := build.Compile(ctx); err != nil {
+			if err := build.Compile(ctx, compileOpts...); err != nil {
 				return fmt.Errorf("compiling build: %w", err)
 			}
 			c.Environment.Contents.Packages = build.Configuration.Environment.Contents.Packages
@@ -514,6 +521,22 @@ func (p *Packages) Repository(arch string) (apk.NamedIndex, error) {
 			}
 		}
 	}
+	// The packages were gathered by walking a map, so their order varies per
+	// run. That order decides which of several equal providers of a virtual
+	// name the resolver picks, and so which dependency edges a graph ends up
+	// with, which is why it is fixed here -- the same reason Packages() sorts.
+	// Origin disambiguates a subpackage from the origin package it came from,
+	// which can share a version.
+	sort.Slice(packages, func(i, j int) bool {
+		if packages[i].Name != packages[j].Name {
+			return packages[i].Name < packages[j].Name
+		}
+		if packages[i].Version != packages[j].Version {
+			return packages[i].Version < packages[j].Version
+		}
+		return packages[i].Origin < packages[j].Origin
+	})
+
 	index := &apk.APKIndex{
 		Description: "local repository",
 		Packages:    packages,

--- a/pkg/dag/packages_options.go
+++ b/pkg/dag/packages_options.go
@@ -4,6 +4,10 @@ type packagesOptions struct {
 	// compileOnly limits melange compilation to these origin package names. A
 	// nil map means every definition is compiled.
 	compileOnly map[string]struct{}
+
+	// dependenciesOnly compiles for build dependencies without producing
+	// runnable pipelines.
+	dependenciesOnly bool
 }
 
 type PackagesOption func(*packagesOptions) error
@@ -35,6 +39,32 @@ func WithCompileOnly(names ...string) PackagesOption {
 		for _, name := range names {
 			o.compileOnly[name] = struct{}{}
 		}
+		return nil
+	}
+}
+
+// WithDependenciesOnly compiles definitions for their build dependencies
+// without producing runnable pipelines.
+//
+// Compiling resolves a definition's `uses:` pipelines, which is what expands
+// .environment.contents.packages and supplies the build-dependency edges a
+// graph is built from. Making the result runnable also normalizes each step's
+// `runs:` body, which means shell-parsing and re-printing every script, and
+// that is the larger half of what compiling costs.
+//
+// The Configurations left behind are not runnable: a step's `runs:` keeps the
+// comments and formatting it was written with. Everything else - substitution,
+// validation, conditionals, and the resolved dependency list - is unchanged, so
+// a definition that fails to compile still fails the same way. Use this only to
+// resolve dependencies, never to produce a configuration that will be built or
+// recorded.
+//
+// It composes with WithCompileOnly: that one chooses which definitions are
+// compiled, this one chooses how much of each compile is done.
+func WithDependenciesOnly() PackagesOption {
+	return func(o *packagesOptions) error {
+		o.dependenciesOnly = true
+
 		return nil
 	}
 }

--- a/pkg/dag/packages_test.go
+++ b/pkg/dag/packages_test.go
@@ -147,3 +147,76 @@ func TestNewPackagesWithCompileOnly(t *testing.T) {
 		require.Equal(t, buildDeps(t, all, "two"), buildDeps(t, none, "two"))
 	})
 }
+
+// subpackageRuns returns the `runs:` body of the named package's first
+// subpackage pipeline step.
+func subpackageRuns(t *testing.T, p *Packages, name string) string {
+	t.Helper()
+	cfgs := p.Config(name, true)
+	require.Len(t, cfgs, 1)
+	for i := range cfgs[0].Subpackages {
+		sp := &cfgs[0].Subpackages[i]
+		if len(sp.Pipeline) > 0 && sp.Pipeline[0].Runs != "" {
+			return sp.Pipeline[0].Runs
+		}
+	}
+	t.Fatalf("no subpackage pipeline with a runs body in %q", name)
+	return ""
+}
+
+func TestNewPackagesWithDependenciesOnly(t *testing.T) {
+	ctx := context.Background()
+	testdir := "testdata/multiple"
+
+	all, err := NewPackages(ctx, os.DirFS(testdir), testdir, nil)
+	require.NoError(t, err)
+
+	deps, err := NewPackages(ctx, os.DirFS(testdir), testdir, nil, WithDependenciesOnly())
+	require.NoError(t, err)
+
+	t.Run("resolved build dependencies are unchanged", func(t *testing.T) {
+		// This is what the option must not disturb: it is the whole reason a
+		// caller compiles at all.
+		for _, name := range all.PackageNames() {
+			require.Equal(t, buildDeps(t, all, name), buildDeps(t, deps, name), "build deps for %q", name)
+		}
+	})
+
+	t.Run("runnable pipelines are not produced", func(t *testing.T) {
+		// A full compile normalizes the script and drops its comments; this
+		// option leaves it as written. Asserting both directions keeps the test
+		// from passing if compilation stopped stripping comments entirely.
+		require.NotContains(t, subpackageRuns(t, all, "one"), "# a comment")
+		require.Contains(t, subpackageRuns(t, deps, "one"), "# a comment")
+	})
+
+	t.Run("local index is unaffected", func(t *testing.T) {
+		require.ElementsMatch(t, all.PackageNames(), deps.PackageNames())
+
+		for _, name := range []string{
+			"two", "two-provides-implicit", "two-provides-explicit",
+			"one-sub1", "one-sub2", "one-subp-provides-implicit",
+		} {
+			require.NotEmpty(t, deps.Config(name, false), "%q missing from index", name)
+		}
+	})
+
+	t.Run("composes with WithCompileOnly", func(t *testing.T) {
+		// The two options answer different questions: WithCompileOnly chooses
+		// which definitions are compiled, this one how much of each compile is
+		// done. Adding it must not change the first answer.
+		scoped, err := NewPackages(ctx, os.DirFS(testdir), testdir, nil, WithCompileOnly("one"))
+		require.NoError(t, err)
+
+		both, err := NewPackages(ctx, os.DirFS(testdir), testdir, nil,
+			WithCompileOnly("one"), WithDependenciesOnly())
+		require.NoError(t, err)
+
+		require.Equal(t, buildDeps(t, all, "one"), buildDeps(t, both, "one"),
+			"the named definition still resolves its dependencies")
+		require.Equal(t, buildDeps(t, scoped, "two"), buildDeps(t, both, "two"),
+			"a definition outside the set is still not compiled at all")
+		require.Contains(t, subpackageRuns(t, both, "one"), "# a comment",
+			"the named definition is still compiled without a runnable pipeline")
+	})
+}

--- a/pkg/dag/testdata/multiple/one.yaml
+++ b/pkg/dag/testdata/multiple/one.yaml
@@ -31,6 +31,7 @@ subpackages:
   - name: one-sub2
     pipeline:
       - runs: |
+          # a comment, which compiling strips and WithDependenciesOnly keeps
           echo "Hello, world!"
     dependencies:
       provides:


### PR DESCRIPTION
## What

Two changes to `pkg/dag`, independent of each other:

1. `WithDependenciesOnly()`, a `PackagesOption` that threads melange's `build.WithDependenciesOnly()` into the `build.Compile` call `NewPackages` makes. It composes with `WithCompileOnly`: that one chooses which definitions are compiled, this one chooses how much of each compile is done.
2. `Repository()` sorts the local index before returning it. It was gathering packages by walking a map, so the slice order varied per run.

## Why

### The option

Compiling a definition resolves its `uses:` pipelines, which is what expands `.environment.contents.packages` and therefore supplies the build-dependency edges a graph is built from. Making the result *runnable* also normalizes each step's `runs:` body — shell-parsing and re-printing every script — and that is the larger half of what compiling costs. A caller that builds a dependency graph reads the dependency lists and discards the bodies.

Measured over ~5,000 package definitions:

| | `NewPackages` | `NewGraph` | rest | total |
| -- | -- | -- | -- | -- |
| full compile | 5.73s | 4.45s | 0.16s | 10.34s |
| `WithDependenciesOnly` | 2.48s | 4.50s | 0.28s | 7.27s |

`NewPackages` alone, repeated to show it is not noise: 5.68s / 5.66s full against 2.30s / 2.26s with the option.

The compile phase is 2.4x faster, but a whole walk is only 1.4x faster, because `NewGraph` is network and resolution that the option does not touch and is now the larger phase. One variant per process matters too: melange's parsed-pipeline cache is process-global, so running both modes in one process makes the second look faster than it is.

### The sort

`Repository()` built the index by ranging over the `packages` map with no ordering, twenty lines below `Packages()`, which sorts and says why: "sort for deterministic output". Index order decides which of several equal providers of a virtual name the resolver selects, and so which dependency edges a graph ends up with.

## Notes

### The option preserves what it is supposed to

What must not change is the resolved dependency list, since that is the reason a graph walk compiles at all. Checked over the same ~5,000 definitions by dumping every definition's `.environment.contents.packages` and diffing:

| comparison | differences |
| -- | -- |
| full compile vs. `WithDependenciesOnly` | 0 |
| two runs of the same mode | 0 |

`TestNewPackagesWithDependenciesOnly` covers the same property on a fixture, plus three things it would be easy to get wrong: that the local index still holds every subpackage and provides entry, that the `runs:` bodies really are left unnormalized, and that adding the option does not change which definitions `WithCompileOnly` compiles.

The `runs:` assertion runs both directions. A full compile must not contain the fixture's comment and a dependencies-only compile must so the test cannot quietly pass if compilation stopped stripping comments altogether. That needed a comment in a fixture's `runs:` body; no test asserts on those bodies, so the existing shared fixture was reused rather than a new one added.

### Scope

`WithDependenciesOnly` leaves Configurations that are not runnable: a step's `runs:` keeps the comments and formatting it was written with. Everything else — substitution, validation, conditionals, and the resolved dependency list — is unchanged, so a definition that fails to compile still fails the same way. It is documented as being for resolving dependencies only, never for producing a configuration that will be built or recorded.

Nothing in this repository passes it. It exists for callers that build a dependency graph over a whole repository, where the saving is proportional to the number of definitions.

### Verification

`gofmt -s`, `go vet`, `go test ./pkg/dag/...` and `golangci-lint run ./pkg/dag/...` are clean.
