### PR TITLE
Do not panic on an empty entry in the repositories block

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -409,12 +409,12 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 			Severity:    SeverityError,
 			LintFunc: func(config config.Configuration) error {
 				for _, repo := range config.Environment.Contents.BuildRepositories {
-					if repo[0] == '@' {
+					if strings.HasPrefix(repo, "@") {
 						return fmt.Errorf("repository %q is tagged", repo)
 					}
 				}
 				for _, repo := range config.Environment.Contents.Repositories {
-					if repo[0] == '@' {
+					if strings.HasPrefix(repo, "@") {
 						return fmt.Errorf("repository %q is tagged", repo)
 					}
 				}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -115,6 +115,17 @@ func TestLinter_Rules(t *testing.T) {
 			matches: 1,
 		},
 		{
+			// an empty entry used to panic the rule on repo[0]
+			file:        "empty-repository-entry.yaml",
+			minSeverity: SeverityWarning,
+			want: EvalResult{
+				File:   "empty-repository-entry",
+				Errors: EvalRuleErrors{},
+			},
+			wantErr: false,
+			matches: 0,
+		},
+		{
 			file:        "forbidden-repository-tagged.yaml",
 			minSeverity: SeverityWarning,
 			want: EvalResult{

--- a/pkg/lint/testdata/files/empty-repository-entry.yaml
+++ b/pkg/lint/testdata/files/empty-repository-entry.yaml
@@ -1,0 +1,27 @@
+#nolint:fetch-templating
+package:
+  name: empty-repository-entry
+  version: 1.0.0
+  epoch: 0
+  description: A package with an empty entry in the repositories block
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+environment:
+  contents:
+    repositories:
+      - ""
+    packages:
+      - foo
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/foo/bar/baz.tar.gz
+      expected-sha512: 6d8e828fa406518b4b3f55b0e5f62bbd5cf25cb5782d1884b9d5eaf61fb0614deaacad4236ab7420fa5b3868c79df226ae1aa5193bb136c556aa52853eeca553
+  - runs: |
+      go build .
+update:
+  enabled: true


### PR DESCRIPTION
The `tagged-repository-in-environment-repos` rule reads `repo[0]` on every entry of `environment.contents.repositories` and `buildRepositories`. An empty string entry is easy to produce with a stray dash in the YAML, and it makes the linter panic on the very file it was asked to lint:

```
panic: runtime error: index out of range [0] with length 0
```

`strings.HasPrefix(repo, "@")` is what the check means anyway, and it is safe on an empty string.

Added a `empty-repository-entry.yaml` fixture whose repositories block has one empty entry. It panics on main and passes here. The existing `forbidden-repository-tagged.yaml` case still reports the tagged repository as before, so the rule itself is unchanged for real input.
